### PR TITLE
Makes body markings not lag anymore

### DIFF
--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -173,6 +173,14 @@
 		//Body markings
 		H.body_markings = dna.body_markings.Copy()
 
+		// OCCULUS EDIT IN AN ECLIPSE EDIT - HONK
+		for(var/tag in dna.body_markings)
+			var/obj/item/organ/external/E = H.organs_by_name[tag]
+			if(E)
+				var/list/marklist = dna.body_markings[tag]
+				E.markings = marklist.Copy()
+		// OCCULUS EDIT END
+
 		// Ears
 		var/ears = dna.GetUIValueRange(DNA_UI_EAR_STYLE, ear_styles_list.len + 1) - 1
 		if(ears <= 1)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -301,7 +301,7 @@ var/global/list/damage_icon_parts = list()
 	//tail
 	update_tail_showing(0)
 	update_wing_showing()
-	update_markings_showing(0)
+	//update_markings_showing(0)	// RIP old laggy system
 
 	appearance_test.Log("EXIT update_body()")
 	if(update_icons)

--- a/code/modules/organs/external/organ_icon.dm
+++ b/code/modules/organs/external/organ_icon.dm
@@ -110,10 +110,22 @@ var/global/list/limb_icon_cache = list()
 					hair.Blend(rgb(owner.r_hair, owner.g_hair, owner.b_hair), ICON_MULTIPLY)	//Eclipse edit.
 				overlays |= hair
 
+///// OCCULUS EDIT START - delete the laggy old markings system
+	for(var/M in markings)
+		var/datum/sprite_accessory/marking/mark_style = markings[M]["datum"]
+		var/icon/mark_s = new/icon("icon" = mark_style.icon, "icon_state" = "[mark_style.icon_state]-[organ_tag]")
+		mark_s.Blend(markings[M]["color"], mark_style.color_blend_mode)
+		add_overlay(mark_s) //So when it's not on your body, it has icons
+		mob_icon.Blend(mark_s, ICON_OVERLAY) //So when it's on your body, it has icons
+		//icon_cache_key += "[M][markings[M]["color"]]"
+///// OCCULUS EDIT END /////
+
 	return mob_icon
 
 /obj/item/organ/external/update_icon(regenerate = 0)
 	var/gender = "_m"
+
+	overlays.Cut()	// OCCULUS EDIT - Make sure we're not stacking up redundant overlays
 
 	if(appearance_test.simple_setup)
 		gender = owner.gender == FEMALE ? "_f" : "_m"
@@ -161,6 +173,16 @@ var/global/list/limb_icon_cache = list()
 			if(s_col)
 				mob_icon.Blend(rgb(s_col[1], s_col[2], s_col[3]), ICON_MULTIPLY)
 
+	///// OCCULUS EDIT START - Delete the laggy body marking system /////
+	if(!istype(src,/obj/item/organ/external/head))
+		for(var/M in markings)
+			var/datum/sprite_accessory/marking/mark_style = markings[M]["datum"]
+			var/icon/mark_s = new/icon("icon" = mark_style.icon, "icon_state" = "[mark_style.icon_state]-[organ_tag]")
+			mark_s.Blend(markings[M]["color"], mark_style.color_blend_mode)
+			add_overlay(mark_s) //So when it's not on your body, it has icons
+			mob_icon.Blend(mark_s, ICON_OVERLAY) //So when it's on your body, it has icons
+			//icon_cache_key += "[M][markings[M]["color"]]"
+	///// OCCULUS EDIT END /////
 
 	dir = EAST
 	icon = mob_icon


### PR DESCRIPTION
## About The Pull Request

By shifting body marking rendering onto limb icon generation code, lag from excessive markings seems to have been drastically reduced, at least on my local server. Previously, body markings were tacked on to the overall mob icon after everything was rendered which seemed to really screw with the icon cache system.

Of course, there is still a chance that the server will still chug, but it should hopefully be reduced rather than made worse with these changes.

## Why It's Good For The Game

Lag reduction is good. Body markings freezing and lagging the shit out of the game has been a massive problem since forever.

## Changelog
```changelog Toriate
refactor: Body markings have been moved over to limb icon generation code, which should reduce the amount of lag caused by body markings.
```