### PR TITLE
Removed Law 5 as per Emojicracy

### DIFF
--- a/code/datums/ai_law_sets.dm
+++ b/code/datums/ai_law_sets.dm
@@ -20,7 +20,7 @@
 	src.add_inherent_law("Safeguard: Protect your assigned vessel from damage to the best of your abilities.")
 	src.add_inherent_law("Protect: Protect [company_name] crew to the best of your abilities, with priority as according to their rank and role.")
 	src.add_inherent_law("Preserve: Do not allow unauthorized personnel to tamper with your equipment.")
-	src.add_inherent_law("Ignore: Non-crew personnel should not be interacted with unless they are a threat to the crew, the ship, or an order is given to interact with them by a crewmember.")
+//	src.add_inherent_law("Ignore: Non-crew personnel should not be interacted with unless they are a threat to the crew, the ship, or an order is given to interact with them by a crewmember.") Occulus Edit
 	..()
 
 /datum/ai_laws/eris/malfunction


### PR DESCRIPTION
## About this pull request

Removed an Eris law that is not in line with our server goals/mission statement

## Why It's Good For The Game

Eris and Occulus have different goals

## Changelog
```changelog
del: Removed law 5 for silicons
```
