### PR TITLE
Comments out 'herald' breakdown

### DIFF
--- a/code/modules/sanity/breakdowns.dm
+++ b/code/modules/sanity/breakdowns.dm
@@ -439,7 +439,7 @@
 		active_view = TRUE
 		time = world.time + time_view
 
-/datum/breakdown/common/herald
+/* /datum/breakdown/common/herald //Occulus edit; disabled
 	name = "Herald"
 	restore_sanity_pre = 5
 	restore_sanity_post = 45
@@ -457,7 +457,7 @@
 	if(world.time >= message_time)
 		message_time = world.time + cooldown_message
 		var/chance = rand(1, 100)
-		holder.owner.say(chance <= 50 ? "[holder.pick_quote_20()]" : "[holder.pick_quote_40()]")
+		holder.owner.say(chance <= 50 ? "[holder.pick_quote_20()]" : "[holder.pick_quote_40()]") */
 
 /datum/breakdown/common/desire_for_chrome
 	name = "Desire for Chrome"


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin. Comments out /datum/breakdown/common/herald and /datum/breakdown/common/herald/update(). I asked about this on discord and nobody really objected to it.

To clarify, this is the breakdown that makes you speak in chat with a breakdown message (not even unique ones), every few seconds.

## Why It's Good For The Game

This is a breakdown that, IC'ly, didn't add a while lot that other breakdowns didn't; a huge lapse in sanity. There are other breakdowns that simulate having a nervous attack/whatever you would call this. These do things with ingame mechanics, such as making you obsessed over a person or item, or making everyone look like _weird spooky symbols,_ or having a hysteric breakdown. The only mechanic this provides is you spamming chat rapidly. It also entirely demystifies the insanity messages, making rare once-every-ten-minute occurences into every-ten-second ones. 

It's hard to RP, makes it hard to RP, and removes a genuine allure of mystery.

## Changelog
```changelog
del: Commented out herald breakdown.
```