### PR TITLE
tiny optimization that probably does nothing

### DIFF
--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -287,6 +287,7 @@ var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 				pref.client = C
 				break
 
+/*	Occulus edit - experimental optimization
 	//lets try again after 1 second
 	//for some reason it doesnt find client on login
 	spawn(10)
@@ -295,6 +296,8 @@ var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 				if(C.ckey == pref.client_ckey)
 					pref.client = C
 					break
+*/
+
 	if(pref.client)
 		return pref.client.mob
 


### PR DESCRIPTION
## About The Pull Request
This PR will remove some crappy copypasta and timers with the aim of reducing character generation lag. This does not appear to have an impact on 500+ body marking characters, but it should help a bit. Juuuuust a little bit.

No noticeable issues were noticed from the removal of the spaghetti, and even in the worst case, it'd just render character previews unavailable until you refresh the character creator screen.

## Changelog
```changelog Toriate
tweak: made a teeny tiny character generation microoptimization that no one will notice
```