### PR TITLE
Nerfs Herald Breakdown

### DIFF
--- a/code/modules/sanity/breakdowns.dm
+++ b/code/modules/sanity/breakdowns.dm
@@ -443,11 +443,11 @@
 	name = "Herald"
 	restore_sanity_pre = 5
 	restore_sanity_post = 45
-	duration = 5 MINUTES
+	duration = 3 MINUTES	// SYZYGY EDIT - Nerfs its duration from 5 to 3 minutes
 	start_messages = list("You've seen the abyss too long, and now forbidden knowledge haunts you.")
 	end_messages = list("You feel like you've forgotten something important. But this comforts you.")
 	var/message_time = 0
-	var/cooldown_message = 10 SECONDS
+	var/cooldown_message = 15 SECONDS	// SYZYGY EDIT - Nerfs its cooldown to 15 seconds from 10
 
 
 /datum/breakdown/common/herald/update()


### PR DESCRIPTION
## About The Pull Request
Alternative to #7. Merge one or the other, not both.

Herald in its current state causes a lot of chat spam and is not conducive to a HRP environment. This PR simply reduces the overall duration to 3 minutes and increases the minimum time between messages to 15 seconds. Reducing the amount of gibberish spewed should make it less egregious and more tolerable.

## Changelog
```changelog
tweak: reduced Herald duration and increased time between messages for Herald
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
