### PR TITLE
Updates the space fortress map

### DIFF
--- a/maps/encounters/spacefortress/spacefortress.dmm
+++ b/maps/encounters/spacefortress/spacefortress.dmm
@@ -467,18 +467,20 @@
 /area/outpost/abandoned_fortress)
 "cc" = (
 /obj/spawner/boxes/low_chance,
-/turf/simulated/floor/plating,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
 "cd" = (
 /obj/spawner/material/resources/rare/low_chance,
 /obj/spawner/material/resources/rare/low_chance,
-/turf/simulated/floor/plating,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
 "ce" = (
 /obj/spawner/lowkeyrandom,
 /obj/spawner/lowkeyrandom,
 /obj/spawner/lowkeyrandom,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
 "cf" = (
 /obj/spawner/ammo/low_chance,
@@ -488,7 +490,8 @@
 "cg" = (
 /obj/spawner/tool/low_chance,
 /obj/spawner/tool/low_chance,
-/turf/simulated/floor/plating,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
 "ch" = (
 /obj/structure/closet/emcloset,
@@ -611,6 +614,12 @@
 /obj/structure/closet/emcloset,
 /turf/simulated/floor/tiled/dark/brown_perforated,
 /area/outpost/abandoned_fortress)
+"dK" = (
+/obj/machinery/light/spot{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/derelict,
+/area/outpost/abandoned_fortress)
 "dT" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -695,15 +704,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/floor/plating/under,
 /area/outpost/abandoned_fortress)
-"fg" = (
-/obj/structure/table/rack/shelf,
-/obj/spawner/junk/low_chance,
-/obj/spawner/junk/low_chance,
-/turf/simulated/floor/tiled/dark/gray_platform,
-/area/outpost/abandoned_fortress)
 "fq" = (
 /mob/living/simple_animal/hostile/onestar_custodian/engineer,
 /turf/simulated/floor/tiled/white/gray_platform,
+/area/outpost/abandoned_fortress)
+"fs" = (
+/obj/structure/salvageable/os/console{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/derelict,
 /area/outpost/abandoned_fortress)
 "fz" = (
 /obj/structure/flora/ausbushes/fernybush,
@@ -790,10 +799,13 @@
 /turf/simulated/floor/plating,
 /area/outpost/abandoned_fortress)
 "hy" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/yellow,
+/obj/machinery/door/airlock/centcom{
+	icon_state = "door_locked";
+	locked = 1;
+	name = "Fortress Airlock"
 	},
-/turf/simulated/floor/carpet,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/outpost/abandoned_fortress)
 "hD" = (
 /obj/structure/flora/ausbushes/sparsegrass,
@@ -910,13 +922,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/outpost/abandoned_fortress)
-"jj" = (
-/obj/structure/barricade,
-/obj/effect/floor_decal/industrial/warning/dust{
-	dir = 1
-	},
-/turf/simulated/floor/plating,
-/area/outpost/abandoned_fortress)
 "jo" = (
 /obj/structure/sign/derelict2{
 	desc = "Looks like a planet crashing by some station above it. It's kinda scary. There's something written underneath it that you don't understand in huge, bold lettering.";
@@ -960,14 +965,15 @@
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/outpost/abandoned_fortress)
 "jR" = (
-/obj/structure/table/rack/shelf,
-/obj/spawner/tool/low_chance,
-/obj/spawner/tool/low_chance,
-/obj/spawner/junk/nondense,
-/turf/simulated/floor/tiled/dark/gray_platform,
+/obj/structure/bed/chair/custom/onestar{
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/roomba/boomba,
+/turf/simulated/floor/tiled/derelict,
 /area/outpost/abandoned_fortress)
 "jT" = (
-/mob/living/simple_animal/hostile/onestar_custodian/chef,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/grassybush,
 /turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
 "jW" = (
@@ -975,6 +981,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/plating/under,
+/area/outpost/abandoned_fortress)
+"jX" = (
+/obj/item/weapon/material/shard/phoron,
+/turf/simulated/floor/tiled/derelict,
 /area/outpost/abandoned_fortress)
 "ka" = (
 /obj/structure/closet/l3closet/general,
@@ -1076,8 +1086,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 1
 	},
-/obj/machinery/porta_turret/One_star,
 /turf/simulated/floor/plating/under,
+/area/outpost/abandoned_fortress)
+"lj" = (
+/obj/spawner/lowkeyrandom/low_chance,
+/turf/simulated/floor/tiled/derelict,
 /area/outpost/abandoned_fortress)
 "lm" = (
 /obj/machinery/door/airlock/centcom{
@@ -1088,6 +1101,12 @@
 "lq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
 /turf/simulated/floor/tiled/dark/brown_platform,
+/area/outpost/abandoned_fortress)
+"lx" = (
+/obj/structure/table/rack/shelf,
+/obj/spawner/techpart/low_chance,
+/obj/spawner/rig/damaged/low_chance,
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/outpost/abandoned_fortress)
 "lA" = (
 /turf/simulated/floor/tiled/derelict/white_big_edges,
@@ -1109,6 +1128,10 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/derelict/white_big_edges,
+/area/outpost/abandoned_fortress)
+"lO" = (
+/obj/structure/salvageable/os/machine,
+/turf/simulated/floor/tiled/derelict,
 /area/outpost/abandoned_fortress)
 "lS" = (
 /obj/structure/catwalk,
@@ -1146,6 +1169,12 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/plating/under,
+/area/outpost/abandoned_fortress)
+"mA" = (
+/obj/structure/sign/faction/one_star_old{
+	desc = "One Star's all-seeing eye. A flash of color in dark monochrome and twilight."
+	},
+/turf/simulated/wall/untinted/onestar_reinforced,
 /area/outpost/abandoned_fortress)
 "na" = (
 /obj/structure/flora/ausbushes,
@@ -1196,12 +1225,13 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/derelict,
 /area/outpost/abandoned_fortress)
 "nI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 5
 	},
+/obj/machinery/light/floor,
 /turf/simulated/floor/plating/under,
 /area/outpost/abandoned_fortress)
 "nN" = (
@@ -1284,6 +1314,16 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/outpost/abandoned_fortress)
+"pB" = (
+/obj/structure/railing/grey{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/yellow{
+	dir = 4
+	},
+/obj/machinery/porta_turret/One_star,
+/turf/simulated/floor/plating/under,
+/area/outpost/abandoned_fortress)
 "pE" = (
 /turf/simulated/floor/tiled/dark/brown_platform,
 /area/outpost/abandoned_fortress)
@@ -1312,7 +1352,6 @@
 /area/outpost/abandoned_fortress)
 "pX" = (
 /obj/structure/table/rack/shelf,
-/obj/spawner/junk/low_chance,
 /obj/item/weapon/tool/weldingtool/onestar,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/outpost/abandoned_fortress)
@@ -1345,6 +1384,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/green,
 /turf/simulated/floor/plating/under,
 /area/outpost/abandoned_fortress)
+"qD" = (
+/obj/item/weapon/caution,
+/turf/simulated/floor/tiled/derelict,
+/area/outpost/abandoned_fortress)
 "qE" = (
 /obj/structure/closet/onestar/tier1/medical,
 /obj/machinery/light/floor{
@@ -1355,6 +1398,10 @@
 "qH" = (
 /obj/structure/flora/ausbushes,
 /turf/simulated/floor/grass,
+/area/outpost/abandoned_fortress)
+"qL" = (
+/obj/item/weapon/material/shard/phoron,
+/turf/simulated/floor/carpet,
 /area/outpost/abandoned_fortress)
 "qN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green,
@@ -1384,8 +1431,12 @@
 /turf/simulated/floor/plating/under,
 /area/outpost/abandoned_fortress)
 "rq" = (
-/mob/living/simple_animal/hostile/onestar_custodian,
+/obj/structure/flora/ausbushes/fullgrass,
 /turf/simulated/floor/grass,
+/area/outpost/abandoned_fortress)
+"rw" = (
+/obj/machinery/door/airlock/glass,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/outpost/abandoned_fortress)
 "ry" = (
 /obj/structure/closet/onestar/tier1,
@@ -1434,6 +1485,7 @@
 /area/outpost/abandoned_fortress)
 "sk" = (
 /obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/brflowers,
 /turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
 "sv" = (
@@ -1519,6 +1571,12 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/outpost/abandoned_fortress)
+"tE" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/carpet,
+/area/outpost/abandoned_fortress)
 "tM" = (
 /obj/structure/grille,
 /turf/simulated/floor/plating/under,
@@ -1578,6 +1636,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/outpost/abandoned_fortress)
+"uz" = (
+/obj/structure/low_wall/onestar,
+/obj/item/weapon/material/shard/phoron,
+/turf/simulated/floor/plating,
+/area/outpost/abandoned_fortress)
 "uB" = (
 /obj/structure/closet/crate/plastic,
 /turf/simulated/mineral,
@@ -1614,6 +1677,11 @@
 /mob/living/simple_animal/hostile/roomba/slayer,
 /turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/outpost/abandoned_fortress)
+"vF" = (
+/obj/structure/window/reinforced,
+/mob/living/simple_animal/hostile/onestar_custodian/chef,
+/turf/simulated/floor/tiled/derelict/red_white_edges,
+/area/outpost/abandoned_fortress)
 "vH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green,
 /turf/simulated/floor/tiled/derelict,
@@ -1649,6 +1717,12 @@
 /obj/structure/railing/grey,
 /turf/simulated/floor/plating/under,
 /area/outpost/abandoned_fortress)
+"wq" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass,
+/area/outpost/abandoned_fortress)
 "wu" = (
 /obj/machinery/porta_turret/One_star,
 /turf/simulated/floor/plating/under,
@@ -1663,6 +1737,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/outpost/abandoned_fortress)
+"wW" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass,
+/area/outpost/abandoned_fortress)
 "wX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
 	dir = 4
@@ -1676,7 +1755,8 @@
 /obj/structure/table/woodentable,
 /obj/item/weapon/reagent_containers/food/snacks/sliceable/applecake{
 	desc = "A cake centered with apples. It's covered in dust, but looks entirely fresh and ready to eat. Do you dare...?";
-	name = "Perfectly Preserved Apple Cake"
+	name = "Perfectly Preserved Apple Cake";
+	nutriment_desc = list("death" = 10, "dust" = 10, "regret" = 15)
 	},
 /turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
@@ -1793,12 +1873,24 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/outpost/abandoned_fortress)
+"yP" = (
+/obj/structure/sign/derelict2{
+	desc = "Looks like a planet crashing by some station above it. It's kinda scary. There's something written underneath it that you don't understand in huge, bold lettering.";
+	pixel_x = 28
+	},
+/obj/structure/salvageable/os/data,
+/turf/simulated/floor/tiled/derelict,
+/area/outpost/abandoned_fortress)
 "yR" = (
 /obj/structure/table/rack/shelf,
 /obj/spawner/lowkeyrandom/low_chance,
 /obj/spawner/lowkeyrandom/low_chance,
 /obj/effect/decal/cleanable/liquid_fuel,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
+/area/outpost/abandoned_fortress)
+"yX" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
 "yZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
@@ -1819,10 +1911,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/outpost/abandoned_fortress)
 "zq" = (
-/obj/structure/sign/faction/one_star_old{
-	desc = "One Star's all-seeing eye. A flash of color in dark monochrome and twilight.";
-	pixel_x = 32
-	},
 /obj/structure/inflatable/wall,
 /turf/simulated/floor/tiled,
 /area/outpost/abandoned_fortress)
@@ -1842,15 +1930,16 @@
 /obj/structure/flora/grass/both,
 /turf/simulated/floor/exoplanet/snow,
 /area/outpost/abandoned_fortress)
