### PR TITLE
Disables reverse-pouring

### DIFF
--- a/code/modules/reagents/atomic_distillery.dm
+++ b/code/modules/reagents/atomic_distillery.dm
@@ -47,5 +47,7 @@
 		return
 	if(standard_pour_into(user, target))
 		return TRUE
+	/* OCCULUS EDIT - NO MORE REVERSE POURING
 	if(standard_dispenser_refill(user, target))
 		return TRUE
+	*/

--- a/code/modules/reagents/enricher.dm
+++ b/code/modules/reagents/enricher.dm
@@ -60,5 +60,7 @@
 		return
 	if(standard_pour_into(user, target))
 		return TRUE
+	/* OCCULUS EDIT - NO MORE REVERSE POURING
 	if(standard_dispenser_refill(user, target))
 		return TRUE
+	*/

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -30,10 +30,11 @@
 
 		if(standard_pour_into(user, target))
 			return
-		/* OCCULUS EDIT - NO MORE REVERSE POURING
-		if(standard_dispenser_refill(user, target))
-			return
-		*/
+		// OCCULUS EDIT START - NO MORE REVERSE POURING
+		if(istype(target, /obj/structure/reagent_dispensers))
+			if(standard_dispenser_refill(user, target))
+				return
+		// OCCULUS EDIT END
 
 		if(istype(target, /obj/item/weapon/reagent_containers/food/snacks)) // These are not opencontainers but we can transfer to them
 			if(!reagents || !reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -30,8 +30,10 @@
 
 		if(standard_pour_into(user, target))
 			return
+		/* OCCULUS EDIT - NO MORE REVERSE POURING
 		if(standard_dispenser_refill(user, target))
 			return
+		*/
 
 		if(istype(target, /obj/item/weapon/reagent_containers/food/snacks)) // These are not opencontainers but we can transfer to them
 			if(!reagents || !reagents.total_volume)

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -45,10 +45,11 @@
 
 	if(standard_pour_into(user, target))
 		return
-	/* OCCULUS EDIT - NO MORE REVERSE POURING
-	if(standard_dispenser_refill(user, target))
-		return
-	*/
+	// OCCULUS EDIT START - NO MORE REVERSE POURING
+	if(istype(target, /obj/structure/reagent_dispensers))
+		if(standard_dispenser_refill(user, target))
+			return
+	// OCCULUS EDIT END
 	return ..()
 
 /obj/item/weapon/reagent_containers/food/drinks/is_closed_message(mob/user)

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -45,8 +45,10 @@
 
 	if(standard_pour_into(user, target))
 		return
+	/* OCCULUS EDIT - NO MORE REVERSE POURING
 	if(standard_dispenser_refill(user, target))
 		return
+	*/
 	return ..()
 
 /obj/item/weapon/reagent_containers/food/drinks/is_closed_message(mob/user)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -121,8 +121,10 @@
 			return
 	if(standard_pour_into(user, target))
 		return 1
+	/* OCCULUS EDIT - NO MORE REVERSE POURING
 	if(standard_dispenser_refill(user, target))
 		return 1
+	*/
 
 /obj/item/weapon/reagent_containers/glass/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/weapon/pen) || istype(I, /obj/item/device/lighting/toggleable/flashlight/pen))

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -121,10 +121,11 @@
 			return
 	if(standard_pour_into(user, target))
 		return 1
-	/* OCCULUS EDIT - NO MORE REVERSE POURING
-	if(standard_dispenser_refill(user, target))
-		return 1
-	*/
+	// OCCULUS EDIT START - NO MORE REVERSE POURING
+	if(istype(target, /obj/structure/reagent_dispensers))
+		if(standard_dispenser_refill(user, target))
+			return 1
+	// OCCULUS EDIT END
 
 /obj/item/weapon/reagent_containers/glass/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/weapon/pen) || istype(I, /obj/item/device/lighting/toggleable/flashlight/pen))


### PR DESCRIPTION
## About The Pull Request
Have you ever mixed a drink, but then suddenly a chunk of your cocktail-in-progress suddenly flowed back into your soda can? Well fret not, for with this PR, all your upstream flow fears shall be eliminated! That's right, for the low, low price of your sanity and the merging of this PR, your greatest nightmares will be gone in a jiffy!

Spray bottles still reversepour.

## Why It's Good For The Game

Quality of life, a long standing issue, etc. etc.

## Changelog
```changelog Toriate
del: Removed reverse-pouring from everything but spraybottles.
```