### PR TITLE
Fixed nonhumans getting doubled organs on clone

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1189,10 +1189,10 @@ var/list/rank_prefix = list(\
 		checkprefcruciform = TRUE
 		qdel(CI)
 */
+	for(var/obj/item/organ/organ in (organs|internal_organs))//Occulus Edit - Moving this out so the cloner stops breaking
+		qdel(organ)//Occulus Edit
 
 	if(from_preference)
-		for(var/obj/item/organ/organ in (organs|internal_organs))
-			qdel(organ)
 
 		if(organs.len)
 			organs.Cut()


### PR DESCRIPTION
## About The Pull Request

Fixes a bad proc call.
Tested and confirms work
High priority fix

## Why It's Good For The Game

High prioirty fix
Prior to erismed2 you couldn't have duplicate organs, so it wasn't neccesary to delete something unless we wanted to replace it (in character_prefs). Now that we can have duplicates, we need to delete the organs created by New() before adding in all the organs a species should have!

TL:DR- We are kinda dumb and this is an issue based on our code!

## Changelog
```changelog
fix: cloning no longer doubles all your organs.
```