-"Af" = (
-/obj/structure/salvageable/os/console,
-/turf/simulated/floor/tiled/dark/brown_perforated,
+"zT" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/outpost/abandoned_fortress)
-"AC" = (
-/obj/structure/table/rack/shelf,
-/obj/spawner/junk/nondense,
-/obj/spawner/junk/nondense,
-/turf/simulated/floor/tiled/dark/gray_platform,
+"Af" = (
+/obj/structure/table/onestar,
+/obj/item/tape/engineering,
+/turf/simulated/floor/tiled/derelict,
 /area/outpost/abandoned_fortress)
 "AD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
@@ -1900,6 +1989,11 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/abandoned_fortress)
+"BO" = (
+/obj/structure/flora/ausbushes/fernybush,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
+/area/outpost/abandoned_fortress)
 "BQ" = (
 /turf/simulated/floor/asteroid,
 /area/outpost/abandoned_fortress)
@@ -1912,6 +2006,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/green,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
+/area/outpost/abandoned_fortress)
+"BX" = (
+/obj/structure/flora/ausbushes/grassybush,
+/turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
 "Cc" = (
 /obj/structure/flora/ausbushes/palebush,
@@ -1956,6 +2054,11 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/derelict/white_small_edges,
+/area/outpost/abandoned_fortress)
+"Dl" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
 "Dx" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -2004,6 +2107,9 @@
 /obj/machinery/light/floor{
 	dir = 4;
 	pixel_x = 4
+	},
+/obj/structure/railing/grey{
+	dir = 8
 	},
 /turf/simulated/floor/plating/under,
 /area/outpost/abandoned_fortress)
