### PR TITLE
Removes the vents and piping from chromelab deepmaint core

### DIFF
--- a/zzzz_modular_occulus/maps/submaps/deepmaint_rooms/core/chromelab.dmm
+++ b/zzzz_modular_occulus/maps/submaps/deepmaint_rooms/core/chromelab.dmm
@@ -1,75 +1,50 @@
-"ai" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor/tiled/steel/techfloor,/area/deepmaint)
-"aC" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/turf/simulated/floor/tiled/white,/area/deepmaint)
-"aZ" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 8},/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 8},/turf/simulated/floor/tiled/white,/area/deepmaint)
 "bf" = (/turf/simulated/floor/tiled/white/bluecorner,/area/deepmaint)
 "bg" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/bed/chair/custom/onestar/red,/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor/tiled/steel/techfloor,/area/deepmaint)
 "bJ" = (/obj/structure/table/rack/shelf,/obj/spawner/gun/energy_cheap,/turf/simulated/floor/tiled/derelict/white_small_edges,/area/deepmaint)
 "bN" = (/obj/item/modular_computer/console,/turf/simulated/floor/tiled/steel,/area/deepmaint)
-"ci" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/turf/simulated/floor/tiled/steel,/area/deepmaint)
-"cj" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled/white,/area/deepmaint)
-"ck" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 5},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/turf/simulated/floor/carpet/bcarpet,/area/deepmaint)
-"cp" = (/obj/machinery/atmospherics/unary/vent_scrubber/on{dir = 1},/turf/simulated/floor/tiled/dark/techfloor,/area/deepmaint)
 "cq" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor/tiled/cafe,/area/deepmaint)
-"cA" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/turf/simulated/floor/carpet/bcarpet,/area/deepmaint)
 "cE" = (/obj/machinery/shower{dir = 1},/obj/structure/curtain/open/shower,/turf/simulated/floor/tiled/derelict/white_small_edges,/area/deepmaint)
 "cG" = (/obj/structure/cyberplant,/turf/simulated/floor/tiled/cafe,/area/deepmaint)
-"cM" = (/obj/structure/railing{dir = 4; icon_state = "railing0"; tag = "icon-railing0 (EAST)"},/obj/machinery/atmospherics/pipe/simple/visible/universal{dir = 4},/turf/simulated/floor/plating/under,/area/deepmaint)
-"cP" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/steel,/area/deepmaint)
-"cT" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/turf/simulated/floor/tiled/white,/area/deepmaint)
+"cM" = (/obj/structure/railing{dir = 4; icon_state = "railing0"; tag = "icon-railing0 (EAST)"},/turf/simulated/floor/plating/under,/area/deepmaint)
 "da" = (/obj/machinery/vending/snack,/turf/simulated/floor/tiled/cafe,/area/deepmaint)
 "dl" = (/turf/simulated/floor/tiled/dark/techfloor,/area/deepmaint)
 "dC" = (/obj/machinery/vending/cart,/turf/simulated/floor/carpet/bcarpet,/area/deepmaint)
 "dE" = (/obj/structure/table/glass,/obj/item/weapon/storage/fancy/cigarettes/dromedaryco,/turf/simulated/floor/tiled/cafe,/area/deepmaint)
 "dN" = (/mob/living/simple_animal/hostile/onestar_custodian/chef,/turf/simulated/floor/tiled/dark/gray_platform,/area/deepmaint)
 "eh" = (/obj/structure/bed/alien,/turf/simulated/floor/tiled/steel/brown_perforated,/area/deepmaint)
-"el" = (/obj/machinery/door/airlock/maintenance_engineering,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/white/panels,/area/deepmaint)
-"ev" = (/obj/structure/table/standard{name = "plastic table frame"},/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/spawner/science/low_chance,/turf/simulated/floor/tiled/steel,/area/deepmaint)
-"gm" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/white/bluecorner,/area/deepmaint)
+"ev" = (/obj/structure/table/standard{name = "plastic table frame"},/obj/spawner/science/low_chance,/turf/simulated/floor/tiled/steel,/area/deepmaint)
 "gB" = (/obj/machinery/atmospherics/unary/vent_pump,/obj/structure/table/glass,/obj/spawner/tool/advanced/low_chance,/turf/simulated/floor/carpet/bcarpet,/area/deepmaint)
