### PR TITLE
Fixes Shorts

### DIFF
--- a/zzz_modular_syzygy/code/modules/loadout/lists/uniforms.dm
+++ b/zzz_modular_syzygy/code/modules/loadout/lists/uniforms.dm
@@ -6,11 +6,11 @@
 /datum/gear/uniform/shorts/color_presets/New()
 	..()
 	var/shorts = list(
-		"Black"			=	/obj/item/clothing/under/color/black,
-		"Blue"			=	/obj/item/clothing/under/color/blue,
-		"Green"			=	/obj/item/clothing/under/color/green,
-		"Grey"			=	/obj/item/clothing/under/color/grey,
-		"Red"			=	/obj/item/clothing/under/color/red
+		"Black"			=	/obj/item/clothing/under/shorts/black,
+		"Blue"			=	/obj/item/clothing/under/shorts/blue,
+		"Green"			=	/obj/item/clothing/under/shorts/green,
+		"Grey"			=	/obj/item/clothing/under/shorts/grey,
+		"Red"			=	/obj/item/clothing/under/shorts/red
 	)
 	gear_tweaks += new /datum/gear_tweak/path(shorts)
 
@@ -23,4 +23,4 @@
 /datum/gear/uniform/turtleneck
 	display_name = "black turtleneck"
 	path = /obj/item/clothing/under/syndicate/civilian
-	
+


### PR DESCRIPTION
## About The Pull Request
You can now properly pick shorts in the loadout now!

## Changelog
```changelog Toriate
fix: you can now properly pick shorts in the loadout!
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
