### PR TITLE
Gives Cruciform Bearers Basic Access To The Church

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -9919,7 +9919,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Church";
-	req_access = list(27)
+	req_one_access = list(27,70)
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/neotheology/storage)
@@ -10008,7 +10008,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock{
 	name = "Church";
-	req_access = list(27)
+	req_one_access = list(27,70)
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/neotheology/storage)
@@ -10202,7 +10202,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Church";
-	req_access = list(27)
+	req_one_access = list(27,70)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -11748,7 +11748,7 @@
 	},
 /obj/machinery/door/airlock{
 	name = "Church";
-	req_access = list(27)
+	req_one_access = list(27,70)
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/neotheology/storage)
@@ -32727,7 +32727,7 @@
 "byQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/maintenance_common{
-	req_access = list(27)
+	req_one_access = list(27,70)
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/neotheology/chapelritualroom)
@@ -47824,7 +47824,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Church";
-	req_access = list(27)
+	req_one_access = list(27,70)
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/neotheology/chapelritualroom)
@@ -51432,7 +51432,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Church";
-	req_access = list(27)
+	req_one_access = list(27,70)
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/neotheology/chapel)


### PR DESCRIPTION
## About The Pull Request
The following doors are now accessible to anyone with a cruciform:
![StrongDMM_UBPnanMdiW](https://user-images.githubusercontent.com/31995558/100829941-80c78000-349d-11eb-8cd2-bfc13b2d8967.png)
![StrongDMM_NCXzBY5WAv](https://user-images.githubusercontent.com/31995558/100829944-82914380-349d-11eb-9324-07238d61e66b.png)
![StrongDMM_phHdSq06MV](https://user-images.githubusercontent.com/31995558/100829947-83c27080-349d-11eb-88df-aa9cc32b0872.png)


## Why It's Good For The Game
This should more closely intertwine cruciform-bearers (church members) with the church itself, which should present interesting RP scenarios.

## Changelog
```changelog Toriate
add: Cruciform bearers now gain limited access to the innards of the church.
```