-"gH" = (/obj/machinery/atmospherics/pipe/simple/visible{dir = 4},/obj/machinery/light/small,/turf/simulated/floor/plating/under,/area/deepmaint)
-"gK" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/white/techfloor,/area/deepmaint)
+"gH" = (/obj/machinery/light/small,/turf/simulated/floor/plating/under,/area/deepmaint)
 "gX" = (/obj/effect/decal/cleanable/dirt,/turf/simulated/floor/tiled/derelict/white_small_edges,/area/deepmaint)
 "hl" = (/obj/machinery/light,/obj/structure/table/onestar,/turf/simulated/floor/tiled/derelict/red_white_edges,/area/deepmaint)
 "hn" = (/obj/spawner/tool/advanced/onestar,/turf/simulated/floor/tiled/steel/techfloor,/area/deepmaint)
-"hv" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/barricade,/turf/simulated/floor/tiled/dark/techfloor,/area/deepmaint)
 "hQ" = (/obj/structure/flora/ausbushes/brflowers,/turf/simulated/floor/grass,/area/deepmaint)
-"il" = (/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled/white/cargo,/area/deepmaint)
-"ja" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled/white,/area/deepmaint)
-"jl" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/white/cargo,/area/deepmaint)
-"jm" = (/obj/machinery/atmospherics/pipe/simple/visible/universal,/obj/machinery/light/small{dir = 4; pixel_y = 0},/obj/structure/railing{dir = 1; icon_state = "railing0"; tag = "icon-railing0 (NORTH)"},/turf/simulated/floor/plating/under,/area/deepmaint)
-"jD" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply,/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,/turf/simulated/floor/tiled/white,/area/deepmaint)
-"jG" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/turf/simulated/wall,/area/deepmaint)
+"jm" = (/obj/machinery/light/small{dir = 4; pixel_y = 0},/obj/structure/railing{dir = 1; icon_state = "railing0"; tag = "icon-railing0 (NORTH)"},/turf/simulated/floor/plating/under,/area/deepmaint)
 "kz" = (/obj/structure/sink{dir = 8; pixel_x = -12},/obj/structure/mirror{pixel_x = -28},/turf/simulated/floor/tiled/derelict/white_small_edges,/area/deepmaint)
-"kD" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/turf/simulated/floor/tiled/white,/area/deepmaint)
-"kL" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled/white/bluecorner,/area/deepmaint)
 "kS" = (/obj/effect/window_lwall_spawn,/obj/machinery/door/firedoor,/turf/simulated/floor/plating,/area/deepmaint)
 "kY" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled/steel,/area/deepmaint)
 "lm" = (/obj/structure/flora/ausbushes/pointybush,/turf/simulated/floor/grass,/area/deepmaint)
 "mb" = (/obj/structure/flora/pottedplant{icon_state = "plant-21"},/turf/simulated/floor/tiled/cafe,/area/deepmaint)
-"mx" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 6},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 5},/turf/simulated/floor/tiled/cafe,/area/deepmaint)
-"mI" = (/obj/structure/bed/chair/office/dark{dir = 1},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled/steel,/area/deepmaint)
 "mK" = (/mob/living/simple_animal/hostile/onestar_custodian,/turf/simulated/floor/tiled/white/techfloor,/area/deepmaint)
 "nv" = (/obj/machinery/door/airlock{name = "Unisex Restrooms"},/turf/simulated/floor/tiled/white/panels,/area/deepmaint)
 "nK" = (/obj/structure/toilet{dir = 4},/obj/machinery/light{dir = 8},/turf/simulated/floor/tiled/derelict/white_small_edges,/area/deepmaint)
-"om" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/light,/turf/simulated/floor/tiled/white,/area/deepmaint)
-"os" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/obj/machinery/vending/sovietsoda,/turf/simulated/floor/tiled/white/cargo,/area/deepmaint)
+"om" = (/obj/machinery/light,/turf/simulated/floor/tiled/white,/area/deepmaint)
+"os" = (/obj/machinery/vending/sovietsoda,/turf/simulated/floor/tiled/white/cargo,/area/deepmaint)
 "oy" = (/obj/machinery/atmospherics/unary/vent_scrubber/on,/turf/simulated/floor/tiled/steel,/area/deepmaint)
 "oY" = (/mob/living/simple_animal/hostile/roomba,/turf/simulated/floor/tiled/white,/area/deepmaint)
