### PR TITLE
Fix mech drills and improve feedback

### DIFF
--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -204,13 +204,24 @@
 
 /obj/item/weapon/material/drill_head/Initialize()
 	. = ..()
-	durability = 2 * (material ? material.integrity : 1)
+	// OCCULUS EDIT -- durability was not being properly applied because material during this proc is null
+	//durability = 2 * (material ? material.integrity : 1)
+
+/obj/item/weapon/material/drill_head/steel/New(var/newloc)
+	..(newloc,MATERIAL_STEEL)
+	src.ApplyDurability()	// OCCULUS EDIT -- apply durability to drills properly
 
 /obj/item/weapon/material/drill_head/plasteel/New(var/newloc)
 	..(newloc,MATERIAL_PLASTEEL)
+	src.ApplyDurability()	// OCCULUS EDIT -- apply durability to drills properly
 
 /obj/item/weapon/material/drill_head/diamond/New(var/newloc)
 	..(newloc,MATERIAL_DIAMOND)
+	src.ApplyDurability()	// OCCULUS EDIT -- apply durability to drills properly
+
+///// OCCULUS EDIT -- handy verb to prevent copy/pasting durability in each New proc
+/obj/item/weapon/material/drill_head/verb/ApplyDurability()
+	durability = 2 * (material ? material.integrity : 1)
 
 /obj/item/mech_equipment/drill
 	name = "drill"
@@ -229,6 +240,7 @@
 /obj/item/mech_equipment/drill/Initialize()
 	. = ..()
 	drill_head = new /obj/item/weapon/material/drill_head(src, "steel")//You start with a basic steel head
+	drill_head.ApplyDurability()	// OCCULUS EDIT -- apply durability to drills properly
 
 /obj/item/mech_equipment/drill/attack_self(var/mob/user)
 	. = ..()
@@ -262,6 +274,7 @@
 		var/obj/item/weapon/cell/C = owner.get_cell()
 		if(istype(C))
 			C.use(active_power_use * CELLRATE)
+		playsound(src, 'sound/weapons/circsawhit.ogg', 50, 1)	// OCCULUS EDIT: More feedback for drilling
 		owner.visible_message("<span class='danger'>\The [owner] starts to drill \the [target]</span>", "<span class='warning'>You hear a large drill.</span>")
 
 		var/T = target.loc
@@ -311,7 +324,7 @@
 								if(get_dir(owner,ore)&owner.dir)
 									ore.Move(ore_box)
 
-				playsound(src, 'sound/weapons/circsawhit.ogg', 50, 1)
+				playsound(src, 'sound/weapons/rapidslice.ogg', 50, 1) // OCCULUS EDIT: more impactful noise
 
 		else
 			to_chat(user, "You must stay still while the drill is engaged!")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #171

Currently, mech drills are completely useless because they shatter after the first digging. This is not intended behaviour!

The issue with the drills is that when their durability is determined, it's calculated at a time when the material hasn't yet been set -- so instead of the proper durability, the drill is given a durability of 1.

A verb was built in (it may be able to be put in the modular folder but I couldn't figure it out) to do ApplyDurability() to make the drill head get the proper durability. Newly spawned mechs also receive the proper drill durability.

A final small change is to add a sound when the drill starts drilling and when it finished for more satisfying player feedback. 

![image](https://user-images.githubusercontent.com/77511162/105770707-943b1880-5f2d-11eb-842f-828370ffe170.png)
![image](https://user-images.githubusercontent.com/77511162/105770808-b03eba00-5f2d-11eb-8202-641dc0ecdb2b.png)

## Why It's Good For The Game

Miners can use mech drills finally! A stronger drillbit drills faster and more powerfully. A single drillbit may be able to last a whole mining mission, but plasteel and diamonds can be made in the field by miners for even more efficiency.

## Changelog
```changelog
tweak: Mech drills have more sound feedback.
fix: Mech drills receive durability properly now and can be used for extended mining missions.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
