### PR TITLE
Adds a tcomms relay to the science shuttle

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2792,6 +2792,7 @@
 #include "zzzz_modular_occulus\code\game\jobs\job\science.dm"
 #include "zzzz_modular_occulus\code\game\jobs\job\security.dm"
 #include "zzzz_modular_occulus\code\game\machinery\jukebox.dm"
+#include "zzzz_modular_occulus\code\game\machinery\telecomms\presets.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\oddities.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\plush.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\toys\balls.dm"

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -95135,6 +95135,7 @@
 /obj/structure/fuel_port{
 	pixel_y = -32
 	},
+/obj/machinery/telecomms/relay/preset/science,
 /turf/simulated/shuttle/floor/science{
 	icon_state = "6,3"
 	},

--- a/zzzz_modular_occulus/code/game/machinery/telecomms/presets.dm
+++ b/zzzz_modular_occulus/code/game/machinery/telecomms/presets.dm
@@ -1,0 +1,14 @@
+// Occulus stuff for preconfigured telecomms machines
+
+/obj/machinery/telecomms/relay/preset/science
+	id = "Count Doku Relay"
+	autolinkers = list("d_relay")
+
+/obj/machinery/telecomms/hub/preset
+	autolinkers = list("hub", "relay", "c_relay", "s_relay", "m_relay", "r_relay", "science", "medical",
+	"supply", "service", "common", "command", "engineering", "security", "nt", "unused",
+	"receiverA", "broadcasterA", "d_relay")
+
+/obj/machinery/telecomms/hub/preset_cent
+	autolinkers = list("hub_cent", "c_relay", "s_relay", "m_relay", "r_relay",
+	 "centcomm", "receiverCent", "broadcasterCent", "d_relay")


### PR DESCRIPTION
## About The Pull Request

Exactly what it says on the tin.

## Why It's Good For The Game

More often than not, the science shuttle gets used for rescuing dead miners, so being able to coordinate with everyone else should make things a lot less hectic. It should also reduce incidences of the ship leaving the shuttles behind, although that has never happened before as far as I'm aware.

## Changelog
```changelog Toriate
add: The Vasily Dorkuchev has been retrofitted with a state of the art telecommunications relay to facilitate communications with the Northern Light.
```