-"pq" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/structure/window/reinforced{dir = 4},/mob/living/simple_animal/hostile/onestar_custodian,/turf/simulated/floor/tiled/steel/techfloor,/area/deepmaint)
+"pq" = (/obj/structure/window/reinforced{dir = 4},/mob/living/simple_animal/hostile/onestar_custodian,/turf/simulated/floor/tiled/steel/techfloor,/area/deepmaint)
 "ps" = (/obj/machinery/atmospherics/pipe/manifold/hidden/supply{dir = 4},/obj/effect/window_lwall_spawn,/turf/simulated/floor/plating,/area/deepmaint)
 "pH" = (/turf/simulated/floor/tiled/cafe,/area/deepmaint)
 "qt" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/flora/ausbushes/fernybush,/turf/simulated/floor/grass,/area/deepmaint)
 "rm" = (/turf/simulated/floor/tiled/steel,/area/deepmaint)
 "rr" = (/obj/structure/bed/chair/comfy/black{dir = 1},/turf/simulated/floor/tiled/cafe,/area/deepmaint)
 "rL" = (/turf/simulated/floor/tiled/dark/gray_platform,/area/deepmaint)
-"rM" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/structure/catwalk,/turf/simulated/floor/plating/under,/area/deepmaint)
-"rP" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/carpet/bcarpet,/area/deepmaint)
 "sg" = (/obj/machinery/vending/powermat,/turf/simulated/floor/tiled/white/techfloor,/area/deepmaint)
 "sp" = (/obj/effect/window_lwall_spawn,/turf/simulated/floor/plating,/area/deepmaint)
 "to" = (/obj/structure/table/standard{name = "plastic table frame"},/obj/item/weapon/reagent_containers/food/drinks/coffee{desc = "Old cup of coffee. Very cold.  "; name = "Old Robust Coffee"},/turf/simulated/floor/tiled/cafe,/area/deepmaint)
 "tF" = (/obj/structure/table/onestar,/obj/structure/bedsheetbin,/turf/simulated/floor/tiled/white/techfloor,/area/deepmaint)
 "tN" = (/obj/effect/decal/cleanable/blood/gibs/body,/turf/simulated/floor/tiled/steel/brown_perforated,/area/deepmaint)
-"tO" = (/obj/machinery/door/airlock/multi_tile/glass{dir = 2},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/white/panels,/area/deepmaint)
+"tO" = (/obj/machinery/door/airlock/multi_tile/glass{dir = 2},/turf/simulated/floor/tiled/white/panels,/area/deepmaint)
 "ut" = (/obj/item/modular_computer/console,/obj/machinery/light{dir = 8},/turf/simulated/floor/tiled/steel,/area/deepmaint)
 "uz" = (/mob/living/simple_animal/hostile/roomba/gun_ba,/turf/simulated/floor/carpet/bcarpet,/area/deepmaint)
 "uG" = (/obj/structure/table/rack/shelf,/obj/spawner/gun,/turf/simulated/floor/tiled/derelict/white_small_edges,/area/deepmaint)
@@ -78,33 +53,26 @@
 "wI" = (/obj/structure/sign/nosmoking_2{pixel_y = -32},/obj/structure/table/standard{name = "plastic table frame"},/obj/item/weapon/paper_bin,/obj/item/weapon/pen,/obj/machinery/light,/turf/simulated/floor/tiled/derelict/white_small_edges,/area/deepmaint)
 "wJ" = (/obj/structure/table/standard{name = "plastic table frame"},/obj/machinery/microwave,/turf/simulated/floor/tiled/cafe,/area/deepmaint)
 "xg" = (/obj/machinery/light{dir = 4},/mob/living/simple_animal/hostile/onestar_custodian/engineer,/turf/simulated/floor/tiled/white,/area/deepmaint)