@@ -2075,6 +2181,10 @@
 /obj/structure/railing/grey{
 	dir = 1
 	},
+/turf/simulated/floor/tiled/derelict/red_white_edges,
+/area/outpost/abandoned_fortress)
+"Fz" = (
+/mob/living/simple_animal/hostile/roomba/gun_ba,
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/outpost/abandoned_fortress)
 "FD" = (
@@ -2249,7 +2359,7 @@
 /turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
 "Ig" = (
-/mob/living/simple_animal/hostile/roomba/gun_ba,
+/mob/living/simple_animal/hostile/shantak,
 /turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
 "Il" = (
@@ -2270,6 +2380,12 @@
 	},
 /turf/simulated/floor/tiled/derelict,
 /area/outpost/abandoned_fortress)
+"IX" = (
+/obj/structure/salvageable/os/console{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/brown_platform,
+/area/outpost/abandoned_fortress)
 "IY" = (
 /obj/structure/reagent_dispensers/fueltank/huge/derelict,
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -2282,6 +2398,10 @@
 "Ji" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow,
 /turf/simulated/mineral,
+/area/outpost/abandoned_fortress)
+"Jn" = (
+/mob/living/simple_animal/hostile/onestar_custodian/chef,
+/turf/simulated/floor/plating/under,
 /area/outpost/abandoned_fortress)
 "Js" = (
 /obj/spawner/prothesis_one_star,
@@ -2346,9 +2466,18 @@
 	},
 /turf/simulated/floor/plating,
 /area/outpost/abandoned_fortress)
+"JW" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/grass,
+/area/outpost/abandoned_fortress)
 "Ki" = (
 /obj/structure/inflatable,
 /turf/simulated/floor/tiled,
+/area/outpost/abandoned_fortress)
+"Kj" = (
+/obj/structure/inflatable/wall,
+/turf/simulated/floor/plating/under,
 /area/outpost/abandoned_fortress)
 "Kr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green,
