### PR TITLE
Changes noble description to add a clear glass clear descriptor on what it does mechanically as a downside besides sanity drain

### DIFF
--- a/code/datums/setup_option/backgrounds/fate.dm
+++ b/code/datums/setup_option/backgrounds/fate.dm
@@ -64,7 +64,9 @@
 	desc = "You are of a prestigious family or lineage. Maybe you're self-made. Maybe you're the heir to a fortune.\
 			Either way, you, like everyone else, are stuck aboard the NEV Northern Light. This is not the luxury you are used to. \
 			You're far more likely to be targeted for abduction by... unsavory types. \
-			Stay safe, star-child."
+			Stay safe, star-child. \
+			((Clarification: By abduction the game strictly and exclusively refers to ASSASSINATE objectives, \
+			not the serbian/merc kidnap objectives))"
 
 	perks = list(PERK_NOBLE)
 


### PR DESCRIPTION
Yeah no, I dont like bait. It baits with interesting ransoming objectives and all it does in reality is make you TC batteries via the most uninspiring objective ever conceived. This doesnt fix that it just adds a disclaimer/additional description on what this trait actually does.

## About The Pull Request

Changes nobles trait description when you pick it in the character creator. Now it shouldn't hide the fact that it turns you into overglorified non-rechargeable TC batteries.

## Why It's Good For The Game

Transparancy. One shouldn't need to code dive to see if a description is actually true to what it says or blatant false advertising like it was in this case.

## Changelog
```changelog
fix: Noble description enhanced to no longer falsely advertise ransom/abduction objectives.
```

