### PR TITLE
Fix crafted drill heads

### DIFF
--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -207,6 +207,15 @@
 	// OCCULUS EDIT -- durability was not being properly applied because material during this proc is null
 	//durability = 2 * (material ? material.integrity : 1)
 
+///// OCCULUS EDIT BEGIN
+// Drills crafted from the crafting menu actually call Created().
+// var/creator is a dummy var to avoid any issues with the call.
+
+/obj/item/weapon/material/drill_head/Created(var/creator)
+	src.ApplyDurability()
+
+///// OCCULUS EDIT END
+
 /obj/item/weapon/material/drill_head/steel/New(var/newloc)
 	..(newloc,MATERIAL_STEEL)
 	src.ApplyDurability()	// OCCULUS EDIT -- apply durability to drills properly


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixed #188

This is a slight correction to #175. In previous testing, I spawned drill heads directly and spawned mech drills and they had the correct durability. I operated under the assumption that making drills from the crafting menu would also work since spawns did, but I did not test thoroughly enough.

Crafted drills call Created() rather than another proc. This fix makes it so drill heads crafted through the crafting menu have the proper durability.

![image](https://user-images.githubusercontent.com/77511162/106320064-55b0a100-6240-11eb-901a-2be782b593b0.png)
![image](https://user-images.githubusercontent.com/77511162/106320082-5a755500-6240-11eb-902a-a5e34b6badab.png)

Crafting of plasteel and diamond drill heads were also tested and received durability as expected.

## Why It's Good For The Game

Miners can now make field replacements for drill heads that actually work.

## Changelog
```changelog
fix: Drill heads crafted through the crafting menu now get the proper durability.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
