### PR TITLE
Fixes Job Department Constants

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -1,15 +1,14 @@
 #define ASSISTANT_TITLE "Deckhand"
 
 //Jobs depatment lists for use in constant expressions
-#define JOBS_SECURITY "Aegis Commander","Gunnery Sergeant","Aegis Inspector","Brig Physician","Aegis Operative","Aegis Medical Specialist"
-#define JOBS_COMMAND "Captain","Head of Personnel","Aegis Commander","Supply Manager","Chief Engineer","Chief Medical Officer","Chief Science Officer","Lazarus Representive"
-#define JOBS_ENGINEERING "Chief Engineer","Ship Engineer"
-#define JOBS_MEDICAL "Chief Medical Officer","Medical Doctor","Psychiatrist","Pharmacist","Paramedic"
-#define JOBS_SCIENCE "Chief Science Officer","Scientist","Roboticist"
+#define JOBS_SECURITY "Aegis Commander","Aegis Gunnery Sergeant","Aegis Inspector","Aegis Operative","Aegis Medical Specialist"
+#define JOBS_COMMAND "Captain","First Officer","Aegis Commander","Free Trade Union Merchant","Chief Engineer","Chief Medical Officer","Chief Science Officer","Chaplain"
+#define JOBS_ENGINEERING "Chief Engineer","Ship Engineer","Engineering Apprentice","Atmospherics Technician","Electrician","Maintenance Technician"
+#define JOBS_MEDICAL "Chief Medical Officer","Medical Doctor","Psychiatrist","Pharmacist","Paramedic","Surgeon","Nurse","Medical Intern"
+#define JOBS_SCIENCE "Chief Science Officer","Scientist","Roboticist","Xenobiologist","Xenoflorist","Research Intern","Anomalist"
 #define JOBS_CARGO "Free Trade Union Merchant","Union Cargo Technician","Union Miner"
-#define JOBS_CIVILIAN "Club Manager","Club Worker","Custodian","Botanist",ASSISTANT_TITLE
-#define JOBS_LAZARUS "Lazarus Representive","Geneticist","Research Associate",
-#define JOBS_CHURCH "NeoTheology Magos","NeoTheology Enginseer","NeoTheology Acolyte",
+#define JOBS_CIVILIAN "Club Manager","Club Worker","Actor",ASSISTANT_TITLE,"Intern","Assistant"
+#define JOBS_CHURCH "Chaplain","Mekhane Acolyte","Mekhane Custodian","Mekhane Agrolyte"
 #define JOBS_NONHUMAN "AI","Robot","pAI"
 
 #define CREDITS "&cent;"

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -133,6 +133,6 @@ Act as the captain's sidekick, bodyguard, and last line of defense in a crisis o
 	)
 
 /obj/landmark/join/start/hop
-	name = "Head of Personnel"
+	name = "First Officer"
 	icon_state = "player-gold"
 	join_tag = /datum/job/hop


### PR DESCRIPTION
## About The Pull Request

This effectively causes the Merchant and First Officer to once again count as heads, when previously they did not. An issue with the First Officer's spawner has also been fixed.

Furthermore, this allows [REDACTED] to work properly for the First Officer and Chaplain positions again.

## Changelog
```changelog Toriate
fix: Job department constants have been fixed and merchants should now count as command staff again.
```