### PR TITLE
Re-rebalances the EC9

### DIFF
--- a/zzzz_modular_occulus/code/modules/projectiles/guns/projectile/pistol/ec9.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/guns/projectile/pistol/ec9.dm
@@ -1,7 +1,7 @@
 /obj/item/weapon/gun/projectile/ec9
 	name = "SMG .35 Auto \"EC9\""
 	desc = "The EC9 is a generic replica of an old and infamous SMG. An extremely cheap design made to look more intimidating than it actually is. \
-			It is incapable of firing in full auto due to its excessively simplified trigger mechanism. Uses .35 Auto Hi-Cap Magazines."
+			It is incapable of firing in full auto due to its excessively simplified trigger mechanism. Uses .35 Auto Hi-Cap and SMG magazines."
 	icon = 'zzzz_modular_occulus/icons/obj/guns/projectile/ec9.dmi'
 	icon_state = "ec9"
 	item_state = "ec9"
@@ -12,15 +12,15 @@
 	slot_flags = SLOT_BELT
 	ammo_type = "/obj/item/ammo_casing/pistol"
 	load_method = MAGAZINE
-	mag_well = MAG_WELL_H_PISTOL
-	magazine_type = /obj/item/ammo_magazine/hpistol
+	mag_well = MAG_WELL_H_PISTOL|MAG_WELL_SMG
+	magazine_type = /obj/item/ammo_magazine/smg
 	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_STEEL = 5, MATERIAL_WOOD = 2)
 	price_tag = 800
-	rarity_value = 10.1
+	rarity_value = 18.5
 	damage_multiplier = 1
 	penetration_multiplier = 1
 	recoil_buildup = 4
-	one_hand_penalty = 3
+	one_hand_penalty = 4
 
 	init_firemodes = list(
 		BURST_5_ROUND,


### PR DESCRIPTION
## About The Pull Request

This makes the EC9 take SMG magazines again, increases its unwielded recoil penalty a bit, and nearly doubles its spawn rarity.

## Why It's Good For The Game

So it turned out I had somehow made it 2x as common as the Atreides and then kept thinking I had made it the same rarity as the Atreides. It is now only slightly more common than the Atreides. Gone are the days of EC9s dominating maint loot!

It has also gotten the ability to use SMG magazines back after some more player feedback, and its recoil has been boosted a bit to be more inline with all the other SMGs.

This should make the EC9 less of a sore thumb in the game overall.

## Changelog
```changelog Toriate
balance: rebalanced the EC9 so that it will stop dominating maint loot and be more inline with all the other SMGs in the sense that it actually takes SMG magazines now.
```