### PR TITLE
Fixes alt. title pay and display in crew manifest

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -29,6 +29,17 @@ SUBSYSTEM_DEF(job)
 			continue
 		occupations += job
 		occupations_by_name[job.title] = job
+
+		///// OCCULUS EDIT START /////
+		// Allow alt titles to get paid.
+		// This has the side effect of ALSO listing alt titles under their proper department instead of misc.
+
+		if(job.alt_titles)
+			for(var/alt_title in job.alt_titles)
+				occupations_by_name[alt_title] = job
+
+		///// OCCULUS EDIT END /////
+
 		// // // BEGIN ECLIPSE EDITS // // //
 		//Rationale: Job whitelisting setup.
 		//I would have preferred to have this before var/J got filtered into job.* but it was causing compiler errors. Alas.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #160 

I've inserted a small clause into jobs.dm to classify alt. titles among regular job titles as being valid variations of the job according to the jobs subsystem. Previously, alt titles were being pulled as null, which made the jobs subsystem recognize them as Deckhands instead.

This fix is a double whammy -- by fixing alt. title payments, I've also accidentally fixed their display in the crew manifest! Now alt. titles will be listed under their proper department.

The screenshots below were taken as an Engineering Apprentice, an alt. title of Ship Engineer.

![image](https://user-images.githubusercontent.com/77511162/105219833-e7bff780-5b24-11eb-8836-03719d2130dc.png)
![image](https://user-images.githubusercontent.com/77511162/105219849-edb5d880-5b24-11eb-9510-2b8a78c00210.png)
![image](https://user-images.githubusercontent.com/77511162/105219866-f1e1f600-5b24-11eb-8cfc-9ef1680b1da5.png)
![image](https://user-images.githubusercontent.com/77511162/105219876-f5757d00-5b24-11eb-8199-f3a0a4e1b122.png)

Additional testing that I do have pictures of but am not listing here for brevity (I will provide if needed):

1. Pay was successfully received for a job without any alt. titles (Roboticist)
2. Pay was successfully received for a job with alt. titles using the primary title (Medical Doctor)

For future job titles, no special work is necessary -- you can just throw in the new job title in the department definition as normal and you'll be good to go.

## Why It's Good For The Game

Folks with alt. titles can finally get their cash! This also helps with manifest organization so you don't have to look at the misc. category and try to think about which department they're in.

## Changelog
```changelog
fix: Alt. titles for jobs now receive payment properly
fix: Alt. titles for jobs now display in their proper department on the manifest
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
