### PR TITLE
Shuffles Aegis Armory Up

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -1317,9 +1317,9 @@
 /area/eris/security/armory)
 "adk" = (
 /obj/structure/table/rack,
-/obj/spawner/rig_module,
-/obj/spawner/rig_module,
-/obj/item/weapon/rig/combat/ironhammer/equipped,
+/obj/spawner/oddities/low_chance,
+/obj/spawner/oddities/low_chance,
+/obj/spawner/oddities/low_chance,
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/security/armory)
 "adl" = (
@@ -2196,6 +2196,7 @@
 "afv" = (
 /obj/structure/closet/secure_closet/reinforced/hos,
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/item/weapon/rig/combat/ironhammer/equipped,
 /turf/simulated/floor/wood,
 /area/eris/command/commander)
 "afw" = (
@@ -104409,6 +104410,13 @@
 /obj/structure/reagent_dispensers/fueltank/huge,
 /turf/simulated/floor,
 /area/shuttle/mining/station)
+"odL" = (
+/obj/structure/table/rack,
+/obj/spawner/gun_upgrade/low_chance,
+/obj/spawner/gun_upgrade/low_chance,
+/obj/spawner/gun_upgrade/low_chance,
+/turf/simulated/floor/tiled/dark/cargo,
+/area/eris/security/armory)
 "ofp" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk{
@@ -127628,7 +127636,7 @@ abB
 abV
 aco
 abd
-adk
+odL
 adS
 aeu
 aaR


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR will remove a hardsuit from the armory, move one hardsuit to the commander's locker, removes half of the hardsuit module spawns, and fills the empty spaces with 30% chance oddity and gunmod spawns.

![StrongDMM_fK7oW8XmDg](https://user-images.githubusercontent.com/31995558/100621742-0262c500-335b-11eb-828b-2a6ea6ee2b4a.png)
![StrongDMM_JRgm1SL8AI](https://user-images.githubusercontent.com/31995558/100621743-0393f200-335b-11eb-939e-e52586c9b97b.png)


## Changelog
```changelog Toriate
add: Budgetary shortfalls as a result of missing RIG modules have resulted in Aegis heavily limiting access to them.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
