### PR TITLE
Tweak chemistry dispenser energy usage for chemist QoL

### DIFF
--- a/code/__DEFINES/chemistry.dm
+++ b/code/__DEFINES/chemistry.dm
@@ -34,6 +34,7 @@
 #define REAGENTS_MIN_EFFECT_MULTIPLIER 0.2
 #define REAGENTS_MAX_EFFECT_MULTIPLIER 2.5
 
+// OCCULUS EDIT: Changed CHEM_SYNTH_ENERGY from 3000 to 2500 to let chemists do 120 units in a single dispensation.
 #define CHEM_SYNTH_ENERGY 2500 // How much energy does it take to synthesize 1 unit of chemical, in Joules.
 
 // Some on_mob_life() procs check for alien races.

--- a/code/__DEFINES/chemistry.dm
+++ b/code/__DEFINES/chemistry.dm
@@ -34,7 +34,7 @@
 #define REAGENTS_MIN_EFFECT_MULTIPLIER 0.2
 #define REAGENTS_MAX_EFFECT_MULTIPLIER 2.5
 
-#define CHEM_SYNTH_ENERGY 3000 // How much energy does it take to synthesize 1 unit of chemical, in Joules.
+#define CHEM_SYNTH_ENERGY 2500 // How much energy does it take to synthesize 1 unit of chemical, in Joules.
 
 // Some on_mob_life() procs check for alien races.
 #define IS_XENOS   1
@@ -55,7 +55,7 @@
 #define CE_BLOODCLOT 	"bloodclot"	// Promote healing but thickens blood, slows and stops bleeding (range 0 - 1)
 #define CE_OXYGENATED    "oxygen"       // Dexalin.
 #define CE_PURGER "purger"	//Purger
-#define CE_NOWITHDRAW "no_withdrawal" 
+#define CE_NOWITHDRAW "no_withdrawal"
 #define CE_VOICEMIMIC "voice_mimic"
 #define CE_DYNAMICFINGERS "dynfingers"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This is a tweak for the chemical dispenser rate that makes it possible for 120 units of a chemical to be dispensed in 600 units of energy. This is primarily a QoL change for chemists (and to a lesser extent, club workers) to help preserve their sanity when working with large quantities of chemicals.

The exact change here is making it so the energy usage rate per chemical unit is 2500 joules rather than 3000 joules. This has two effects:

1. Chemists (and people using soda fountains) will be able to fill a 120 volume container in a single sitting without having to wait a few extra seconds to top off a container.
2. Chemistry will use approximately 16% less power (as an engineer player for a little while I know that it eats a lot of power)

Per Kallin's concerns in Discord, I did some timing tests between atomcells and regular cells. The purpose of the test was to see how significant of a difference this would make in the availability of chemicals.

The conditions of the test were to use 600 energy (120 units) and time how long it would take for the cell to fully recharge. As an interested side effect of these timing tests, I also discovered that upgrading the stock part components of the chemical dispenser doesn't actually do anything -- you _can_ give it a pico-manipulator and etc., but the only component that makes a difference is the power cell.

These tests were done with a physical stopwatch so there's some imprecision in the numbers.

**Test 1:** Default cell, default parts. Took **~48** seconds to recharge 600 energy.
**Test 2:** Atomcell, default parts. Took **~28** seconds to recharge 600 energy.
**Test 3:** Default cell, upgraded parts. Took **~48** seconds to recharge 600 energy.
**Test 4:** Atomcell, upgraded parts. Took **~28** seconds to recharge 600 energy.

A fix to make the components actually do something will come later.

The following machines are touched by these changes:

1. The chemical dispenser (as seen in chemistry and RnD)
2. The soda fountain (it is a subtype of the chemical dispenser)
3. The booze dispenser (it is a subtype of the chemical dispenser -- I don't believe this is used ingame, it's different from the vending machine)
4. The magic chem dispenser (a cheat machine)
5. The industrial chem dispenser (maybe not placed anywhere?)
6. The sleepers (does not affect their functionality, but their power draw is based on the same variable that I've modified here)

## Why It's Good For The Game

This is a QoL fix for chemists and to a lesser extent, club workers. The primary purpose of the change is to make it so you can dispense 120 units of chemicals in one sitting rather than waiting for the energy to recharge to top off your containers. It looks like the original 3000 joules was made under the intention of letting chemical dispensers comfortably dispense 100 units at a time.

## Changelog
```changelog
tweak: Reduced chemistry synthesis energy cost to allow for 120 units in a single dispensation
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
