### PR TITLE
Fixed pickweight() selecting options with a weight of 0.

### DIFF
--- a/code/__HELPERS/_lists.dm
+++ b/code/__HELPERS/_lists.dm
@@ -258,7 +258,7 @@
 	total = rand() * total
 	for (item in L)
 		total -= L[item]
-		if (total <= 0)
+		if (total <= 0 && L[item] > 0)//Occulus Edit: If we have a weight of zero or lower, do not pick that option.
 			return item
 
 //Picks a number of elements from a list based on weight.


### PR DESCRIPTION
## About The Pull Request

Weighted list sorting will now no longer select options that have 0 weight.

## Why It's Good For The Game

A weight of 0 means something should never be picked.

## Changelog
```changelog
fix: adjusted pickweight() proc to be more sane
```