### PR TITLE
Grants disease immunity to FBPs and those with synthetic lungs/liver

### DIFF
--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -75,6 +75,29 @@
 		cure(mob)
 		return
 
+	///// OCCULUS EDIT START
+	// Grant disease immunity to those with a robotic liver and robotic lungs.
+	// TODO: Later on, introduce computer viruses for people with prosthetics instead of regular viruses.
+	// This is also a QoL fix for FBPs since they cannot use spaceacillin easily, nor does it make sense
+	// for them to need medicine.
+
+	if(istype(H) && H.internal_organs)
+
+		if(H.isSynthetic())
+
+			src.cure(mob)
+			return
+
+		var/obj/item/organ/internal/lungs/lungs = H.random_organ_by_process(OP_LUNGS)
+		var/obj/item/organ/internal/liver/liver = H.random_organ_by_process(OP_LIVER)
+
+		if ((BP_IS_ROBOTIC(lungs) && BP_IS_ROBOTIC(liver)))
+
+			src.cure(mob)
+			return
+
+	///// OCCULUS EDIT END
+
 	if(mob.radiation > 50)
 		if(prob(1))
 			majormutate()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes #189 

FBPs are unfortunately a pretty buggy thing, but just as fortunately, not too many people play as them. This is a QoL fix for FBP players as well as opening the door for non-FBPs to get augmentations.

Specifically, this is a modification to the disease code to prevent FBPs and people with robotics lungs/liver (as printed by the robotics prosthetic fabricator) from getting diseases. Later on I would like to introduce a 'computer virus' flavor of disease that only affects prosthetics.

Three tests were performed:

1. Spawning a disease event vs. an FBP (using mob.isSynthetic(), which is called if all organs [internal and external] are prosthetics)

![image](https://user-images.githubusercontent.com/77511162/106394072-9e936180-63c8-11eb-93cf-b6b5b06f2641.png)

2. Spawning a disease event vs. a mob that I performed surgery on to replace their liver and lungs with prosthetics from the robotics fabricator

![image](https://user-images.githubusercontent.com/77511162/106394086-b965d600-63c8-11eb-8b3d-b673ba9e27af.png)

3. Spawning a disease event vs. a mob with no prosthetics

![image](https://user-images.githubusercontent.com/77511162/106394089-c2ef3e00-63c8-11eb-9099-2d3c3bf1b2b7.png)

(Don't worry, admins -- these admin log messages were for testing purposes only and they are not in the final code.)

## Why It's Good For The Game

FBPs can get organic diseases, which is pretty nonsense. They can't get injections to cure the disease, so they have to resort to eating spaceacillin pills (which should also not work.) The idea behind this is that the lungs are the doorway for incoming viruses and some research online tells me that the liver is responsible for immune system control response. Therefore, if a patient has both robotic lungs and a robotic liver, they will be immune to disease.

Later on, I would like to look into implementing a disease-like 'computer virus' event that only affects prosthetics and synthetics.

## Changelog
```changelog
add: Robotic lungs and liver will render you immune to disease -- talk to your local roboticist!
tweak: FBPs can no longer catch organic diseases.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