-"xp" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 9},/turf/simulated/floor/tiled/white/bluecorner,/area/deepmaint)
-"xV" = (/obj/machinery/atmospherics/pipe/tank{dir = 4},/turf/simulated/floor/plating/under,/area/deepmaint)
-"yx" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/barricade,/turf/simulated/floor/tiled/dark/techfloor,/area/deepmaint)
-"yD" = (/obj/machinery/door/airlock/maintenance_engineering,/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/white/panels,/area/deepmaint)
+"yx" = (/obj/structure/barricade,/turf/simulated/floor/tiled/dark/techfloor,/area/deepmaint)
+"yD" = (/obj/machinery/door/airlock/maintenance_engineering,/turf/simulated/floor/tiled/white/panels,/area/deepmaint)
 "yY" = (/obj/structure/bed/chair/comfy/black{dir = 8},/obj/machinery/light{dir = 4},/turf/simulated/floor/carpet/bcarpet,/area/deepmaint)
-"zj" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/extinguisher_cabinet{pixel_x = -27},/turf/simulated/floor/tiled/white/techfloor,/area/deepmaint)
+"zj" = (/obj/structure/extinguisher_cabinet{pixel_x = -27},/turf/simulated/floor/tiled/white/techfloor,/area/deepmaint)
 "zx" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/flora/ausbushes/ppflowers,/obj/machinery/light,/turf/simulated/floor/grass,/area/deepmaint)
-"zZ" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled/dark/techfloor,/area/deepmaint)
-"Aa" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 10},/turf/simulated/floor/tiled/white,/area/deepmaint)
 "AW" = (/obj/structure/toilet{dir = 8},/mob/living/simple_animal/hostile/onestar_custodian/engineer,/turf/simulated/floor/tiled/steel/brown_perforated,/area/deepmaint)
-"Bl" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/white,/area/deepmaint)
 "BY" = (/obj/item/weapon/stock_parts/micro_laser/alien,/obj/item/weapon/tool/crowbar/onestar,/obj/structure/table/onestar,/turf/simulated/floor/tiled/steel/brown_perforated,/area/deepmaint)
 "Cb" = (/obj/structure/table/standard{name = "plastic table frame"},/obj/item/weapon/oddity/common/paper_bundle,/obj/item/weapon/oddity/common/paper_crumpled,/turf/simulated/floor/tiled/steel,/area/deepmaint)
 "CF" = (/obj/structure/defibcabinet{pixel_y = 32},/turf/simulated/floor/tiled/cafe,/area/deepmaint)
 "Dm" = (/obj/effect/decal/cleanable/blood,/turf/simulated/floor/tiled/steel/brown_perforated,/area/deepmaint)
 "Du" = (/obj/structure/catwalk,/obj/structure/table/rack/shelf,/obj/item/stack/material/plasteel{amount = 50},/obj/item/stack/material/plasteel{amount = 10},/obj/spawner/tool_upgrade/rare,/turf/simulated/floor/plating/under,/area/deepmaint)
 "DR" = (/obj/structure/table/onestar,/turf/simulated/floor/tiled/derelict/red_white_edges,/area/deepmaint)
-"DT" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 6},/obj/item/remains/robot,/turf/simulated/floor/tiled/white/bluecorner,/area/deepmaint)
+"DT" = (/obj/item/remains/robot,/turf/simulated/floor/tiled/white/bluecorner,/area/deepmaint)
 "Es" = (/obj/structure/flora/ausbushes/ppflowers,/turf/simulated/floor/grass,/area/deepmaint)
 "Et" = (/obj/structure/closet/onestar/tier1/medical,/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled/steel/techfloor,/area/deepmaint)
-"EK" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 10},/turf/simulated/floor/tiled/white/techfloor,/area/deepmaint)
 "Ft" = (/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled/cafe,/area/deepmaint)
-"FI" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor/tiled/steel/techfloor,/area/deepmaint)
+"FI" = (/obj/structure/window/reinforced{dir = 4},/turf/simulated/floor/tiled/steel/techfloor,/area/deepmaint)
 "FL" = (/mob/living/simple_animal/hostile/roomba,/turf/simulated/floor/tiled/dark/gray_platform,/area/deepmaint)
 "FQ" = (/obj/structure/flora/ausbushes/sunnybush,/turf/simulated/floor/grass,/area/deepmaint)
