### PR TITLE
Unincludes bear's new dungeon from the main .dme

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2845,6 +2845,5 @@
 #include "zzzz_modular_occulus\code\modules\sprite_accessories\_accessory_hair.dm"
 #include "zzzz_modular_occulus\code\modules\sprite_accessories\_accessory_tesh.dm"
 #include "zzzz_modular_occulus\maps\submaps\deepmaint_rooms\core\core_rooms.dm"
-#include "zzzz_modular_occulus\maps\submaps\deepmaint_rooms\core\chromelab.dmm"
 #include "zzzz_modular_occulus\maps\submaps\deepmaint_rooms\normal\normal_rooms.dm"
 // END_INCLUDE


### PR DESCRIPTION
## About The Pull Request
Exactly what it says on the tin.

## Why It's Good For The Game
Deepmaint rooms do not need to be compiled with everything else, as a different mechanism is responsible for loading them when deepmaint is generated.

At best, this would slow down regular compiling ever so slightly. At worst, this would break it somehow (unconfirmed but you'll never know with BYOND.).

## Changelog
```changelog Toriate
code: bear's new deepmaint room is no longer included
```
