### PR TITLE
Map fixes: aft section 2 blastdoor and shower airlock names

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -44922,7 +44922,7 @@
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock{
-	name = "Changing Room"
+	name = "Showers"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -50432,7 +50432,7 @@
 	id = "SecondSectionLockdown";
 	layer = 2.6;
 	name = "Second Section Lockdown";
-	pixel_x = 0
+	opacity = 0
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/hallway/main/section2)
@@ -99221,7 +99221,7 @@
 "eyr" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
-	name = "Showers"
+	name = "Auxiliary Closet"
 	},
 /turf/simulated/floor/tiled/white/cargo,
 /area/eris/hallway/main/section2)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR will fix the opacity of the aft section 2 blastdoor, and also fixes the airlock names on the auxiliary closet (the old showers) and the changing room (the new showers).

## Changelog
```changelog Toriate
fix: Aft Section 2 Blastdoor is no longer wonky
fix: Aux closet and showers airlocks are now appropriately named
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