-"FR" = (/obj/structure/table/standard{name = "plastic table frame"},/obj/item/weapon/oddity/common/old_newspaper,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/steel,/area/deepmaint)
-"Ge" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/structure/catwalk,/turf/simulated/floor/plating/under,/area/deepmaint)
+"FR" = (/obj/structure/table/standard{name = "plastic table frame"},/obj/item/weapon/oddity/common/old_newspaper,/turf/simulated/floor/tiled/steel,/area/deepmaint)
 "Gw" = (/obj/structure/closet/onestar/tier1/medical,/turf/simulated/floor/tiled/derelict/red_white_edges,/area/deepmaint)
 "GD" = (/obj/structure/table/standard{name = "plastic table frame"},/obj/spawner/lathe_disk/advanced,/turf/simulated/floor/tiled/steel,/area/deepmaint)
 "GJ" = (/turf/simulated/floor/tiled/white/panels,/area/deepmaint)
@@ -120,39 +88,28 @@
 "JI" = (/obj/structure/bed/chair/sofa/blue/right,/turf/simulated/floor/carpet/bcarpet,/area/deepmaint)
 "JJ" = (/obj/structure/bed/alien,/obj/item/weapon/bedsheet,/turf/simulated/floor/tiled/derelict/red_white_edges,/area/deepmaint)
 "JU" = (/obj/structure/bed/chair/sofa/blue/left,/turf/simulated/floor/carpet/bcarpet,/area/deepmaint)
-"Ki" = (/obj/machinery/atmospherics/pipe/simple/hidden{dir = 9},/turf/simulated/floor/plating/under,/area/deepmaint)
 "Kk" = (/obj/item/modular_computer/console/preset/security/camera,/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled/derelict/white_small_edges,/area/deepmaint)
 "KG" = (/obj/structure/table/onestar,/obj/spawner/tool/advanced/onestar,/obj/machinery/light,/turf/simulated/floor/tiled/steel/techfloor,/area/deepmaint)
 "Lj" = (/obj/machinery/light{dir = 1},/obj/structure/table/onestar,/obj/spawner/tool/advanced/low_chance,/obj/spawner/tool/advanced/low_chance,/turf/simulated/floor/tiled/white/techfloor,/area/deepmaint)
 "Lu" = (/obj/structure/sign/faction/neotheology_cross,/turf/simulated/wall,/area/deepmaint)
-"Mg" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled/steel,/area/deepmaint)
 "Mw" = (/turf/simulated/floor/tiled/derelict/red_white_edges,/area/deepmaint)
-"Nl" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/turf/simulated/floor/tiled/white,/area/deepmaint)
 "Nz" = (/obj/structure/table/standard{name = "plastic table frame"},/obj/item/weapon/reagent_containers/food/drinks/coffee{desc = "Old cup of coffee. Very cold.  "; name = "Old Robust Coffee"},/turf/simulated/floor/tiled/steel,/area/deepmaint)
-"Ov" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply,/obj/machinery/door/airlock/vault,/turf/simulated/floor/tiled/white/panels,/area/deepmaint)
 "Pq" = (/obj/structure/table/standard{name = "plastic table frame"},/obj/item/weapon/storage/box/cups,/turf/simulated/floor/tiled/cafe,/area/deepmaint)
 "Pz" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/flora/ausbushes/stalkybush,/turf/simulated/floor/grass,/area/deepmaint)
-"PE" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled/cafe,/area/deepmaint)
 "Qu" = (/obj/machinery/door/airlock/glass,/turf/simulated/floor/tiled/white/panels,/area/deepmaint)
-"Rd" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/steel/techfloor,/area/deepmaint)
+"Rd" = (/turf/simulated/floor/tiled/steel/techfloor,/area/deepmaint)
 "Rr" = (/obj/structure/bed/chair/office/dark{dir = 4},/turf/simulated/floor/tiled/derelict/white_small_edges,/area/deepmaint)
 "Rz" = (/mob/living/simple_animal/hostile/onestar_custodian/chef,/turf/simulated/floor/tiled/white,/area/deepmaint)
-"RK" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled/white/cargo,/area/deepmaint)
-"RP" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/turf/simulated/floor/tiled/white,/area/deepmaint)
-"RV" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,/obj/machinery/door/airlock/vault,/turf/simulated/floor/tiled/white/panels,/area/deepmaint)
 "Si" = (/turf/simulated/floor/tiled/white,/area/deepmaint)
 "SN" = (/turf/simulated/floor/tiled/steel/brown_perforated,/area/deepmaint)
