### PR TITLE
Update storytellers.dm

### DIFF
--- a/zzzz_modular_occulus/code/game/gamemodes/storytellers/storytellers.dm
+++ b/zzzz_modular_occulus/code/game/gamemodes/storytellers/storytellers.dm
@@ -9,7 +9,7 @@ It is set as storyteller base in __defines/gamemode.dm
 	name = "The Guide"
 	welcome = "Let me share with you the terrible wonders I have come to know."
 	description = "Offers a well balanced experience that has a little of everything. Considered the default experience"
-	var/list/points = list(
+	points = list(
 		EVENT_LEVEL_MUNDANE = 0, //Mundane
 		EVENT_LEVEL_MODERATE = 0, //Moderate
 		EVENT_LEVEL_MAJOR = 0, //Major

--- a/zzzz_modular_occulus/code/game/gamemodes/storytellers/storytellers.dm
+++ b/zzzz_modular_occulus/code/game/gamemodes/storytellers/storytellers.dm
@@ -9,6 +9,12 @@ It is set as storyteller base in __defines/gamemode.dm
 	name = "The Guide"
 	welcome = "Let me share with you the terrible wonders I have come to know."
 	description = "Offers a well balanced experience that has a little of everything. Considered the default experience"
+	var/list/points = list(
+		EVENT_LEVEL_MUNDANE = 0, //Mundane
+		EVENT_LEVEL_MODERATE = 0, //Moderate
+		EVENT_LEVEL_MAJOR = 0, //Major
+		EVENT_LEVEL_ROLESET = 90 //Roleset - Spawns antagonists at 30minutes and 150 minutes roughly
+	)
 
 /datum/storyteller/sentinel
 	config_tag = "sentinel"


### PR DESCRIPTION
## About The Pull Request

Added 90 points to the guide roleset pool at round start. Antagonists should spawn roughly 30 minutes into the round, and again at 150minutes.

## Why It's Good For The Game

We've had complaints that antagonists in guide have been spawning too late to do anything or right before transfer. This should remedy that issue.

## Changelog
```changelog
tweak: adjusts the number of points for antagonist generation that guide has at roundstart.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