@@ -2381,6 +2510,11 @@
 	},
 /turf/simulated/floor/tiled/derelict/white_big_edges,
 /area/outpost/abandoned_fortress)
+"KD" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/obj/structure/flora/ausbushes/stalkybush,
+/turf/simulated/floor/grass,
+/area/outpost/abandoned_fortress)
 "KE" = (
 /obj/item/roller,
 /obj/structure/table/onestar,
@@ -2388,6 +2522,7 @@
 /area/outpost/abandoned_fortress)
 "KM" = (
 /obj/spawner/gun/normal/low_chance,
+/obj/structure/flora/ausbushes/stalkybush,
 /turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
 "KN" = (
@@ -2572,6 +2707,11 @@
 /obj/structure/flora/ausbushes/fernybush,
 /turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
+"Ns" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/fullgrass,
+/turf/simulated/floor/grass,
+/area/outpost/abandoned_fortress)
 "NA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
@@ -2616,6 +2756,10 @@
 	},
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/outpost/abandoned_fortress)
+"NT" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/simulated/floor/grass,
+/area/outpost/abandoned_fortress)
 "NX" = (
 /obj/structure/closet/onestar/tier2,
 /turf/simulated/floor/plating,
@@ -2656,7 +2800,7 @@
 /area/outpost/abandoned_fortress)
 "OI" = (
 /obj/structure/table/rack/shelf,
-/obj/spawner/junk/nondense,
+/obj/spawner/techpart/low_chance,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/outpost/abandoned_fortress)
 "OM" = (
@@ -2717,6 +2861,11 @@
 /obj/item/weapon/stool,
 /turf/simulated/floor/tiled/derelict,
 /area/outpost/abandoned_fortress)
+"PP" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/item/weapon/material/shard/phoron,
+/turf/simulated/floor/grass,
+/area/outpost/abandoned_fortress)
 "PQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/floor/plating/under,
