### PR TITLE
Fixes custom named item losing name when wielded

### DIFF
--- a/code/game/objects/items/wielding.dm
+++ b/code/game/objects/items/wielding.dm
@@ -23,9 +23,9 @@
 		force = force_unwielded
 	else
 		force = (force / 1.3)
-	var/sf = findtext(name,"Wielded ")
+	var/sf = findtext(name,"Wielded ") //Occulus Edit.
 	if(sf)
-		name = copytext(name,9)
+		name = copytext(name,9) //Occulus Edit.
 	else //something went wrong
 		name = "[initial(name)]"
 	update_unwield_icon()
@@ -55,7 +55,7 @@
 		force = force_wielded
 	else //This will give items wielded 30% more damage. This is balanced by the fact you cannot use your other hand.
 		force = (force * 1.3) //Items that do 0 damage will still do 0 damage though.
-	name = "Wielded [name]"
+	name = "Wielded [name]" //Occulus Edit.
 	update_wield_icon()
 	update_icon()//Legacy
 	if(user)

--- a/code/game/objects/items/wielding.dm
+++ b/code/game/objects/items/wielding.dm
@@ -23,9 +23,9 @@
 		force = force_unwielded
 	else
 		force = (force / 1.3)
-	var/sf = findtext(name," (Wielded)")
+	var/sf = findtext(name,"Wielded ")
 	if(sf)
-		name = copytext(name,1,sf)
+		name = copytext(name,9)
 	else //something went wrong
 		name = "[initial(name)]"
 	update_unwield_icon()
@@ -55,7 +55,7 @@
 		force = force_wielded
 	else //This will give items wielded 30% more damage. This is balanced by the fact you cannot use your other hand.
 		force = (force * 1.3) //Items that do 0 damage will still do 0 damage though.
-	name = "wielded [name]"
+	name = "Wielded [name]"
 	update_wield_icon()
 	update_icon()//Legacy
 	if(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Custom named items will now keep their custom name after wielding and unwielding them. Small little bug fix that was missed during testing and was more of an overlook from the original code than anything.

![image](https://user-images.githubusercontent.com/45645502/105119931-8fabd580-5ad1-11eb-8cc7-5784c2e379cf.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

People's custom named items will no longer be set back to the original item's base name, and instead will keep their custom name!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
fix: Custom Items will retain their custom name after unwielding them.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
