### PR TITLE
Bucket Transfer Change

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2836,6 +2836,7 @@
 #include "zzzz_modular_occulus\code\modules\projectiles\projectile\bullettypes.dm"
 #include "zzzz_modular_occulus\code\modules\reagents\food-Drinks.dm"
 #include "zzzz_modular_occulus\code\modules\reagents\recipes.dm"
+#include "zzzz_modular_occulus\code\modules\reagents\reagent_containers\glass\beaker.dm"
 #include "zzzz_modular_occulus\code\modules\sanity\sanity_mob.dm"
 #include "zzzz_modular_occulus\code\modules\shield_generators\shield_generator.dm"
 #include "zzzz_modular_occulus\code\modules\soulcrypt\holochip.dm"

--- a/zzzz_modular_occulus/code/modules/reagents/reagent_containers/glass/beaker.dm
+++ b/zzzz_modular_occulus/code/modules/reagents/reagent_containers/glass/beaker.dm
@@ -1,0 +1,3 @@
+/obj/item/weapon/reagent_containers/glass/bucket
+	possible_transfer_amounts = list(10,20,30,50,60,100,120,200) //Added a transfer value for 50 and 100
+


### PR DESCRIPTION
Added 50 and 100 to the bucket transfer values, because my OCD was killing me.

## About The Pull Request

Added reagent_containers/glass/beaker.dm to the modular Occulus folder
Added 50 and 100 unit transfer values to the common plastic buckets.

## Why It's Good For The Game

Personally, not having an even amount of water to pour into a tray to refill it bothered me. Previously, your best bet was to use 20, which involved 5 clicks to fill a tray and ten to refill it, or 60 if you didn't mind wasting some water. Not that it's exactly possible to waste what is effectively an infinite resource, but it bothered me enough that I decided it would be a good idea to change it in my first PR. 

Tested it out after, every other transfer value showed up, and the new values worked just fine for taking water in and pouring it out.

## Changelog
```changelog
tweak: Buckets can now transfer 50 / 100 units at a time, in addition to their previous values.
```

