### PR TITLE
Enables Object Depossession

### DIFF
--- a/code/modules/admin/verbs/possess.dm
+++ b/code/modules/admin/verbs/possess.dm
@@ -20,6 +20,7 @@ ADMIN_VERB_ADD(/proc/possess, R_FUN, FALSE)
 	usr.control_object = O
 	usr.ReplaceMovementHandler(/datum/movement_handler/mob/admin_possess)
 
+ADMIN_VERB_ADD(/proc/release, R_FUN, FALSE)	//OCCULUS EDIT - Enables depossession
 /proc/release(obj/O)
 	set name = "Release Obj"
 	set category = "Object"


### PR DESCRIPTION
## About The Pull Request

Non-modular change to enable the Release Obj verb which is what you actually need to use to leave an item after using the Possess Obj Verb.

## Changelog
```changelog Toriate
admin: you can now actually depossess objects rather than becoming permanently stuck in one
```
