### PR TITLE
Fix RCON input load display

### DIFF
--- a/code/modules/modular_computers/file_system/programs/engineering/rcon_console.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/rcon_console.dm
@@ -33,7 +33,7 @@
 		"charge" = round(SMES.Percentage()),
 		"input_set" = SMES.input_attempt,
 		"input_val" = round(SMES.input_level/1000, 0.1),
-		"input_load" = round(SMES.input_available/1000, 0.1),
+		"input_load" = round(SMES.target_load/1000, 0.1),		// Occulus edit: 'target_load' replaces 'input_available' -- input_available does not have a use, but target_load displays incoming power as expected.
 		"output_set" = SMES.output_attempt,
 		"output_val" = round(SMES.output_level/1000, 0.1),
 		"output_load" = round(SMES.output_used/1000, 0.1),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #137

This is a small edit to the RCON console code to fix a bug where the Input Load line was always at zero. The cause of the bug is that the RCON console was attempting to pull from an SMES variable called input_available, which was not actually defined beyond always being set at zero. I've instead pointed the RCON console to look at a variable called target_load, which outputs exactly how much the SMES is trying to draw from the network at a time (this does zero out/show smaller numbers when the SMES is full/nearly full.)

## Why It's Good For The Game

Engineers will now be able to pinpoint whether power issues are sourced from a substation not receiving power rather than manually checking the wires to the substation.

## Changelog
```changelog
fix: RCON console now properly shows input load (previously always read zero)
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
