### PR TITLE
Moves Aegis Hardsuits to Secure Armory

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -1315,13 +1315,6 @@
 /obj/item/weapon/cell/small/high,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/security/armory)
-"adk" = (
-/obj/structure/table/rack,
-/obj/spawner/rig_module,
-/obj/spawner/rig_module,
-/obj/item/weapon/rig/combat/ironhammer/equipped,
-/turf/simulated/floor/tiled/dark/cargo,
-/area/eris/security/armory)
 "adl" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	id_tag = "security_access_console";
@@ -1482,9 +1475,6 @@
 /obj/structure/table/rack,
 /obj/spawner/rig_module,
 /obj/spawner/rig_module,
-/obj/spawner/rig_module,
-/obj/spawner/rig_module,
-/obj/item/weapon/rig/combat/ironhammer/equipped,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/security/armory)
 "adJ" = (
@@ -103642,6 +103632,21 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/hangarsupply)
+"iYz" = (
+/obj/structure/table/rack,
+/obj/item/weapon/rig/combat/ironhammer/equipped{
+	pixel_x = -8
+	},
+/obj/item/weapon/rig/combat/ironhammer/equipped,
+/obj/item/weapon/rig/combat/ironhammer/equipped{
+	pixel_x = 8
+	},
+/obj/machinery/door/blast/shutters/glass{
+	id = "Armoury";
+	name = "Armoury showcase"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/eris/security/warden)
 "jak" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/structure/cable/yellow{
@@ -127135,7 +127140,7 @@ abC
 abU
 acn
 abd
-adk
+adI
 adS
 aet
 aaL
@@ -127337,7 +127342,7 @@ abB
 abV
 aco
 abd
-adk
+adI
 adS
 aeu
 aaR
@@ -167332,7 +167337,7 @@ aQC
 aaJ
 aTa
 aSy
-aTa
+iYz
 aTx
 aVa
 aSS


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Aegis' Hardsuits are now no longer just sitting in the regular armory, they are now locked behind the secure armory's glass.

![dreammaker_3A0fGwUOZU](https://user-images.githubusercontent.com/31995558/100354245-cd890200-302a-11eb-896b-2032712d9efe.png)

Hardsuit modules still spawn at the same place, but now there is only a total of 6 spawns instead of 8.

![dreammaker_Y8cOkuq8XF](https://user-images.githubusercontent.com/31995558/100354263-d679d380-302a-11eb-95ca-b2a9159364e1.png)


## Changelog
```changelog
add: Aegis Hardsuits are now locked up in the secure armory.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
