### PR TITLE
Adds 'Union Salvage Technician' as an alt. title for Union Miner

### DIFF
--- a/code/game/jobs/job/guild.dm
+++ b/code/game/jobs/job/guild.dm
@@ -125,6 +125,7 @@ Your main duties are to keep the local Union branch operational and profitable. 
 	supervisors = "the Free Trade Union Merchant"
 	selection_color = "#c3b9a6"
 	wage = WAGE_LABOUR_HAZARD //The miners union is stubborn
+	alt_titles = list("Union Salvage Technician")	// OCCULUS EDIT
 	outfit_type = /decl/hierarchy/outfit/job/cargo/mining
 
 	description = "You are an asteroid miner, working in resource Procurement for the local branch of the Free Trade Union.<br>\


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I saw a few requests for this in Discord -- so here we are!

![image](https://user-images.githubusercontent.com/77511162/105221766-936a4700-5b27-11eb-8a8c-388f92149cd7.png)
![image](https://user-images.githubusercontent.com/77511162/105221780-96653780-5b27-11eb-8ea6-7012c86b341d.png)

## Why It's Good For The Game

For Union folks who want to have a more technical title than 'miner'.

## Changelog
```changelog
add: Added an alt. title for Union Miner: 'Union Salvage Technician'
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
