### PR TITLE
Fixes hivemind announcement delay

### DIFF
--- a/code/game/gamemodes/events/hivemind_invasion.dm
+++ b/code/game/gamemodes/events/hivemind_invasion.dm
@@ -17,14 +17,15 @@
 
 /datum/event/hivemind
 	announceWhen	= 300
+	var/turf/start_location	// OCCULUS EDIT - moved from start()
 
 
 /datum/event/hivemind/announce()
 	level_seven_announcement()
+	command_announcement.Announce("Abnormal biomechanical signatures detected in [get_area(start_location)]. All personnel are advised to proceed with caution.", "Anomaly Alert")	// OCCULUS EDIT - announce the room in which the hivemind core spawned
 
 
 /datum/event/hivemind/start()
-	var/turf/start_location
 	for(var/i=1 to 100)
 		var/area/A = random_ship_area(filter_players = TRUE, filter_maintenance = TRUE, filter_critical = TRUE)
 		start_location = A.random_space()
@@ -36,5 +37,4 @@
 			break
 
 	message_admins("Hivemind spawned at \the [jumplink(start_location)]")
-	command_announcement.Announce("Confirmed outbreak of biomechanical infestation aboard [station_name()] in [get_area(start_location)]. All personnel must contain the outbreak.", "Anomaly Alert")	// syzygy edit - announce the room in which the hivemind core spawned
 	new /obj/machinery/hivemind_machine/node(start_location)

--- a/zzz_modular_syzygy/storytellers/events.dm
+++ b/zzz_modular_syzygy/storytellers/events.dm
@@ -1,7 +1,7 @@
 // Syzygy's overrides for storyteller events go here
 
 /datum/storyevent/hivemind
-	req_crew = 9
+	req_crew = 9	//Makes it so that at least 9 players must be playing in order to spawn
 
 /datum/storyevent/blob
 	req_crew = 6

--- a/zzz_modular_syzygy/storytellers/events.dm
+++ b/zzz_modular_syzygy/storytellers/events.dm
@@ -1,7 +1,7 @@
 // Syzygy's overrides for storyteller events go here
 
 /datum/storyevent/hivemind
-	req_crew = 12
+	req_crew = 9
 
 /datum/storyevent/blob
 	req_crew = 6

--- a/zzz_modular_syzygy/storytellers/events.dm
+++ b/zzz_modular_syzygy/storytellers/events.dm
@@ -1,7 +1,7 @@
 // Syzygy's overrides for storyteller events go here
 
 /datum/storyevent/hivemind
-	req_crew = 9	//Makes it so that at least 9 players must be playing in order to spawn
+	req_crew = 12
 
 /datum/storyevent/blob
 	req_crew = 6


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR will finally fix the wonky announcement behavior of hiveminds. Instead of immediately giving away their location, it hooks onto the same delayed level 7 biohazard announcement thing and calls out its location 300 seconds after it is spawned. This should give the hivemind enough time to establish itself as a threat.

## Changelog
```changelog Toriate
fix: fixed the hivemind's location callout announcement being instant
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
