### PR TITLE
Alt Civ Pack Balance Pass

### DIFF
--- a/zzzz_modular_occulus/code/modules/projectiles/guns/projectile/automatic/rx8.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/guns/projectile/automatic/rx8.dm
@@ -1,6 +1,6 @@
 /obj/item/weapon/gun/projectile/automatic/rx8
 	name = "PCC .35 Auto \"RX8\""
-	desc = "An experimental Pistol Caliber Carbine, designed as a low cost and easy to deploy alternative to full size rifles. \
+	desc = "An experimental Pistol Caliber Carbine, designed as a low cost and easy to deploy alternative to full sized rifles. \
 			Primarily employed in CQC scenarios or as a self defence tool. \
 			Takes both highcap pistol and smg mags. Uses .35 Auto rounds."
 	icon = 'zzzz_modular_occulus/icons/obj/guns/projectile/rx8.dmi'
@@ -15,12 +15,12 @@
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_H_PISTOL|MAG_WELL_SMG
 	magazine_type = /obj/item/ammo_magazine/smg
-	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_STEEL = 5, MATERIAL_WOOD = 2)
+	matter = list(MATERIAL_PLASTEEL = 10, MATERIAL_STEEL = 10, MATERIAL_WOOD = 2)
 	price_tag = 1400
 	rarity_value = 12
 
-	damage_multiplier = 1.2
-	penetration_multiplier = 1
+	damage_multiplier = 0.85
+	penetration_multiplier = 0.9
 	recoil_buildup = 3
 	one_hand_penalty = 5 //SMG level.
 

--- a/zzzz_modular_occulus/code/modules/projectiles/guns/projectile/pistol/ec9.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/guns/projectile/pistol/ec9.dm
@@ -14,11 +14,11 @@
 	load_method = MAGAZINE
 	mag_well = MAG_WELL_H_PISTOL|MAG_WELL_SMG
 	magazine_type = /obj/item/ammo_magazine/smg
-	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_STEEL = 5, MATERIAL_WOOD = 2)
+	matter = list(MATERIAL_PLASTEEL = 5, MATERIAL_STEEL = 10, MATERIAL_WOOD = 2)
 	price_tag = 800
 	rarity_value = 18.5
-	damage_multiplier = 1
-	penetration_multiplier = 1
+	damage_multiplier = 0.9	// Sliiiightly higher than the atreides since this can't go full auto
+	penetration_multiplier = 0.8
 	recoil_buildup = 4
 	one_hand_penalty = 4
 


### PR DESCRIPTION
## About The Pull Request

The EC9 and RX8 have been toned down quite a bit so that they are not strictly superior to the Atreides. In particular, both of them have had their damages slashed by a rather large margin. I had been balancing them against semi-auto weapons so their numbers were out of whack. Now with reference to other full auto SMG class weapons, they should be less silly.

## Why It's Good For The Game

Balance is good!

## Changelog
```changelog Toriate
balance: rebalanced the EC9 and RX8 to be more in line with SMG-class guns. A chunk of their damage has been taken away.
```
