### PR TITLE
Makes rubbershot actually rubber

### DIFF
--- a/zzzz_modular_occulus/code/modules/projectiles/projectile/bullettypes.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/projectile/bullettypes.dm
@@ -9,6 +9,9 @@
 	range_step = 2
 	spread_step = 10
 	knockback = 1
+	armor_penetration = 0
+	embed = FALSE
+	sharp = FALSE
 
 /obj/item/projectile/bullet/pellet/shotgun/rubber/stinger	//used for the stinger grenade
 	damage_types = list(BRUTE = 2)


### PR DESCRIPTION
## About The Pull Request

Rubbershot is no longer sharp and will not embed, and will also not penetrate armor.

## Why It's Good For The Game

Rubbershot is supposed to be non-lethal. Embedding is lethal. Causing bleeding is lethal.

## Changelog
```changelog Toriate
fix: rubbershot is now actually rubber
```
