### PR TITLE
Hivemind difficulty tweak

### DIFF
--- a/code/game/objects/structures/burrows.dm
+++ b/code/game/objects/structures/burrows.dm
@@ -146,7 +146,7 @@
 	//Creatures only. No humans or robots
 	if (!isanimal(L) && !issuperioranimal(L))
 		return FALSE
-	
+
 	//Kaisers are too fat, they can't fit in
 	if(istype(L, /mob/living/carbon/superior_animal/roach/kaiser))
 		return FALSE
@@ -638,6 +638,7 @@ percentage is a value in the range 0..1 that determines what portion of this mob
 /obj/structure/burrow/proc/spread_plants()
 	reveal()
 	if(istype(plant, /datum/seed/wires))		//hivemind wireweeds handling
+		/*		Occulus Edit start
 		if(locate(/obj/effect/plant) in loc)
 			return
 
@@ -648,7 +649,9 @@ percentage is a value in the range 0..1 that determines what portion of this mob
 		var/obj/machinery/hivemind_machine/node/hivemind_node = pick(hive_mind_ai.hives)
 		var/obj/effect/plant/hivemind/wire = new(loc, plant)
 		hivemind_node.add_wireweed(wire)
-
+		Occulus edit end
+*/
+		return //Occulus edit: removed hivemind burrow
 	for (var/obj/effect/plant in loc)
 		return
 

--- a/code/modules/hivemind/core.dm
+++ b/code/modules/hivemind/core.dm
@@ -26,7 +26,9 @@ var/datum/hivemind/hive_mind_ai
 											/obj/machinery/button,					/obj/machinery/status_display,
 											/obj/machinery/floor_light,				/obj/machinery/flasher,
 											/obj/machinery/filler_object,			/obj/machinery/hivemind_machine,
-											/obj/machinery/cryopod)
+											/obj/machinery/cryopod, 				/obj/machinery/portable_atmospherics,//Occulus Edit: Restrict Canisters, Pumps, and Portable trays from being converted
+											/obj/machinery/conveyor//Occulus edit: Blacklisted Conveyor objects
+											)
 	//internals
 	var/list/global_abilities_cooldown = list()
 	var/list/EP_price_list = list()


### PR DESCRIPTION
## About The Pull Request

Hivemind burrow spread disabled
Portable Atmospheric machinery can no longer be converted by hiveminds
Non-modular due to nature of the PR

## Why It's Good For The Game

Hiveminds in their current form are, simply put, too much for even borderline non-lowpop crews to handle.

## Changelog
```changelog
tweak: Hivemind burrow spread disabled
tweak: Portable Atmospheric machinery can no longer be converted by hiveminds
```
