### PR TITLE
Cherypicks more hotkey stuff from upstream

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -89,6 +89,30 @@ macro "borghotkeymode"
 	elem 
 		name = "CTRL+SOUTH"
 		command = "southface"
+	elem
+		name = "ALT+A"
+		command = "westfaceperm"
+	elem 
+		name = "CTRL+A"
+		command = "westface"
+	elem 
+		name = "ALT+W"
+		command = "northfaceperm"
+	elem 
+		name = "CTRL+W"
+		command = "northface"
+	elem 
+		name = "ALT+D"
+		command = "eastfaceperm"
+	elem 
+		name = "CTRL+D"
+		command = "eastface"
+	elem 
+		name = "ALT+S"
+		command = "southfaceperm"
+	elem 
+		name = "CTRL+S"
+		command = "southface"
 	elem 
 		name = "INSERT"
 		command = "a-intent right"
@@ -173,6 +197,9 @@ macro "borghotkeymode"
 	elem 
 		name = "CTRL+Z"
 		command = "Activate-Held-Object"
+	elem
+		name = "B"
+		command = "resist" 
 	elem 
 		name = "F1"
 		command = "adminhelp"
@@ -513,7 +540,31 @@ macro "hotkeymode"
 	elem 
 		name = "CTRL+South"
 		command = "southface"
+		elem
+		name = "ALT+A"
+		command = "westfaceperm"
 	elem 
+		name = "CTRL+A"
+		command = "westface"
+	elem 
+		name = "ALT+W"
+		command = "northfaceperm"
+	elem 
+		name = "CTRL+W"
+		command = "northface"
+	elem 
+		name = "ALT+D"
+		command = "eastfaceperm"
+	elem 
+		name = "CTRL+D"
+		command = "eastface"
+	elem 
+		name = "ALT+S"
+		command = "southfaceperm"
+	elem 
+		name = "CTRL+S"
+		command = "southface"
+	elem
 		name = "CTRL+SHIFT+South"
 		command = "southshift"
 	elem 
@@ -591,6 +642,9 @@ macro "hotkeymode"
 	elem 
 		name = "CTRL+G"
 		command = "a-intent right"
+	elem
+		name = "B"
+		command = "resist" 
 	elem 
 		name = "H"
 		command = "holster"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Cherrypicks https://github.com/discordia-space/CEV-Eris/pull/5588

ctrl+wasd can now rotate you. B now resists.

## Why It's Good For The Game

More convenience! And also makes things more in-line with other server's hotkeys apparently, according to the upstream PR.

## Changelog
```changelog Toriate
add: Ctrl+wasd to rotate, Alt+wasd to lock facing, B to resist
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
