### PR TITLE
Stop pre-round meteors (without runlevel changes)

### DIFF
--- a/code/game/gamemodes/events/meteors.dm
+++ b/code/game/gamemodes/events/meteors.dm
@@ -190,11 +190,12 @@
 	var/Me = pickweight(meteortypes)
 	var/obj/effect/meteor/M = new Me(pickedstart)
 	M.dest = pickedgoal
-	if (Master.current_runlevel >= 3)	// OCCULUS EDIT: 3 is the actual number for RUNLEVEL_GAME -- adjusting the Runlevel code
-										// to change it to 4 was met with unforeseen consequences
+	///// OCCULUS EDIT BEGIN
+	// 3 is the actual number for RUNLEVEL_GAME -- adjusting the Runlevel code
+	// to change it to 4 was met with unforeseen consequences
+	if (Master.current_runlevel >= 3)
 		spawn(0)
 			walk_towards(M, M.dest, 1)
-	///// OCCULUS EDIT BEGIN
 	else
 		message_admins("A meteor attempted to spawn, but the round has not started.")
 	///// OCCULUS EDIT END

--- a/code/game/gamemodes/events/meteors.dm
+++ b/code/game/gamemodes/events/meteors.dm
@@ -190,8 +190,14 @@
 	var/Me = pickweight(meteortypes)
 	var/obj/effect/meteor/M = new Me(pickedstart)
 	M.dest = pickedgoal
-	spawn(0)
-		walk_towards(M, M.dest, 1)
+	if (Master.current_runlevel >= 3)	// OCCULUS EDIT: 3 is the actual number for RUNLEVEL_GAME -- adjusting the Runlevel code
+										// to change it to 4 was met with unforeseen consequences
+		spawn(0)
+			walk_towards(M, M.dest, 1)
+	///// OCCULUS EDIT BEGIN
+	else
+		message_admins("A meteor attempted to spawn, but the round has not started.")
+	///// OCCULUS EDIT END
 	return
 
 /proc/spaceDebrisStartLoc(startSide, Z)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request


This is a resubmission of #166 without fixes to the Runlevel in the Master Controller.

The code will instead look specifically for Runlevel 3 (the round has started) before determining if meteors can spawn. This is somewhat misleading, since the Master Controller reports that 'the round has started' is actually Runlevel 4, which the Master Controller variables themselves show that it is Runlevel 3.

The previous attempt to fix what the Master Controller believed the Runlevel is ran into unforeseen consequences where the Storyteller system did not tick properly, among other issues.

Testing log:

1. Started game, watched Storyteller Panel to make sure event pool points were being gained. Points were being gained successfully.
2. During runlevel 1/2 (setup/pre-game lobby): waited for meteor to attempt to spawn, successfully received failure message.

![image](https://user-images.githubusercontent.com/77511162/106187563-cb027000-6173-11eb-8a0c-f833f82d89cb.png)

3. During runlevel 3 (round has started): force spawned meteor shower via Storyteller Panel, admin log had impacts as expected.

![image](https://user-images.githubusercontent.com/77511162/106187592-d48bd800-6173-11eb-985b-103ec5b51e45.png)

Finally, the actual insertion of the conditional clause to stop the meteors was moved to a more precise point in the event that a failure to return might cause further problems.

## Why It's Good For The Game

There are times when the server sits with no players on it! During this time, meteors can still spawn and damage the ship before the game begins. If someone wants to play and they don't want to repair all the damage, this usually leads to a transfer vote to start a fresh ship.

This change does not prevent any meteors from spawning immediately after the game starts -- only before it starts.

## Changelog
```changelog
fix: Meteors no longer impact the ship before the round begins.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
