### PR TITLE
Changes resting so that you should prooobably only need one cup/meal of a desire to level up.

### DIFF
--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -276,9 +276,9 @@
 	if(resting && E.taste_tag.len)
 		for(var/taste_tag in E.taste_tag)
 			if(multiplier <= 1 )
-				add_rest(taste_tag, 4 * 1/E.taste_tag.len)  //just so it got somme effect of things with small multipliers
+				add_rest(taste_tag, 9 * 1/E.taste_tag.len)  //just so it got somme effect of things with small multipliers      //occulus edit
 			else
-				add_rest(taste_tag, 4 * multiplier/E.taste_tag.len)
+				add_rest(taste_tag, 9 * multiplier/E.taste_tag.len) //occulus edit
 
 /datum/sanity/proc/onEat(obj/item/weapon/reagent_containers/food/snacks/snack, snack_sanity_gain, snack_sanity_message)
 	if(world.time > eat_time_message && snack_sanity_message)
@@ -287,7 +287,7 @@
 	changeLevel(snack_sanity_gain)
 	if(snack.cooked && resting && snack.taste_tag.len)
 		for(var/taste in snack.taste_tag)
-			add_rest(taste, snack_sanity_gain * 50/snack.taste_tag.len)
+			add_rest(taste, snack_sanity_gain * 90/snack.taste_tag.len) //occulus edit
 
 /datum/sanity/proc/onSmoke(obj/item/clothing/mask/smokable/S)
 	changeLevel(SANITY_GAIN_SMOKE * S.quality_multiplier)


### PR DESCRIPTION
## About The Pull Request

See title. Worked...fine, on my personal copy?

## Why It's Good For The Game

Because having to order two drinks just feels kind of weird and out of character for some, well, characters?

## Changelog
```changelog
tweak: should be able to level up from 1 serving of a desire. Should.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
