### PR TITLE
Tunes up the Lever Action, clarifies it's caliber.

### DIFF
--- a/zzzz_modular_occulus/code/modules/projectiles/guns/projectile/rifle/magnumlever.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/guns/projectile/rifle/magnumlever.dm
@@ -1,9 +1,9 @@
 /obj/item/weapon/gun/projectile/shotgun/leveraction/magnum
-	name = "lever-action rifle"
-	desc = "A vintage USARC design. Old, yet reliable."
+	name = ".40 lever-action rifle"
+	desc = "A vintage USARC design. Old, yet reliable. Uses .40 Magnum Ammo."
 	icon = 'zzzz_modular_occulus/icons/obj/guns/projectile/magnumlever.dmi'
 	icon_state = "leveraction"
-	max_shells = 5
+	max_shells = 9
 	caliber = CAL_MAGNUM
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 1)
 	load_method = SINGLE_CASING
@@ -11,6 +11,8 @@
 	fire_sound = 'sound/weapons/guns/fire/batrifle_fire.ogg'
 	matter = list(MATERIAL_PLASTIC = 6, MATERIAL_STEEL = 18)
 	price_tag = 600
+	damage_multiplier = 1.2 //34 x 1.2 ~ 40 damage. Revolvers still beat it out, but this holds more rounds and is easier to reload.
+	armor_penetration = 1.35 //A hair over 20 armor pen.
 	recoil_buildup = 20
 	one_hand_penalty = 15 //full sized shotgun level
 

--- a/zzzz_modular_occulus/code/modules/projectiles/guns/projectile/rifle/magnumleversawn.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/guns/projectile/rifle/magnumleversawn.dm
@@ -3,8 +3,11 @@
 	desc = "Why would you do this? This is the definition of undercompensating."
 	icon = 'zzzz_modular_occulus/icons/obj/guns/projectile/magnumleversawn.dmi'
 	icon_state = "leveraction_sawed"
+	max_shells = 4
 	fire_sound = 'sound/weapons/guns/fire/batrifle_fire.ogg'
 	caliber = CAL_MAGNUM
 	ammo_type = /obj/item/projectile/bullet/magnum/rubber
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_STEEL = 12)	//less stuff out of it due to being sawed
 	price_tag = 300	//becomes less valuable when you ruin it
+	damage_multiplier = 1 //34 damage, 6 or so less than the unsawn version.
+	armor_penetration = 1.05 //Around 15 armor penetration, less punchthrough because of the shorter barrel.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Clarifies it's ammo and makes it a _little_ more competitive. I don't want to kneejerk this thing into being way too overtuned.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I worried about this basically being a worse revolver, and (the only) feedback I've gotten so far kinda confirmed that. Every other revolver has speedloaders, very nice damage / armor pen multipliers, and fits in holsters, and this was... not better than them in any way at all. Hopefully this helps out a little.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
balance: rebalanced the lever action rifle
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
