### PR TITLE
Suggbox Wave 1: Now with less CRLF crap

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2803,6 +2803,7 @@
 #include "zzzz_modular_occulus\code\game\objects\items\weapons\grenades\chem_grenade.dm"
 #include "zzzz_modular_occulus\code\game\objects\random\utility.dm"
 #include "zzzz_modular_occulus\code\game\objects\structures\fitness.dm"
+#include "zzzz_modular_occulus\code\game\objects\structures\crates_lockers\closets\secure\engineering.dm"
 #include "zzzz_modular_occulus\code\modules\loot_spawn_blacklist.dm"
 #include "zzzz_modular_occulus\code\modules\client\preference_setup\loadout\lists\headwear.dm"
 #include "zzzz_modular_occulus\code\modules\clothing\mekhanearmor.dm"

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -18920,6 +18920,9 @@
 	dir = 6
 	},
 /obj/structure/cyberplant,
+/obj/machinery/light_switch{
+	pixel_x = -32
+	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/barracks)
 "aTO" = (

--- a/zzzz_modular_occulus/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
+++ b/zzzz_modular_occulus/code/game/objects/structures/crates_lockers/closets/secure/engineering.dm
@@ -1,0 +1,5 @@
+// One whole file just for a tiny override!
+
+/obj/structure/closet/secure_closet/personal/engineering_personal/populate_contents()
+	..()
+	new /obj/item/taperoll/engineering(src)


### PR DESCRIPTION
## About The Pull Request
Literally just https://github.com/Occulus-Server/Occulus-Eris/pull/116 except I kept the old lightswitch and the .dme is not ruined.

![StrongDMM_qob4B8mgmq](https://user-images.githubusercontent.com/31995558/103449168-63294880-4cdf-11eb-9ef0-182c9abdcae9.png)

## Why It's Good For The Game

Listening to your players is good.

## Changelog
```changelog
add: Engineering lockers now get engineering tape. The aegis barracks also has had an extra lightswitch installed.
```