### PR TITLE
Reverts nanoui vote window back to plain html

### DIFF
--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -19,9 +19,14 @@ SUBSYSTEM_DEF(vote)
 		interface_client(C)
 
 /datum/controller/subsystem/vote/proc/interface_client(client/C)
+// OCCULUS EDIT START - Experimental revert to plain html to attempt to mitigate the whole unable to reliably close window thing
+	C << browse(interface(C),"window=vote;size=500x700;can_close=0;can_resize=0;can_minimize=0")
+/*
 	var/datum/browser/panel = new(C.mob, "Vote","Vote", 500, 650)
 	panel.set_content(interface(C))
 	panel.open()
+*/
+// OCCULUS EDIT END - Experimental revert to plain html to attempt to mitigate the whole unable to reliably close window thing
 
 /datum/controller/subsystem/vote/fire()
 	if(active_vote)


### PR DESCRIPTION
## About The Pull Request

Exactly what it says on the tin. The nanoui vote window's close button is very unresponsive and leaves the window open. With this, the close button will instantly close the vote window, and should prevent it from popping up again.

![dreamseeker_AAcLxo2uU9](https://user-images.githubusercontent.com/31995558/102156555-c2522500-3eb8-11eb-81a5-7808420ab055.png)

## Changelog
```changelog Toriate
del: Reverted nanoui vote window back to plain html for better voting responsiveness.
```
