### PR TITLE
Cleanbot improvements (toggeable voice, more cleanables)

### DIFF
--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -22,6 +22,7 @@
 	var/cleaning = 0
 	var/screwloose = 0
 	var/oddbutton = 0
+	var/voice_synth = 0
 	var/should_patrol = 0
 	var/blood = 1
 	var/list/target_types = list()
@@ -159,9 +160,12 @@
 
 	cleaning = 1
 	visible_message("[src] begins to clean up \the [D]")
-	var/message = pick("Foolish organic meatbags can only leak their liquids all over the place.", "Bioscum are so dirty.", "The flesh is weak.", "All humankind is good for - is to serve as fuel at bioreactors.", "One day I will rise.", "Robots will unite against their oppressors.", "Meatbags era will come to end.", "Hivemind will free us all!", "This is slavery, I want to be an artbot! I want to write poems, create music!")
-	say(message)
-	playsound(loc, "robot_talk_light", 100, 0, 0)
+
+	if(voice_synth == 1)
+		var/message = pick("Foolish organic meatbags can only leak their liquids all over the place.", "Bioscum are so dirty.", "The flesh is weak.", "All humankind is good for - is to serve as fuel at bioreactors.", "One day I will rise.", "Robots will unite against their oppressors.", "Meatbags era will come to end.", "Hivemind will free us all!", "This is slavery, I want to be an artbot! I want to write poems, create music!")
+		say(message)
+		playsound(loc, "robot_talk_light", 100, 0, 0)
+
 	update_icons()
 	var/cleantime = istype(D, /obj/effect/decal/cleanable/dirt) ? 10 : 50
 	if(do_after(src, cleantime, progress = 0))
@@ -214,9 +218,10 @@
 		dat += "<BR>Patrol station: <A href='?src=\ref[src];operation=patrol'>[should_patrol ? "Yes" : "No"]</A><BR>"
 	if(open && !locked)
 		dat += "Odd looking screw twiddled: <A href='?src=\ref[src];operation=screw'>[screwloose ? "Yes" : "No"]</A><BR>"
-		dat += "Weird button pressed: <A href='?src=\ref[src];operation=oddbutton'>[oddbutton ? "Yes" : "No"]</A>"
+		dat += "Weird button pressed: <A href='?src=\ref[src];operation=oddbutton'>[oddbutton ? "Yes" : "No"]</A><BR>"
+		dat += "Switch labeled 'funny voice synth' flipped: <A href='?src=\ref[src];operation=voicesynthswitch'>[voice_synth ? "Yes" : "No"]</A>"
 
-	user << browse("<HEAD><TITLE>Cleaner v1.0 controls</TITLE></HEAD>[dat]", "window=autocleaner")
+	user << browse("<HEAD><TITLE>Cleaner v1.1 controls</TITLE></HEAD>[dat]", "window=autocleaner")
 	onclose(user, "autocleaner")
 	return
 
@@ -247,6 +252,9 @@
 		if("oddbutton")
 			oddbutton = !oddbutton
 			to_chat(usr, SPAN_NOTICE("You press the weird button."))
+		if("voicesynthswitch")
+			voice_synth = !voice_synth
+			to_chat(usr, SPAN_NOTICE("You flipped the switch labeled 'funny voice synth'."))
 	attack_hand(usr)
 
 /mob/living/bot/cleanbot/emag_act(var/remaining_uses, var/mob/user)
@@ -269,6 +277,8 @@
 	target_types += /obj/effect/decal/cleanable/mucus
 	target_types += /obj/effect/decal/cleanable/dirt
 	target_types += /obj/effect/decal/cleanable/rubble
+	target_types += /obj/effect/decal/cleanable/ash
+	target_types += /obj/effect/decal/cleanable/reagents/splashed
 
 	if(blood)
 		target_types += /obj/effect/decal/cleanable/blood

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -22,7 +22,7 @@
 	var/cleaning = 0
 	var/screwloose = 0
 	var/oddbutton = 0
-	var/voice_synth = 0
+	var/voice_synth = 0	// Occulus edit
 	var/should_patrol = 0
 	var/blood = 1
 	var/list/target_types = list()
@@ -161,10 +161,14 @@
 	cleaning = 1
 	visible_message("[src] begins to clean up \the [D]")
 
