### PR TITLE
Update makechangelogs to acutally run on our Repo

### DIFF
--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   MakeCL:
     runs-on: ubuntu-latest
-    if: github.repository == 'SyzygyStation/Syzygy-Eris'
+    if: github.repository == 'Occulus-Server/Occulus-Eris'
     steps:
       - name: Checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
## About The Pull Request

Fixes a bad variable in our workflows

## Why It's Good For The Game

administrative stuff

## Changelog
```changelog
admin: fixing changelog workflows
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
