### PR TITLE
Removes the debug fallback Core Implant selection

### DIFF
--- a/code/datums/setup_option/core_implants.dm
+++ b/code/datums/setup_option/core_implants.dm
@@ -28,12 +28,3 @@
 
 /datum/category_item/setup_option/core_implant/soulcrypt/apply(mob/living/carbon/human/character)
 	character.create_soulcrypt()
-
-// SYZYGY SPAGHETTI START - This is to make it so that old characters with the cruciform selected pre-update won't get borked over completely
-/datum/category_item/setup_option/core_implant/cruciform/oldprefsfix
-	name = "Core Implant"
-	desc = "DEBUG OPTION: This is to prevent a glitch where characters saved with cruciforms selected before the church rework update get permanently stuck with a non-existant implant. <br>\
-	Deus Ex Anima. A marvelous confection of modern technology, the Cruciform <br>\
-	allows a faithful acolyte to retain their mind and soul even in death.<br>\
-	Signifies your dedication and loyalty to Children of The Mekhane."
-// SYZYGY SPAGHETTI END


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Considering we shouldn't have any old characters still stuck with the old Core Implant selection in the character creator, this crutch is no longer necessary.

## Changelog
```changelog Toriate
code: removed a minor debug option
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
