### PR TITLE
Quick lazy port of mob optimizations from upstream

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -8,8 +8,7 @@
 	..()
 
 /mob/living/carbon/Life()
-	..()
-
+	. = ..()
 	handle_viruses()
 	// Increase germ_level regularly
 	if(germ_level < GERM_LEVEL_AMBIENT && prob(30))	//if you're just standing there, you shouldn't get more germs beyond an ambient level

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -53,7 +53,7 @@
 	if(wearing_rig && wearing_rig.offline)
 		wearing_rig = null
 
-	..()
+	. = ..()
 
 	if(life_tick%30==15)
 		hud_updateflag = 1022
@@ -61,7 +61,7 @@
 	voice = GetVoice()
 
 	//No need to update all of these procs if the guy is dead.
-	if(stat != DEAD && !in_stasis)
+	if(. && !in_stasis)
 
 		//Organs and blood
 		handle_organs()
@@ -100,8 +100,8 @@
 
 /mob/living/carbon/human/proc/handle_some_updates()
 	if(life_tick > 5 && timeofdeath && (timeofdeath < 5 || world.time - timeofdeath > 6000))	//We are long dead, or we're junk mobs spawned like the clowns on the clown shuttle
-		return 0
-	return 1
+		return FALSE
+	return TRUE
 
 /mob/living/carbon/human/breathe()
 	if(!in_stasis)

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/roachling.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/roachling.dm
@@ -15,11 +15,11 @@
 	meat_type = /obj/item/weapon/reagent_containers/food/snacks/meat/roachmeat
 	meat_amount = 1
 
-	var/amount_grown = 0
 	probability_egg_laying = 0
+	var/amount_grown = 0
 
 /mob/living/carbon/superior_animal/roach/roachling/Life()
-	..()
+	.=..()
 	if(!stat)
 		amount_grown += rand(0,2) // Roachling growing up
 

--- a/code/modules/mob/living/carbon/superior_animal/roach/types/support.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/types/support.dm
@@ -12,7 +12,7 @@
 	rarity_value = 11.25
 
 /mob/living/carbon/superior_animal/roach/support/New()
-	..()
+	.=..()
 	gas_sac = new /datum/reagents(100, src)
 
 /mob/living/carbon/superior_animal/roach/support/proc/gas_attack()

--- a/code/modules/mob/living/carbon/viruses.dm
+++ b/code/modules/mob/living/carbon/viruses.dm
@@ -1,5 +1,4 @@
 /mob/living/carbon/proc/handle_viruses()
-
 	if(status_flags & GODMODE)	return 0	//godmode
 
 	if(bodytemperature > 406)
@@ -7,7 +6,7 @@
 			var/datum/disease2/disease/V = virus2[ID]
 			V.cure(src)
 
-	if(life_tick % 3) //don't spam checks over all objects in view every tick.
+	if(life_tick % 3 && stat != DEAD) //don't spam checks over all objects in view every tick.
 		for(var/obj/effect/decal/cleanable/O in view(1,src))
 			if(istype(O,/obj/effect/decal/cleanable/blood))
 				var/obj/effect/decal/cleanable/blood/B = O

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -2,6 +2,7 @@
 	set invisibility = 0
 	set background = BACKGROUND_ENABLED
 
+	. = FALSE
 	..()
 	if(config.enable_mob_sleep)
 		if(life_cycles_before_scan > 0)
@@ -41,7 +42,7 @@
 			//Random events (vomiting etc)
 			handle_random_events()
 
-			. = 1
+			. = TRUE
 
 		//Handle temperature/pressure differences between body and environment
 		if(environment)

--- a/code/modules/mob/living/silicon/pai/life.dm
+++ b/code/modules/mob/living/silicon/pai/life.dm
@@ -1,6 +1,5 @@
 /mob/living/silicon/pai/Life()
-
-	if (src.stat == 2)
+	if (src.stat == DEAD)
 		return
 
 	if(src.cable)
@@ -13,10 +12,10 @@
 
 	handle_regular_hud_updates()
 
-	if(src.secHUD == 1)
+	if(src.secHUD)
 		process_sec_hud(src, 1)
 
-	if(src.medHUD == 1)
+	if(src.medHUD)
 		process_med_hud(src, 1)
 
 	if(silence_time)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -54,8 +54,8 @@
 	var/screen				// Which screen our main window displays
 	var/subscreen			// Which specific function of the main screen is being displayed
 
-	var/secHUD = 0			// Toggles whether the Security HUD is active or not
-	var/medHUD = 0			// Toggles whether the Medical  HUD is active or not
+	var/secHUD = FALSE			// Toggles whether the Security HUD is active or not
+	var/medHUD = FALSE			// Toggles whether the Medical  HUD is active or not
 
 	var/medical_cannotfind = 0
 	var/datum/data/record/medicalActive1		// Datacore record declarations for record software

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -169,16 +169,16 @@
 		to_chat(user, SPAN_WARNING("It looks wounded."))
 
 /mob/living/simple_animal/Life()
-	..()
+	.=..()
 
 	if(!stasis)
 
-		if(stat == DEAD)
-			return 0
+		if(!.)
+			return FALSE
 
 		if(health <= 0)
 			death()
-			return
+			return FALSE
 
 		if(health > maxHealth)
 			health = maxHealth
@@ -252,7 +252,7 @@
 					speak_audio()
 
 			if(incapacitated())
-				return 1
+				return TRUE
 
 			//Movement
 			turns_since_move++
@@ -266,7 +266,7 @@
 							step_glide(src, moving_to, DELAY2GLIDESIZE(0.5 SECONDS))
 							turns_since_move = 0
 
-	return 1
+	return TRUE
 
 /mob/living/simple_animal/proc/visible_emote(message)
 	if(islist(message))

--- a/code/modules/sanity/breakdown.dm
+++ b/code/modules/sanity/breakdown.dm
@@ -32,7 +32,7 @@
 	return !!name
 
 /datum/breakdown/proc/update()
-	if(finished || (duration && world.time > end_time))
+	if(finished || (duration && world.time > end_time) || holder.owner.stat == DEAD)
 		conclude()
 		return FALSE
 	return TRUE

--- a/code/modules/virus2/disease2.dm
+++ b/code/modules/virus2/disease2.dm
@@ -58,12 +58,12 @@
 				res |= picked.primitive_form
 	return res
 
-/datum/disease2/disease/proc/activate(var/mob/living/carbon/mob)
+/datum/disease2/disease/proc/activate(mob/living/carbon/mob)
 	if(dead)
 		cure(mob)
 		return
 
-	if(mob.stat == 2)
+	if(mob.stat == DEAD)
 		return
 	if(stage <= 1 && clicks == 0) 	// with a certain chance, the mob may become immune to the disease before it starts properly
 		if(prob(5))


### PR DESCRIPTION
## About The Pull Request

Ports https://github.com/discordia-space/CEV-Eris/pull/5642

This makes a lot of code stop running for dead mobs.

Bluespace entropy and individual objectives content has been stripped from this PR.

## Why It's Good For The Game

Optimizations! Also no more spamming deadchat with Herald.

## Changelog
```changelog Toriate
refactor: Ported mob optimizations from upstream. Breakdowns should now end on death.
```