### PR TITLE
Robot and Mech fixes! Literally playable!

### DIFF
--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -243,3 +243,5 @@
 			gases = gas
 	log_admin("[usr] ([usr.ckey]) opened '[src.name]' containing [gases].")
 	message_admins("[usr] ([usr.ckey]) opened '[src.name]' containing [gases].")
+/obj/machinery/portable_atmospherics/proc/dropped()//Occulus Edit: Kills a runtime from mecha
+	return

--- a/code/modules/mechs/mech.dm
+++ b/code/modules/mechs/mech.dm
@@ -4,7 +4,7 @@
 	desc = "A powerful machine piloted from a cockpit, but worn like a suit of armour."
 	density = TRUE
 	opacity = TRUE
-	anchored = TRUE
+//	anchored = TRUE Occulus Edit: Removing Anchoring
 	default_pixel_x = -8
 	default_pixel_y = 0
 	status_flags = PASSEMOTES

--- a/code/modules/mechs/mech_movement.dm
+++ b/code/modules/mechs/mech_movement.dm
@@ -87,35 +87,33 @@
 
 /datum/movement_handler/mob/space/exosuit/expected_host_type = /mob/living/exosuit
 
-// Space movement
+// Space movement Occulus Edit Start
 /datum/movement_handler/mob/space/exosuit/DoMove(var/direction, var/mob/mover)
-
-	if(!mob.check_solid_ground())
-		mob.anchored = FALSE
-		var/allowmove = mob.allow_spacemove(0)
+	if(!mob.check_gravity())//If there is no solid ground beneath us, we fall in space!
+		var/allowmove = mob.allow_spacemove()
 		if(!allowmove)
 			return MOVEMENT_HANDLED
 		else if(allowmove == -1 && mob.handle_spaceslipping()) //Check to see if we slipped
 			return MOVEMENT_HANDLED
 		else
 			mob.inertia_dir = 0 //If not then we can reset inertia and move
-	else mob.anchored = TRUE
+	else
 
 /datum/movement_handler/mob/space/exosuit/MayMove(var/mob/mover, var/is_external)
-	if((mover != host) && is_external)
+	if((mover != host) && is_external)//If we are being pulled,  continue
 		return MOVEMENT_PROCEED
 
-	if(!mob.check_solid_ground())
-		if(!mob.allow_spacemove(0))
+	if(!mob.check_gravity())//If there is gravity, we can move!
+		if(!mob.allow_spacemove())//If there isn't gravity, check if we can spacemove
 			return MOVEMENT_STOP
 	return MOVEMENT_PROCEED
-
+// Occulus Edit End
 /mob/living/exosuit/lost_in_space()
 	for(var/atom/movable/AM in contents)
 		if(!AM.lost_in_space())
 			return FALSE
 	return !pilots.len
-
+/*
 /mob/living/exosuit/get_fall_damage(var/turf/from, var/turf/dest)
 	return (from.z - dest.z > 1) ? (50 * from.z - dest.z) : 0 //Exosuits are big and heavy //but one z level can't damage them
 
@@ -125,4 +123,5 @@
 	..()
 	var/damage = 30 //Enough to cause a malfunction if unlucky
 	apply_damage(rand(0, damage), BRUTE, BP_R_LEG) //Any leg is good, will damage both
+*/
 */

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -156,7 +156,7 @@
 	//Robots should not be falling! Their bulky inarticulate frames lack shock absorbers, and gravity turns their armor plating against them
 	//Falling down a floor is extremely painful for robots, and for anything under them, including the floor
 
-	var/damage = maxHealth*0.49 //Just under half of their health
+	var/damage = maxHealth*0.33 //Just under half of their health. Occulus Edit: Nerfed to 33%
 	//A percentage is used here to simulate different robots having different masses. The bigger they are, the harder they fall
 
 	//Falling two floors is not an instakill, but it almost is


### PR DESCRIPTION
## About The Pull Request

Fixed mechs not moving on catwalks
Mechs now take substantial damage (66% per Z)  while falling
Robots now take less damage (33% per Z) while falling
Fixed a runtime in mecha and air canister code

## Why It's Good For The Game

This fixes many notable bugs with mechs, fixes a hidden runtime, and helps robots out a bit

## Changelog
```changelog
fix: Mechs can walk on catwalks now
balance: Mechs now take substantial damage (66% per Z)  while falling
balance: Robots now take less damage (33% per Z) while falling
fix: Removing an air can from a mech chassis no longer runtimes
```