@@ -2741,6 +2890,10 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/under,
+/area/outpost/abandoned_fortress)
+"Qm" = (
+/obj/item/weapon/tool/screwdriver/combi_driver/onestar,
+/turf/simulated/floor/tiled/derelict,
 /area/outpost/abandoned_fortress)
 "Qp" = (
 /obj/structure/railing/grey,
@@ -2770,6 +2923,11 @@
 	},
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/outpost/abandoned_fortress)
+"QS" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass,
+/area/outpost/abandoned_fortress)
 "QZ" = (
 /obj/structure/closet/onestar/tier1/normal/empty,
 /turf/simulated/floor/plating,
@@ -2780,6 +2938,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow,
 /turf/simulated/floor/plating/under,
+/area/outpost/abandoned_fortress)
+"Re" = (
+/obj/structure/flora/ausbushes/fernybush,
+/mob/living/simple_animal/hostile/shantak,
+/turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
 "Rm" = (
 /obj/item/weapon/stool,
@@ -2801,6 +2964,10 @@
 	dir = 10
 	},
 /turf/simulated/wall/untinted/onestar_reinforced,
+/area/outpost/abandoned_fortress)
+"Rv" = (
+/obj/spawner/rig,
+/turf/simulated/floor/tiled/derelict/white_small_edges,
 /area/outpost/abandoned_fortress)
 "Rz" = (
 /obj/structure/table/rack/shelf,
@@ -2831,6 +2998,10 @@
 /mob/living/simple_animal/hostile/roomba/gun_ba,
 /turf/simulated/floor/plating/under,
 /area/outpost/abandoned_fortress)
+"RS" = (
+/obj/structure/flora/ausbushes/lavendergrass,
+/turf/simulated/floor/grass,
+/area/outpost/abandoned_fortress)
 "RX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow{
 	dir = 4
@@ -2854,12 +3025,14 @@
 /turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
 "Sr" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Fortress Airlock"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 1
+	},
+/obj/machinery/door/airlock/centcom{
+	icon_state = "door_locked";
+	locked = 1;
+	name = "Fortress Airlock"
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/outpost/abandoned_fortress)
@@ -2951,6 +3124,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/railing/grey{
+	dir = 8
+	},
 /turf/simulated/floor/plating/under,
 /area/outpost/abandoned_fortress)
 "TD" = (
@@ -2963,9 +3139,8 @@
 /area/outpost/abandoned_fortress)
 "TN" = (
 /obj/structure/table/rack/shelf,
-/obj/spawner/junk/nondense,
-/obj/spawner/junk/nondense,
 /obj/machinery/light,
+/obj/spawner/techpart/low_chance,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/outpost/abandoned_fortress)
 "TU" = (
@@ -3021,6 +3196,12 @@
 	},
 /turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
+"UB" = (
+/obj/structure/table/rack/shelf,
+/obj/spawner/techpart/low_chance,
+/obj/spawner/rig/low_chance,
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/outpost/abandoned_fortress)
 "UW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 10
