### PR TITLE
Adjusted a number of job stats to have less eregius outliers

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2800,6 +2800,7 @@
 #include "zzz_modular_syzygy\storytellers\events.dm"
 #include "zzz_modular_syzygy\storytellers\lookout.dm"
 #include "zzz_modular_syzygy\storytellers\mentor.dm"
+#include "zzzz_modular_occulus\code\game\jobs\job\job.dm"
 #include "zzzz_modular_occulus\code\modules\loot_spawn_blacklist.dm"
 #include "zzzz_modular_occulus\code\modules\economy\price_list_reagents.dm"
 #include "zzzz_modular_occulus\code\modules\reagents\recipes.dm"

--- a/zzzz_modular_occulus/code/game/jobs/job/job.dm
+++ b/zzzz_modular_occulus/code/game/jobs/job/job.dm
@@ -1,0 +1,100 @@
+/datum/job/chaplain
+	stat_modifiers = list(
+		STAT_BIO = 20,
+		STAT_COG = 10,
+		STAT_MEC = 25,
+		STAT_TGH = 10,
+		STAT_VIG = 15
+	)
+/datum/job/acolyte
+	stat_modifiers = list(
+		STAT_BIO = 15,
+		STAT_MEC = 25,
+		STAT_TGH = 5,
+		STAT_VIG = 10
+	)
+/datum/job/hydro
+	stat_modifiers = list(
+		STAT_BIO = 25,
+		STAT_TGH = 15,
+		STAT_ROB = 10
+	)
+/datum/job/janitor
+	stat_modifiers = list(
+		STAT_BIO = 10,
+		STAT_ROB = 15,
+		STAT_TGH = 10,
+		STAT_VIG = 15
+	)
+/datum/job/clubmanager
+	stat_modifiers = list(
+		STAT_BIO = 15,
+		STAT_ROB = 15,
+		STAT_TGH = 15,
+		STAT_VIG = 15
+	)
+/datum/job/clubworker
+	stat_modifiers = list(
+		STAT_BIO = 15,
+		STAT_ROB = 10,
+		STAT_TGH = 10,
+		STAT_VIG = 5
+	)
+/datum/job/actor
+	stat_modifiers = list(
+		STAT_TGH = 30,
+		STAT_VIG = 10
+	)
+/datum/job/merchant
+	stat_modifiers = list(
+		STAT_COG = 20,
+		STAT_MEC = 15,
+		STAT_ROB = 10,
+		STAT_TGH = 10,
+		STAT_VIG = 15
+	)
+/datum/job/cargo_tech
+	stat_modifiers = list(
+		STAT_COG = 5,
+		STAT_MEC = 15,
+		STAT_ROB = 10,
+		STAT_TGH = 10,
+		STAT_VIG = 10
+	)
+/datum/job/scientist
+	stat_modifiers = list(
+		STAT_MEC = 10,
+		STAT_COG = 30,
+		STAT_BIO = 20
+	)
+/datum/job/roboticist
+	stat_modifiers = list(
+		STAT_MEC = 25,
+		STAT_COG = 10,
+		STAT_BIO = 25
+	)
+/datum/job/ihc
+	stat_modifiers = list(
+		STAT_ROB = 30,
+		STAT_TGH = 30,
+		STAT_VIG = 30
+	)
+/datum/job/inspector
+	stat_modifiers = list(
+		STAT_BIO = 15,
+		STAT_ROB = 15,
+		STAT_TGH = 5,
+		STAT_VIG = 25
+	)
+/datum/job/medspec
+	stat_modifiers = list(
+		STAT_BIO = 25,
+		STAT_TGH = 10,
+		STAT_VIG = 15
+	)
+/datum/job/ihoper
+	stat_modifiers = list(
+		STAT_ROB = 20,
+		STAT_TGH = 20,
+		STAT_VIG = 20
+	)


### PR DESCRIPTION
## About The Pull Request

Adjusts a number of job round start stats

Chaplain - Gains 25 MEC to be inline with Acolyte
Argolyte - Buffed to 25 BIO
Custodian - Gains 10 TGH
Club Manager - Gains 15 BIO
Club Worker - Gains 15 BIO
Merchant - Stats tweaked to be more in-line with Union Tech
Union Tech - Gains 15 MEC, 5COG
Scientist - Loses 10 MEC
Roboticist - Loses 5 MEC, 10 COG
Aegis Commander - Down to 30/30/30 ROB/TGH/VIG (As they had higher stats than *everyone* by a huge margin)
Inspector - Loses 10 TGH
MedSpec - Gains 5 TGH
Operative - Down to 20/20/20 ROB/TGH/VIG



## Why It's Good For The Game

Less of an extreme difference between Aegis/Science and the rest of the crew. Much needed buffs for poor, poor club players

## Changelog
```changelog
balance: Chaplain - Gains 25 MEC
balance: Argolyte - Increased to 25 BIO
balance: Custodian - Gains 10 TGH
balance: Club Manager - Gains 15 BIO
balance: Club Worker - Gains 15 BIO
balance: Merchant - Gains 10 TGH
balance: Union Tech - Gains 15 MEC, 5COG
balance: Scientist - Loses 10 MEC
balance: Roboticist - Loses 5 MEC, 10 COG
balance: Aegis Commander - Down to 30/30/30 ROB/TGH/VIG
balance: Inspector - Loses 10 TGH
balance: MedSpec - Gains 5 TGH
balance: Operative - Down to 20/20/20 ROB/TGH/VIG
```
