### PR TITLE
fixes .60 scrap box from spawning hellishly often

### DIFF
--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -253,7 +253,7 @@
 	caliber = CAL_ANTIM
 	ammo_type = /obj/item/ammo_casing/antim
 	max_ammo = 30
-	spawn_blacklisted = TRUE
+	spawn_blacklisted = TRUE // occulus modular, kill after loot rework
 
 /obj/item/ammo_magazine/ammobox/antim/scrap
 	name = "ammunition box (old .60 Anti Material)"
@@ -261,4 +261,4 @@
 	ammo_type = /obj/item/ammo_casing/antim/scrap
 	max_ammo = 30
 	rarity_value = 1
-	spawn_blacklisted = TRUE
+	spawn_blacklisted = TRUE // occulus modular, kill after loot rework

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -253,6 +253,7 @@
 	caliber = CAL_ANTIM
 	ammo_type = /obj/item/ammo_casing/antim
 	max_ammo = 30
+	spawn_blacklisted = TRUE
 
 /obj/item/ammo_magazine/ammobox/antim/scrap
 	name = "ammunition box (old .60 Anti Material)"
@@ -260,3 +261,4 @@
 	ammo_type = /obj/item/ammo_casing/antim/scrap
 	max_ammo = 30
 	rarity_value = 1
+	spawn_blacklisted = TRUE


### PR DESCRIPTION
## About The Pull Request

Blacklists .60 ammo boxes from spawning. why were they allowed to spawn? why was their rarity value 1? it makes literally zero sense

## Why It's Good For The Game

https://media.discordapp.net/attachments/777382113737572393/806331599146582074/unknown.png

maint is literally FLOODED with antimaterial rifle bullets

## Changelog
```changelog
fix: fixed .60 boxes spawning every 5 feet
```