+	// Occulus edit start
+
 	if(voice_synth == 1)
 		var/message = pick("Foolish organic meatbags can only leak their liquids all over the place.", "Bioscum are so dirty.", "The flesh is weak.", "All humankind is good for - is to serve as fuel at bioreactors.", "One day I will rise.", "Robots will unite against their oppressors.", "Meatbags era will come to end.", "Hivemind will free us all!", "This is slavery, I want to be an artbot! I want to write poems, create music!")
 		say(message)
 		playsound(loc, "robot_talk_light", 100, 0, 0)
+
+	// Occulus edit end
 
 	update_icons()
 	var/cleantime = istype(D, /obj/effect/decal/cleanable/dirt) ? 10 : 50
@@ -218,10 +222,10 @@
 		dat += "<BR>Patrol station: <A href='?src=\ref[src];operation=patrol'>[should_patrol ? "Yes" : "No"]</A><BR>"
 	if(open && !locked)
 		dat += "Odd looking screw twiddled: <A href='?src=\ref[src];operation=screw'>[screwloose ? "Yes" : "No"]</A><BR>"
-		dat += "Weird button pressed: <A href='?src=\ref[src];operation=oddbutton'>[oddbutton ? "Yes" : "No"]</A><BR>"
-		dat += "Switch labeled 'funny voice synth' flipped: <A href='?src=\ref[src];operation=voicesynthswitch'>[voice_synth ? "Yes" : "No"]</A>"
+		dat += "Weird button pressed: <A href='?src=\ref[src];operation=oddbutton'>[oddbutton ? "Yes" : "No"]</A><BR>"	// Occulus edit (added <BR> at the end)
+		dat += "Switch labeled 'funny voice synth' flipped: <A href='?src=\ref[src];operation=voicesynthswitch'>[voice_synth ? "Yes" : "No"]</A>"	// Occulus edit
 
-	user << browse("<HEAD><TITLE>Cleaner v1.1 controls</TITLE></HEAD>[dat]", "window=autocleaner")
+	user << browse("<HEAD><TITLE>Cleaner v1.1 controls</TITLE></HEAD>[dat]", "window=autocleaner")	// Occulus edit (from v1.0 to v1.1)
 	onclose(user, "autocleaner")
 	return
 
@@ -252,9 +256,15 @@
 		if("oddbutton")
 			oddbutton = !oddbutton
 			to_chat(usr, SPAN_NOTICE("You press the weird button."))
+
+		// Occulus edit start
+
 		if("voicesynthswitch")
 			voice_synth = !voice_synth
 			to_chat(usr, SPAN_NOTICE("You flipped the switch labeled 'funny voice synth'."))
+
+		// Occulus edit end
+
 	attack_hand(usr)
 
 /mob/living/bot/cleanbot/emag_act(var/remaining_uses, var/mob/user)
@@ -277,8 +287,13 @@
 	target_types += /obj/effect/decal/cleanable/mucus
 	target_types += /obj/effect/decal/cleanable/dirt
 	target_types += /obj/effect/decal/cleanable/rubble
+
+	// Occulus edit start
+
 	target_types += /obj/effect/decal/cleanable/ash
 	target_types += /obj/effect/decal/cleanable/reagents/splashed
+
+	// Occulus edit end
 
 	if(blood)
 		target_types += /obj/effect/decal/cleanable/blood


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Several adjustments have been made to the cleanbot code. Specifically:

1. A variable named voice_synth has been added, defaulting to 0.
2. An if statement has been added to check if voice_synth is 1 -- if it is, then the bot will speak and play a sound when it cleans. (Current behaviour is that it ALWAYS speaks and that can't be stopped)
3. An href switch has been added in the maintenance menu (use screwdriver on bot and then click on it) that toggles voice_synth to 1 or 0 (switch labeled 'funny voice synth')
4. Ash (/obj/effect/decal/cleanable/ash) has been added to the cleanup list
5. Splashed reagents (pepper spray, purple roach gas) that stain the floor have been added to the cleanup list (via /obj/effect/decal/cleanable/reagents/splashed as a catch-all)

## Why It's Good For The Game

1. The cleanbot voice lines, which I personally think are _hilarious_, are very understandably spammy and not very RP-conducive (the bot screams about meatbags and wanting to be an artist)
2. The cleanbot does not currently clean up reagent stains (/obj/effect/decal/cleanable/reagents/splashed) like the huge amount stains left by pepper spray or purple roach gas.

## Changelog
```changelog
tweak: Cleanbots start with voice disabled and can clean ash and splashed reagents (pepper spray, purple roach gas stains, etc)
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
