### PR TITLE
Fixes a runtime and makes oddities have perks again!

### DIFF
--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -34,6 +34,10 @@
 			for(var/stat in oddity_stats)
 				oddity_stats[stat] = rand(1, oddity_stats[stat])
 		AddComponent(/datum/component/inspiration, oddity_stats, perk)
+	//OCCULUS EDIT START - REEE GIMME PERKS
+	if(!perk)
+		perk = pick(subtypesof(/datum/perk/oddity))
+	//OCCULUS EDIT END
 
 /obj/item/weapon/oddity/examine(user)
 	..()

--- a/code/modules/surgery/surgery_ui.dm
+++ b/code/modules/surgery/surgery_ui.dm
@@ -33,8 +33,12 @@
 	data["limb_efficiency"] = limb_efficiency
 	data["occupied_volume"] = get_total_occupied_volume()
 	data["max_volume"] = max_volume
-	data["owner_oxyloss"] = owner.getOxyLoss()
-	data["owner_oxymax"] = 100 - owner.total_oxygen_req
+
+	//OCCULUS EDIT START - RUNTIME FIX
+	if(owner)
+		data["owner_oxyloss"] = owner.getOxyLoss()
+		data["owner_oxymax"] = 100 - owner.total_oxygen_req
+	//OCCULUS EDIT END
 
 	data["conditions"] = get_conditions()
 	data["diagnosed"] = diagnosed


### PR DESCRIPTION
## About The Pull Request
There's a PR upstream that straight out nerfs oddities and makes it so that they only have a limited chance to spawn with perks, which was seemingly in place already when the EOTP stuff was done upstream, hence us getting some changes that unintentionally broke the crap out of our oddity perks. Until we decide to port that, we'll have to revert to the old system.

This will also fix a runtime with surgery'ing detached limbs.

## Changelog
```changelog Toriate
fix: Oddities should have perks again!
fix: Surgery'ing detached limbs should not throw an error anymore!
```