-"SW" = (/obj/machinery/atmospherics/binary/passive_gate{dir = 4},/turf/simulated/floor/plating/under,/area/deepmaint)
 "SX" = (/obj/item/remains/human,/turf/simulated/floor/tiled/dark/gray_platform,/area/deepmaint)
-"Ti" = (/obj/machinery/door/airlock/command,/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/steel/monofloor,/area/deepmaint)
+"Ti" = (/obj/machinery/door/airlock/command,/turf/simulated/floor/tiled/steel/monofloor,/area/deepmaint)
 "TO" = (/obj/structure/bed/chair/office/dark{dir = 1},/turf/simulated/floor/tiled/steel,/area/deepmaint)
-"TY" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 9},/turf/simulated/floor/tiled/cafe,/area/deepmaint)
-"Uc" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled/white,/area/deepmaint)
-"Uz" = (/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/mob/living/simple_animal/hostile/onestar_custodian/engineer,/turf/simulated/floor/tiled/white/bluecorner,/area/deepmaint)
+"Uc" = (/obj/machinery/light{dir = 1},/turf/simulated/floor/tiled/white,/area/deepmaint)
+"Uz" = (/mob/living/simple_animal/hostile/onestar_custodian/engineer,/turf/simulated/floor/tiled/white/bluecorner,/area/deepmaint)
 "UK" = (/obj/effect/decal/cleanable/blood/gibs/limb,/turf/simulated/floor/tiled/steel/techfloor,/area/deepmaint)
 "Vf" = (/obj/machinery/door/window/brigdoor/eastleft,/obj/machinery/atmospherics/unary/vent_pump/on{dir = 1},/turf/simulated/floor/tiled/steel/techfloor,/area/deepmaint)
 "Vv" = (/obj/item/remains/human,/turf/simulated/floor/tiled/dark/techfloor,/area/deepmaint)
-"Vz" = (/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{dir = 4},/obj/machinery/atmospherics/pipe/simple/hidden/supply{dir = 4},/turf/simulated/floor/tiled/cafe,/area/deepmaint)
 "Wt" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/flora/ausbushes,/obj/machinery/light{dir = 1},/turf/simulated/floor/grass,/area/deepmaint)
 "Wu" = (/obj/structure/table/glass,/obj/machinery/atmospherics/unary/vent_scrubber/on,/obj/spawner/science/low_chance,/turf/simulated/floor/carpet/bcarpet,/area/deepmaint)
 "Wy" = (/obj/structure/table/onestar,/obj/spawner/tool/advanced/low_chance,/turf/simulated/floor/tiled/white/techfloor,/area/deepmaint)
@@ -160,9 +117,8 @@
 "Xj" = (/turf/simulated/wall,/area/deepmaint)
 "Xm" = (/mob/living/simple_animal/hostile/onestar_custodian/engineer,/turf/simulated/floor/tiled/derelict/red_white_edges,/area/deepmaint)
 "Xu" = (/obj/machinery/door/airlock/security,/turf/simulated/floor/tiled/white/panels,/area/deepmaint)
-"XG" = (/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,/turf/simulated/floor/tiled/white/bluecorner,/area/deepmaint)
 "Yr" = (/obj/structure/bed/chair/comfy/black,/turf/simulated/floor/tiled/cafe,/area/deepmaint)
-"Yu" = (/obj/machinery/atmospherics/pipe/simple/visible{dir = 4},/turf/simulated/floor/plating/under,/area/deepmaint)
+"Yu" = (/turf/simulated/floor/plating/under,/area/deepmaint)
 "YL" = (/turf/simulated/floor/tiled/derelict/white_small_edges,/area/deepmaint)
 "Zp" = (/obj/structure/extinguisher_cabinet{pixel_x = 26},/turf/simulated/floor/tiled/white,/area/deepmaint)
 "Zt" = (/turf/simulated/wall/r_wall,/area/deepmaint)
