### PR TITLE
Events with a weighting of 0 will no longer fire.

### DIFF
--- a/code/game/gamemodes/storyevent.dm
+++ b/code/game/gamemodes/storyevent.dm
@@ -70,7 +70,7 @@
 	if (!enabled)
 		if (report) to_chat(report, SPAN_NOTICE("Failure: The event is disabled"))
 		return FALSE
-		
+
 	if (ocurrences_max > 0 && ocurrences >= ocurrences_max)
 		if (report) to_chat(report, SPAN_NOTICE("Failure: The event has already triggered the maximum number of times for a single round"))
 		return FALSE

--- a/code/game/gamemodes/storyevent.dm
+++ b/code/game/gamemodes/storyevent.dm
@@ -70,7 +70,6 @@
 	if (!enabled)
 		if (report) to_chat(report, SPAN_NOTICE("Failure: The event is disabled"))
 		return FALSE
-
 	if (ocurrences_max > 0 && ocurrences >= ocurrences_max)
 		if (report) to_chat(report, SPAN_NOTICE("Failure: The event has already triggered the maximum number of times for a single round"))
 		return FALSE

--- a/code/game/gamemodes/storyevent.dm
+++ b/code/game/gamemodes/storyevent.dm
@@ -70,6 +70,7 @@
 	if (!enabled)
 		if (report) to_chat(report, SPAN_NOTICE("Failure: The event is disabled"))
 		return FALSE
+		
 	if (ocurrences_max > 0 && ocurrences >= ocurrences_max)
 		if (report) to_chat(report, SPAN_NOTICE("Failure: The event has already triggered the maximum number of times for a single round"))
 		return FALSE

--- a/code/game/gamemodes/storyteller.dm
+++ b/code/game/gamemodes/storyteller.dm
@@ -280,7 +280,7 @@ GLOBAL_DATUM(storyteller, /datum/storyteller)
 	//We pick an event from the pool at random, and check if it's allowed to run
 	while (choice == null)
 		choice = pickweight(temp_pool)
-		if (!choice.can_trigger(event_type))
+		if (!choice.can_trigger(event_type) || calculate_event_weight(choice) == 0)//Occulus Edit
 			//If its not, we'll remove it from the temp pool and then pick another
 			temp_pool -= choice
 			choice = null


### PR DESCRIPTION
## About The Pull Request

Events with a weighting of 0 will no longer fire

## Why It's Good For The Game

0 weighting means SOMETHING SHOULD NOT BE PICKED

## Changelog
```changelog
fix: Major events such as Hivemind should no longer trigger during a Healer round.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
