### PR TITLE
Crew Records Fixes (AKA: ALT TITLES NOW WORK!!!!!!)

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -91,6 +91,8 @@ SUBSYSTEM_DEF(job)
 			Debug("Player: [player] is now Rank: [rank], JCP:[job.current_positions], JPL:[position_limit]")
 			player.mind.assigned_role = rank
 			player.mind.assigned_job = job
+			if(job.alt_titles)	// Occulus edit: gib alt titles
+				player.mind.role_alt_title = player.client.prefs.GetPlayerAltTitle(job)	// Occulus edit: gib alt titles pls
 			unassigned -= player
 			job.current_positions++
 			return TRUE
@@ -361,7 +363,17 @@ SUBSYSTEM_DEF(job)
 		//Equip job items and language stuff
 		job.setup_account(H)
 
-		job.equip(H, flavor ? flavor.title : H.mind ? H.mind.role_alt_title : "")
+// OCCULUS EDIT  START - minor refactor to make it such that only vagabonds get random job titles on their ID
+
+		if(H.mind)	// Is there a mind associated with the target?
+			if(H.mind.role_alt_title == "Vagabond")	// Is the target a vagabond?
+				job.equip(H, flavor ? flavor.title : "")	// If so, give their ID a random flavor title just like vagabonds should have
+			else
+				job.equip(H, H.mind ? H.mind.role_alt_title : "")	// If not, give them whatever their alt title is. If they do not have one, don't change anything at all.
+		else
+			job.equip(H)	// In case there is no mind associated with the target (Maybe the player DC'd while spawning in?), just give them what they should spawn with anyways without changing anything.
+
+// OECCULUS EDIT END - minor refactor to make it such that only vagabonds get random job titles on their ID
 
 		//loadout items.
 		if(spawn_in_storage)

--- a/code/game/jobs/job/assistant.dm
+++ b/code/game/jobs/job/assistant.dm
@@ -38,9 +38,8 @@ As an drifter, you should strive to help out anyone you can. Or at least, anyone
 	name = ASSISTANT_TITLE
 	icon_state = "player-grey"
 	join_tag = /datum/job/assistant
-/* None for now - Eclipse Edit
+
 /datum/job/assistant/New()
 	..()
 	for(var/alt in subtypesof(/datum/job_flavor/assistant))
 		random_flavors += new alt
-*/

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -24,7 +24,7 @@ GLOBAL_VAR_INIT(arrest_security_status, "Arrest")
 
 /datum/computer_file/report/crew_record/proc/load_from_mob(var/mob/living/carbon/human/H)
 	if(istype(H))
-		if(H.job == "Vagabond") // As stowaways, Vagabond do not show up on the crew manifest.
+		if(H.mind.role_alt_title == "Vagabond") // As stowaways, Vagabond do not show up on the crew manifest.	// OCCULUS EDIT - vagabond fix
 			GLOB.all_crew_records.Remove(src)
 			return
 	if(istype(H))
@@ -61,9 +61,9 @@ GLOBAL_VAR_INIT(arrest_security_status, "Arrest")
 	set_account((H && H.mind) ? H.mind.initial_account.account_number : "000000")
 
 	// TODO: enable after baymed
-	//set_species(H ? H.get_species() : SPECIES_HUMAN)
+	set_species(H ? H.get_species() : SPECIES_HUMAN)	//OCCULUS EDIT: ENABLED
 
-	set_species("Human")
+	//set_species("Human")	//OCCULUS EDIT: DISABLED
 	//set_branch(H ? (H.char_branch && H.char_branch.name) : "None")
 	//set_rank(H ? (H.char_rank && H.char_rank.name) : "None")
 


### PR DESCRIPTION
## About The Pull Request

This PR fixes up crew records such that everyone is no longer forcibly listed as a human, fixes job alt titles, and also restores Vagabonds to their former glory. Deckhands still get randomized stats, but only Vagabonds get randomized job titles. Vagabonds also no longer exist in the manifest.

![O4ZKn5ijph](https://user-images.githubusercontent.com/31995558/99805427-7f31ba00-2b77-11eb-9fd4-5a87cfc49471.png)


## Changelog
```changelog Toriate
fix: alt titles now actually work
fix: vagabonds (which are now an alt title) are properly excluded from the manifest
fix: crew records now actually properly list your selected species
```