@@ -171,23 +127,23 @@
 (1,1,1) = {"
 rLrLrLrLrLrLrLrLrLrLrLrLrLrLrLrLrLrLrLrLrL
 rLZtZtZtZtZtZtZtZtZtZtZtZtZtZtZtZtZtZtZtrL
-rLXjxVYuSWgHcMGeGeyDEKWyLjsgIdZtGwMwJJZtrL
+rLXjYuYuYugHcMwqwqyDIUWyLjsgIdZtGwMwJJZtrL
 rLZtZtZtXjXjXjXjDuXjzjmKIUIUIUQuMwMwXmZtrL
-FLWtlmGTcGdavKXjXjXjgKIUIUIUtFZtDRhlDRZtrL
-rLPzhQGTYrcqpHCFpHjGpsspQuXjZtXjXjLuXjZtrL
-rLqtEsGTdEmxPEVzVzTYcjjaAaSiZtEtbgehBYZtrL
-rLzxFQGTrrFttowJPqmbSiSiNlxgZthnaitNHQZtrL
-rLZtZtZtXjXjspspspspXjXjaZBlTiRdpqHQSNZtrL
-rLZtutGDbNGQdCGPJIJUZXspNlZpZtUKFISNDmZtrL
-rLZtTOoyTOrmGPGPgBWuyYspNlSiZtKGVfDmAWZtrL
-rLZtbNFRbNCbbfbfDTxpbfGJNlSiZtZtZtZtZtZtrL
-rLZtTOcimIMgUzkLXGgmgmtOjDBlaCRPUcRKosZtFL
-rLZtutevbNNzGPGPrPGPGPspoYSikDSiRzIijlZtrL
-rLZtTOcPTOrmGPuzckcAGPspSiSikDcTomRKilZtrL
-rLZtrmkYrmrmGPGPGPGPGPXjXjXjOvRVXjXjelZtrL
-rLZtXjXjnvXjXjXjXjXuXjXjKkkSyxhvspwqrMZtrL
-rLZtnKgXYLgXXjuGYLYLYLYLRrWPzZcpspIMjmZtrL
-rLZtkzgXYLcEXjbJYLYLYLYLwIkSdlVvspxVKiZtrL
+FLWtlmGTcGdavKXjXjXjIUIUIUIUtFZtDRhlDRZtrL
+rLPzhQGTYrcqpHCFpHXjpsspQuXjZtXjXjLuXjZtrL
+rLqtEsGTdEpHpHpHpHpHSiSiSiSiZtEtbgehBYZtrL
+rLzxFQGTrrFttowJPqmbSiSiSixgZthnFItNHQZtrL
+rLZtZtZtXjXjspspspspXjXjSiSiTiRdpqHQSNZtrL
+rLZtutGDbNGQdCGPJIJUZXspSiZpZtUKFISNDmZtrL
+rLZtTOoyTOrmGPGPgBWuyYspSiSiZtKGVfDmAWZtrL
+rLZtbNFRbNCbbfbfDTbfbfGJSiSiZtZtZtZtZtZtrL
+rLZtTOrmTOrmUzbfbfbfbftOSiSiSiSiUcIiosZtFL
+rLZtutevbNNzGPGPGPGPGPspoYSiSiSiRzIiIiZtrL
+rLZtTOrmTOrmGPuzGPGPGPspSiSiSiSiomIiIiZtrL
+rLZtrmkYrmrmGPGPGPGPGPXjXjXjHBHBXjXjyDZtrL
+rLZtXjXjnvXjXjXjXjXuXjXjKkkSyxyxspwqwqZtrL
+rLZtnKgXYLgXXjuGYLYLYLYLRrWPdldlspIMjmZtrL
+rLZtkzgXYLcEXjbJYLYLYLYLwIkSdlVvspYuYuZtrL
 dNZtZtZtZtZtZtZtZtZtZtZtZtZtHBHBZtZtZtZtrL
 rLrLrLrLrLrLrLrLrLrLrLrLrLrLSXrLrLrLrLrLrL
 "}


### PR DESCRIPTION
## About The Pull Request

Removes the vents nad pipes from my deepmaint core room I added.

## Why It's Good For The Game

May have been creating a lot of extra lag, unsure, but generally deepmaint doesn't seem to like atmospherics a lot. Bugfix change.

## Changelog
```changelog
fix: removed some piping causing lag from chrome labs
```