@@ -3051,13 +3232,13 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/outpost/abandoned_fortress)
+"Vr" = (
+/obj/structure/salvageable/os/computer,
+/turf/simulated/floor/tiled/derelict,
+/area/outpost/abandoned_fortress)
 "Vt" = (
-/obj/structure/table/rack/shelf,
-/obj/spawner/tool/low_chance,
-/obj/spawner/tool/low_chance,
-/obj/spawner/techpart,
-/obj/spawner/junk/nondense,
-/turf/simulated/floor/tiled/dark/gray_platform,
+/obj/item/weapon/caution/cone,
+/turf/simulated/floor/tiled/derelict,
 /area/outpost/abandoned_fortress)
 "Vu" = (
 /obj/machinery/light/spot{
@@ -3095,6 +3276,14 @@
 	dir = 4
 	},
 /turf/simulated/wall/untinted/onestar_reinforced,
+/area/outpost/abandoned_fortress)
+"VW" = (
+/obj/structure/railing/grey{
+	dir = 8
+	},
+/obj/structure/flora/ausbushes/fernybush,
+/mob/living/simple_animal/hostile/diyaab,
+/turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
 "VZ" = (
 /obj/structure/flora/ausbushes,
@@ -3156,6 +3345,11 @@
 /obj/structure/railing/grey,
 /turf/simulated/floor/plating/under,
 /area/outpost/abandoned_fortress)
+"Xl" = (
+/obj/structure/catwalk,
+/mob/living/simple_animal/hostile/roomba/boomba,
+/turf/simulated/floor/plating/under,
+/area/outpost/abandoned_fortress)
 "Xm" = (
 /obj/spawner/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -3174,6 +3368,11 @@
 	dir = 4
 	},
 /turf/simulated/floor/plating/under,
+/area/outpost/abandoned_fortress)
+"XL" = (
+/obj/structure/window/reinforced,
+/obj/structure/flora/ausbushes/ywflowers,
+/turf/simulated/floor/grass,
 /area/outpost/abandoned_fortress)
 "XO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3208,7 +3407,7 @@
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled/derelict,
 /area/outpost/abandoned_fortress)
 "Yj" = (
 /obj/structure/table/rack/shelf,
@@ -10504,7 +10703,7 @@ ab
 ab
 ab
 Lq
-wC
+Ig
 Lq
 ab
 Lq
@@ -10705,7 +10904,7 @@ ab
 ab
 ab
 ab
-wC
+Ue
 wC
 WY
 ab
@@ -10902,11 +11101,11 @@ Lq
 ab
 ab
 cc
-wC
-wC
+wW
+KD
 KM
-ab
-ab
+bw
+jX
 wC
 xh
 wC
@@ -11103,14 +11302,14 @@ ab
 ab
 ab
 ab
-ae
-ae
-wC
-wC
-wC
-wC
-wC
-wC
+RS
+JW
+wq
+wW
+uz
+PP
+PP
+rq
 WY
 ab
 ab
@@ -11303,16 +11502,16 @@ aa
 Lq
 ab
 ab
-ab
-ab
-ae
-ae
-ae
+rq
+rq
+rq
+rq
+RS
 cf
-ab
-MT
-WY
-wC
+bw
+qL
+qL
+RS
 WY
 ab
 ab
@@ -11505,17 +11704,17 @@ aa
 Lq
 ab
 ab
-ab
-ab
-ae
+rq
+rq
+JW
 cd
 ce
 cg
-ab
-MT
-hy
-wC
-wC
+bw
+tE
+WY
+QS
+RS
 ab
 ab
 ab
@@ -11707,17 +11906,17 @@ bw
 Lq
 ab
 ab
-ab
-ab
+rq
+rq
 ab
 ab
 ab
 MT
 MT
 MT
-wC
+RS
 WY
-wC
+QS
 ab
 ab
 ab
@@ -11915,12 +12114,12 @@ ab
 ab
 ab
 Lq
+Re
+BX
+RS
 wC
-wC
-wC
-wC
-wC
-wC
+rq
+rq
 Id
 ab
 ab
@@ -12117,13 +12316,13 @@ TF
 hl
 TF
 Lq
+rq
+kf
+rq
 wC
-wC
-wC
-wC
-wC
-wC
-wC
+RS
+rq
+yX
 ab
 ab
 ab
@@ -12314,18 +12513,18 @@ hM
 hM
 hM
 hM
-hM
+SS
 hM
 Sv
 hM
 Lq
 hM
-wC
+BX
 jT
 wC
 rq
-wC
-wC
+rq
+rq
 Lq
 Lq
 Lq
@@ -12523,11 +12722,11 @@ hM
 lm
 KV
 wC
-wC
+BO
 Ig
-wC
-wC
-wC
+rq
+kf
+yX
 wC
 tt
 bw
@@ -12721,15 +12920,15 @@ hM
 SS
 hM
 hM
-hM
+Da
 Lq
 hM
+rq
 wC
+yX
 wC
-wC
-wC
-wC
-wC
+rq
+rq
 Lq
 Lq
 Lq
@@ -12927,11 +13126,11 @@ ab
 Lq
 wC
 wC
+rq
+rq
 wC
 wC
-wC
-wC
-wC
+Ig
 ab
 ab
 ab
@@ -13111,7 +13310,7 @@ ae
 ae
 ae
 ae
-ae
+BU
 ae
 ae
 ae
@@ -13127,12 +13326,12 @@ ae
 ae
 ae
 Lq
-wC
-wC
-hM
+rq
+rq
+dK
 KV
-hM
-wC
+dK
+NT
 wC
 ab
 ab
@@ -13481,7 +13680,7 @@ ab
 ab
 ab
 hM
-hM
+qD
 hM
 ab
 ca
@@ -13720,7 +13919,7 @@ ab
 ab
 ab
 ab
-ae
+wa
 ab
 ab
 ab
@@ -14115,7 +14314,7 @@ ab
 MT
 NN
 bv
-bv
+EU
 CC
 EU
 CC
@@ -14497,7 +14696,7 @@ ab
 ca
 ab
 MT
-hS
+Rv
 bb
 hS
 bi
@@ -14525,7 +14724,7 @@ EU
 CC
 EU
 CC
-Vt
+GB
 MT
 ab
 ae
@@ -14727,7 +14926,7 @@ CC
 EU
 CC
 EU
-jR
+FR
 MT
 ab
 ae
@@ -15094,7 +15293,7 @@ aa
 aa
 aa
 bw
-cC
+jR
 hM
 hM
 hM
@@ -15333,7 +15532,7 @@ bJ
 bJ
 bJ
 bJ
-AC
+lx
 MT
 ab
 ae
@@ -15354,7 +15553,7 @@ ab
 hO
 hO
 NI
-Up
+ca
 Xm
 ca
 ab
@@ -15700,7 +15899,7 @@ aa
 aa
 aa
 bw
-qm
+Af
 hM
 hM
 hM
@@ -15723,7 +15922,7 @@ ab
 Lq
 wh
 cF
-cF
+zT
 cF
 Lq
 ab
@@ -15734,10 +15933,10 @@ yv
 GB
 FR
 GB
-fg
-fg
-AC
-AC
+OI
+UB
+OI
+OI
 MT
 ab
 ae
@@ -15924,9 +16123,9 @@ MT
 Lq
 Lq
 Lq
-fV
+sv
 Lq
-fV
+sv
 Lq
 ab
 ab
@@ -16106,9 +16305,9 @@ aa
 Lq
 Lq
 Lq
-hM
-hM
-hM
+Vt
+Vt
+Vt
 ab
 ca
 ca
@@ -16328,9 +16527,9 @@ ab
 ab
 Lq
 Lq
-fV
+sv
 Lq
-fV
+sv
 MT
 ab
 ab
@@ -16531,7 +16730,7 @@ Lq
 Lq
 nr
 cF
-cF
+NP
 cF
 MT
 ab
@@ -17980,7 +18179,7 @@ ab
 hO
 lS
 Wn
-ab
+ca
 ab
 ab
 aa
@@ -18126,7 +18325,7 @@ Lq
 Lq
 ab
 ab
-hM
+Qg
 Sv
 hM
 ab
@@ -18734,7 +18933,7 @@ ab
 ab
 hM
 hM
-hM
+Qg
 ab
 ca
 ab
@@ -18787,7 +18986,7 @@ ae
 ab
 nw
 hO
-Wn
+NI
 ab
 ab
 ab
@@ -18923,12 +19122,12 @@ ab
 hM
 hM
 Sv
+Qg
 hM
 hM
 hM
 hM
-hM
-hM
+Qg
 hM
 hM
 hM
@@ -19119,11 +19318,11 @@ hM
 ab
 Sv
 ab
+pf
 hM
 hM
 hM
-hM
-hM
+Qg
 hM
 hM
 hM
@@ -19322,19 +19521,19 @@ pf
 ab
 ab
 Lx
-hM
+Ok
 ab
 hM
 hM
 hM
 hM
-hM
+Qg
 hM
 hM
 Sv
 Sv
 hM
-hM
+Qg
 hM
 hM
 hM
@@ -20975,10 +21174,10 @@ lA
 xB
 cF
 hS
-hS
+xy
 hS
 cF
-hS
+rw
 lA
 KA
 lA
@@ -21009,7 +21208,7 @@ Xm
 ab
 hO
 hO
-Wn
+pB
 ca
 ab
 ab
@@ -21180,7 +21379,7 @@ hS
 hS
 hS
 cF
-hS
+MT
 lA
 cU
 lA
@@ -21382,7 +21581,7 @@ hS
 hS
 hS
 cF
-hS
+rw
 lA
 vT
 lA
@@ -21791,7 +21990,7 @@ hS
 MT
 MT
 MT
-hS
+fT
 MT
 MT
 MT
@@ -22417,7 +22616,7 @@ ab
 ab
 ab
 Lq
-wC
+rq
 sk
 hM
 hM
@@ -22619,8 +22818,8 @@ ab
 ab
 ab
 Lq
-wC
-sk
+kf
+Ns
 hM
 hM
 hM
@@ -22821,8 +23020,8 @@ ab
 ab
 ab
 Lq
-wC
-sk
+rq
+XL
 hM
 hM
 hM
@@ -23023,8 +23222,8 @@ ae
 ae
 ab
 Lq
-wC
-sk
+RS
+Dl
 hM
 hM
 hM
@@ -23225,8 +23424,8 @@ ae
 at
 ab
 Lq
-wC
-sk
+zj
+XL
 ZM
 Xe
 Xe
@@ -23427,8 +23626,8 @@ ae
 TW
 Lq
 Lq
-wC
-sk
+Sp
+Dl
 hM
 Xe
 hM
@@ -23629,8 +23828,8 @@ ae
 cb
 ab
 Lq
-wC
-sk
+zj
+XL
 ZM
 Xe
 hM
@@ -23831,8 +24030,8 @@ ca
 ca
 ca
 Lq
-wC
-sk
+NT
+Dl
 hM
 hM
 hM
@@ -23841,7 +24040,7 @@ hM
 hM
 hM
 Lq
-Lq
+mA
 Lq
 tm
 dj
@@ -24221,8 +24420,8 @@ pE
 pE
 pE
 MT
-hM
-hM
+lO
+Qm
 Lq
 Yh
 by
@@ -24423,9 +24622,9 @@ Zt
 pE
 pE
 MT
-Sv
+Vr
 xo
-Lq
+QA
 nH
 fG
 fG
@@ -24625,10 +24824,10 @@ pE
 pE
 pE
 MT
-jo
-hM
+yP
+lj
 Lq
-jj
+nH
 by
 Je
 by
@@ -24984,7 +25183,7 @@ ab
 ab
 ab
 ab
-Lq
+ab
 ab
 ab
 ab
@@ -25175,7 +25374,7 @@ qc
 hM
 hM
 JI
-Vm
+hy
 PQ
 PQ
 PQ
@@ -25391,9 +25590,9 @@ ab
 ca
 Rq
 PQ
-PQ
-PQ
-PQ
+ab
+ab
+ab
 PQ
 PQ
 PQ
@@ -25409,8 +25608,8 @@ LZ
 Vu
 hM
 gb
-hM
-hM
+fs
+fs
 Lq
 ab
 ab
@@ -28075,7 +28274,7 @@ ab
 ab
 ab
 ab
-ca
+Jn
 Lq
 hM
 hM
@@ -28467,11 +28666,11 @@ LU
 hS
 hS
 hS
-Lq
+BQ
 ab
 BQ
 BQ
-BQ
+om
 BQ
 ab
 ab
@@ -29082,7 +29281,7 @@ ab
 ca
 Lq
 hM
-hM
+iI
 hM
 Lq
 hM
@@ -29213,7 +29412,7 @@ Lq
 ab
 Lq
 hS
-hS
+xy
 hS
 Lq
 ab
@@ -29471,7 +29670,7 @@ cF
 bN
 bN
 bN
-FU
+vF
 xY
 Lq
 TU
@@ -29487,7 +29686,7 @@ ca
 Lq
 Sv
 hM
-hM
+iI
 Lq
 Sv
 Sv
@@ -29617,7 +29816,7 @@ Lq
 Lq
 Lq
 hS
-hS
+Sb
 hS
 Lq
 Lq
@@ -29683,11 +29882,11 @@ ca
 ca
 ab
 ab
-ab
-ab
+ca
+ca
 ca
 Lq
-hM
+iI
 hM
 hM
 Lq
@@ -31101,7 +31300,7 @@ ae
 MT
 ca
 ab
-hM
+iI
 kf
 Sv
 Lq
@@ -31434,7 +31633,7 @@ Lq
 Lq
 Lq
 Lq
-hS
+Sb
 Sb
 hS
 Lq
@@ -32304,7 +32503,7 @@ ab
 ab
 ab
 TD
-ca
+Kj
 ca
 ca
 ca
@@ -32685,7 +32884,7 @@ hM
 bE
 hS
 Uo
-cF
+Fz
 cF
 cF
 cF
@@ -33079,7 +33278,7 @@ hM
 hM
 Sv
 hM
-hO
+Xl
 Lq
 Lq
 bw
@@ -33089,7 +33288,7 @@ Lq
 Lq
 Lq
 cF
-cF
+sS
 cF
 cF
 Uo
@@ -33283,7 +33482,7 @@ Lq
 wo
 hO
 Lq
-Af
+km
 pE
 fc
 pE
@@ -33306,7 +33505,7 @@ Jw
 Hc
 MO
 uW
-rV
+VW
 Jw
 Mz
 rV
@@ -33460,11 +33659,11 @@ UW
 Hs
 Uh
 Hs
-Uh
+Hs
 Hs
 Uh
 Hs
-Uh
+Hs
 Hs
 Uh
 Hs
@@ -33472,11 +33671,11 @@ kZ
 Hs
 Uh
 Hs
-Uh
+Hs
 Hs
 Uh
 Hs
-Uh
+Hs
 Hs
 Uh
 Hs
@@ -33489,7 +33688,7 @@ km
 gd
 Ye
 gd
-pE
+IX
 YZ
 Lq
 Lq


### PR DESCRIPTION
## About The Pull Request

Includes some more detail to the map, such as a few new mobs, pays out fairer rewards for managing to get to certain areas, and tweaks the difficulty. Also adds some appropriate taste descriptors to the perfectly preserved apple; death, dust, and regret. (You don't take damage or die, don't worry!)

## Changelog
```changelog
tweak: tweaked space fortress difficulty
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
