### PR TITLE
Halves the nutrition cost of most litanies, and fixes some bugs

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -33,7 +33,7 @@
 
 /datum/ritual/cruciform/base/soul_hunger/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
 	H.nutrition += 100
-	H.adjustToxLoss(15)	// OCCULUS EDIT - NERF THE FREE NUTRITION
+	H.adjustToxLoss(10)	// OCCULUS EDIT - NERF THE FREE NUTRITION
 	return TRUE
 
 

--- a/code/modules/core_implant/cruciform/rituals/inquisitor.dm
+++ b/code/modules/core_implant/cruciform/rituals/inquisitor.dm
@@ -204,7 +204,7 @@
 	if(user == M)
 		fail("You feel stupid.",user,C,targets)
 		return FALSE
-	log_and_message_admins("looks through the eyes of [C.wearer] with scrying litany")	//OCCULUS EDIT - Makes it so that it actually tells you whose eyes are being looked through, rather than just saying THE CORE IMPLANT
+	log_and_message_admins("looks through the eyes of [M.real_name] with scrying litany")	//OCCULUS EDIT - Makes it so that it actually tells you whose eyes are being looked through, rather than just saying THE CORE IMPLANT
 	to_chat(M, SPAN_NOTICE("You feel an odd presence in the back of your mind. A lingering sense that someone is watching you..."))
 
 	var/mob/observer/eye/god/eye = new/mob/observer/eye/god(M)

--- a/zzzz_modular_occulus/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/zzzz_modular_occulus/code/modules/core_implant/cruciform/rituals/base.dm
@@ -41,7 +41,7 @@
 			return
 		log_and_message_admins("soothed [H]'s pain with the Reprieve litany")
 		to_chat(H, "<span class='info'>A numbing sensation bathes you, soothing your agony a little.</span>")
-		user.nutrition -= 100
+		user.nutrition -= 50
 		H.add_chemical_effect(CE_PAINKILLER, 20)	// Just a bit more than the base effect, so you can more effectively treat others than yourself.
 		return TRUE
 
@@ -98,7 +98,7 @@ Let there be light! Makes you glow for 5 minutes at a time.
 /datum/ritual/cruciform/base/enkindle/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/list/glowy_doods = list()	// Initialize a list of who's getting affected!
 	glowy_doods.Add(user)	// Add the caster to the list
-	user.nutrition -= 100
+	user.nutrition -= 50
 	user.adjustToxLoss(5)
 
 	var/mob/living/carbon/human/H = get_victim(user)	// See if we have a lucky victim (someone who's being grabbed or is directly in front of the caster)

--- a/zzzz_modular_occulus/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/zzzz_modular_occulus/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -14,7 +14,7 @@ A copypasta of Convalescence, but with half the effects and no pain removal. Als
 /datum/ritual/cruciform/priest/selfheal/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C,list/targets)
 	to_chat(H, "<span class='info'>A sensation of relief bathes you, washing away your pain.</span>")
 	log_and_message_admins("healed himself with the Recuperation litany.")
-	H.nutrition -= 100
+	H.nutrition -= 50
 	H.adjustBruteLoss(-10)
 	H.adjustFireLoss(-10)
 	H.adjustOxyLoss(-20)
@@ -61,7 +61,7 @@ Ditto but for Succour
 			return
 		log_and_message_admins("healed [CI.wearer] with Invigorate litany")
 		to_chat(H, "<span class='info'>A sensation of relief bathes you, soothing your wounds a little.</span>")
-		user.nutrition -= 100
+		user.nutrition -= 50
 		H.adjustBruteLoss(-10)
 		H.adjustFireLoss(-10)
 		H.adjustOxyLoss(-20)
@@ -94,7 +94,7 @@ A big universal AOE heal
 		if(people_around.len > 0)
 			to_chat(user, SPAN_DANGER("You collapse to the ground, exhausted."))
 			user.Weaken(10)
-			user.nutrition -= 200
+			user.nutrition -= 100
 			user.adjustToxLoss(10)
 			playsound(user.loc, 'sound/machines/signal.ogg', 50, 1)
 			for(var/mob/living/carbon/human/participant in people_around)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Exactly what it says on the tin. A bug has also been fixed where the Scrying litany logs the user as looking through their own eyes when that is in fact impossible and they're looking through someone else's eyes. Also, the toxloss of Soul Hunger has been reduced juuust a bit.

## Why It's Good For The Game

Emojicracy voted in favor of halving all litany nutrition costs. Should make them far more useable.

## Changelog
```changelog Toriate
balance: Litany nutrition costs have been toned back!
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
