### PR TITLE
Ports the Revelation litany from upstream

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -111,3 +111,22 @@
 		fail("No target. Make sure your target is either in front of you or grabbed by you.", H, C)
 		return FALSE
 	return TRUE
+
+/datum/ritual/cruciform/base/revelation
+	name = "Revelation"
+	phrase = "Patris ostendere viam"
+	desc = "A person close to you will have a vision that could increase their sanity... or that's what you hope will happen."
+	power = 50
+
+/datum/ritual/cruciform/base/revelation/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
+	var/mob/living/carbon/human/T = get_front_human_in_range(H, 4)
+	//if(!T || !T.client)
+	if(!T)
+		fail("No target.", H, C)
+		return FALSE
+	T.hallucination(30,50)	//OCCULUS EDIT - Tweaks to be more in line with mindwipe
+	var/sanity_lost = rand(0,5)	//OCCULUS EDIT - Makes it so that it won't tank someone's sanity, but isn't as powerful
+	T.druggy = max(T.druggy, 10)
+	T.sanity.changeLevel(sanity_lost)
+	//SEND_SIGNAL(H, COMSIG_RITUAL, src, T)	//OCCULUS EDIT - We don't have individual objectives here
+	return TRUE

--- a/code/modules/core_implant/ritual.dm
+++ b/code/modules/core_implant/ritual.dm
@@ -117,6 +117,14 @@
 		L = get_front_mob(user)
 	return L
 
+/proc/get_front_human_in_range(var/mob/living/carbon/human/user, nrange = 1)
+	var/turf/T = get_step(user,user.dir)
+	for(var/i=1, i<=nrange, i++)
+		var/mob/living/carbon/human/H = locate(/mob/living) in T
+		if(H)
+			return H
+		T = get_step(T,user.dir)
+	return
 
 //Getting implants
 /mob/living/proc/get_core_implant(ctype = null, req_activated = TRUE)


### PR DESCRIPTION
## About The Pull Request

As we did not get the individual objectives update from upstream, we have missed out on two litanies, Revelation and Sanctify. Revelation causes a hallucination in the target, and has a chance to either restore or drain their sanity. Sanctify is purely fluff and literally does nothing aside from completing individual objectives. This sanctify should NOT be confused with the church's weapon's sanctify upgrade, which does something else entirely.

This PR will only port Revelation, and tweaks it slightly. It will have generally less negative effects, but won't be as powerful.

## Changelog
```changelog Toriate
add: Ported the revelation litany from upstream.
```