### PR TITLE
Stop meteors from spawning pre-round and Runlevel fixes

### DIFF
--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -213,7 +213,10 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		old_runlevel = "NULL"
 
 	report_progress("MC: Runlevel changed from [old_runlevel] to [new_runlevel]")
-	current_runlevel = log(2, new_runlevel) + 1
+	// current_runlevel = log(2, new_runlevel) + 1
+	current_runlevel = new_runlevel	// OCCULUS EDIT: The previous logarithmic function did not actually adjust runlevel properly
+									// eg. when RUNLEVEL_GAME was active, current_runlevel was actually returning 3 rather than 4
+									// and current_runlevel during RUNLEVEL_POSTGAME was returning 4 rather than 8.
 	if(current_runlevel < 1)
 		CRASH("Attempted to set invalid runlevel: [new_runlevel]")
 
@@ -565,7 +568,7 @@ GLOBAL_REAL(Master, /datum/controller/master) = new
 		SS.state = SS_IDLE
 	if (queue_head && !istype(queue_head))
 		to_chat(world, "MC: SoftReset: Found bad data in subsystem queue, queue_head = '[queue_head]'")
-	else 
+	else
 		to_chat(world, "MC: Resetting queue_head, was '[queue_head]'")
 	queue_head = null
 	if (queue_tail && !istype(queue_tail))

--- a/code/game/gamemodes/events/meteors.dm
+++ b/code/game/gamemodes/events/meteors.dm
@@ -175,14 +175,17 @@
 ///////////////////////////////
 
 /proc/spawn_meteors(var/number = 1, var/list/meteortypes, var/startSide, var/zlevel)
-	for(var/i = 0; i < number; i++)
-		//If no target zlevel is specified, then we'll throw each meteor at an individually randomly selected ship zlevel
-		var/target_level
-		if (zlevel)
-			target_level = zlevel
-		else
-			target_level = pick(GLOB.maps_data.station_levels)
-		spawn_meteor(meteortypes, startSide, target_level)
+	if (Master.current_runlevel >= RUNLEVEL_GAME)	// OCCULUS EDIT -- Prevent meteors from spawning before the game
+		for(var/i = 0; i < number; i++)
+			//If no target zlevel is specified, then we'll throw each meteor at an individually randomly selected ship zlevel
+			var/target_level
+			if (zlevel)
+				target_level = zlevel
+			else
+				target_level = pick(GLOB.maps_data.station_levels)
+			spawn_meteor(meteortypes, startSide, target_level)
+	else
+		message_admins("A meteor attempted to spawn, but runlevel is [Master.current_runlevel] (must be 4 or higher)")	// OCCULUS EDIT
 
 /proc/spawn_meteor(var/list/meteortypes, var/startSide, var/zlevel)
 	var/turf/pickedstart = spaceDebrisStartLoc(startSide, zlevel)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #69 

There are two fixes in this pull -- the runlevel fix is necessary for the meteor fix without needing hardcoding to check the runlevel:

**1.** The Master Controller has a variable called current_runlevel that doesn't seem to have ever been properly defined the match the bitflags for the game's runlevel. There was a strange logarthmic function in use that did little more than increment the runlevel by 1 for each runlevel change.

Currently, the Runlevel flags are:

RUNLEVEL_INIT 0
RUNLEVEL_LOBBY 1
RUNLEVEL_SETUP 2
RUNLEVEL_GAME 4
RUNLEVEL_POSTGAME 8

After a thorough check-over of the code, I found that the current_runlevel variable was only checked in two circumstances:

_1._ To see if there is an active Runlevel (to indicate that initialization has finished), or
_2._ To see if there is NOT an active Runlevel (to indicate that initialization needed to be done)

Finally, there was a single case of bitwise flag checking: the chat box. It checked to see if the current_runlevel was RUNLEVEL_INIT, which would return 0 in either case.

I noticed that the subsystems do check for the RUNLEVEL, but not via current_runlevel -- so they're unaffected by this change. I suspect the code has been like this because nothing needed to check the runlevel in this way before.

I ran a server for a while to make sure there was no strangeness with the subsystems and didn't encounter any issues.

**2.** Meteors will no longer spawn before the round begins. I've inserted an if clause to check the current_runlevel, and if it is not RUNLEVEL_GAME or above (they *can* still spawn in the postgame), the spawning is canceled. These meteor spawns are tied to the overmap rather than the events subsystem. Note that this doesn't stop meteors from spawning on the overmap, it just prevents them from spawning in a way that can actually impact the ship.

Finally, an admin log is generated when a meteor spawn is prevented (to stop any uncertainty if they're actually spawning or not)

**Test log:**

1. Waited in the lobby for a meteor to try to spawn. A meteor tried to spawn and was prevented by the new clause. (I failed to get a picture of this the first time it happened -- I did wait in the lobby for another hour to try to get a picture of it on a new compile but no meteors spawned from the overmap. The clause to prevent meteors did not change between compiles)
2. Started the game and summoned a meteor wave via storyteller panel. Meteors spawned and impacted the ship as expected.
3. Started the game and interacted with subsystems that could've potentially been affected (machines, mobs, etc) -- no issues found

(I'm a baby to coding -- I'm not sure why there's a whitespace change on the edit line in Master.dm, if it's a problem then I'll try to correct it, but I'm not sure how to yet)

## Why It's Good For The Game

There are times when the server sits with no players on it! During this time, meteors can still spawn and damage the ship before the game begins. If someone wants to play and they don't want to repair all the damage, this usually leads to a transfer vote to start a fresh ship.

This change does not prevent any meteors from spawning immediately after the game starts -- only before it starts.

## Changelog
```changelog
fix: Meteors no longer impact the ship before roundstart
code: SetRunLevel now properly sets current_runlevel in the Master Controller
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
