### PR TITLE
Fix minerals so they can be seen through walls with mesons

### DIFF
--- a/code/modules/mining/mineral_effect.dm
+++ b/code/modules/mining/mineral_effect.dm
@@ -15,7 +15,7 @@
 	ore_key = M.name
 	icon_state = "rock_[ore_key]"
 	var/turf/T = get_turf(src)
-	T.overlays += image('icons/obj/mining.dmi', "rock_[ore_key]", dir = 1)
+	T.overlays += image('icons/obj/mining.dmi', "rock_[ore_key]", dir = 1)	// OCCULUS EDIT: Show ores through walls when using mesons
 	if(T.color)
 		color = T.color
 

--- a/code/modules/mining/mineral_effect.dm
+++ b/code/modules/mining/mineral_effect.dm
@@ -15,6 +15,7 @@
 	ore_key = M.name
 	icon_state = "rock_[ore_key]"
 	var/turf/T = get_turf(src)
+	T.overlays += image('icons/obj/mining.dmi', "rock_[ore_key]", dir = 1)
 	if(T.color)
 		color = T.color
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #37

Thanks to a big tip from RadiantFlash, I was able to narrow down where the issue was. During generation, minerals don't add themselves to the overlays like archaeological spots do -- now, minerals can be seen through walls while using mesons.

![image](https://user-images.githubusercontent.com/77511162/105892432-dae94b00-5fdf-11eb-87f9-72e36402f3a7.png)
![image](https://user-images.githubusercontent.com/77511162/105893055-9ad69800-5fe0-11eb-8ac9-f426028d2bf7.png)

## Why It's Good For The Game

Miners can see where to dig now!

## Changelog
```changelog
fix: Mesons now see ore through walls
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
