### PR TITLE
Adds a range check for mech drill and clamp usage

### DIFF
--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -16,11 +16,10 @@
 	if(. && !carrying)
 
 		// OCCULUS EDIT: Range wasn't being checked...
+		// A clause has been inserted and the following code tabbed as a result.
 		if(!inrange)
 			to_chat(user, "You need to be adjacent to \the [target] to use the hydraulic clamp.")
 		else
-		// OCCULUS EDIT END
-
 			if(istype(target, /obj))
 				var/obj/O = target
 				if(O.buckled_mob)
@@ -49,7 +48,6 @@
 					carrying = O
 					owner.visible_message(SPAN_NOTICE("\The [owner] loads \the [O] into its cargo compartment."))
 
-
 			//attacking - Cannot be carrying something, cause then your clamp would be full
 			else if(istype(target,/mob/living))
 				var/mob/living/M = target
@@ -67,6 +65,7 @@
 					step_away(M, owner)
 					to_chat(user, "You push [target] out of the way.")
 					owner.visible_message("[owner] pushes [target] out of the way.")
+			// OCCULUS EDIT END
 
 /obj/item/mech_equipment/clamp/attack_self(var/mob/user)
 	. = ..()
@@ -268,11 +267,13 @@
 	. = ..()
 	if(.)
 
+
 		// OCCULUS EDIT: Range wasn't being checked...
+		// The following codeblock has been tabbed after this conditional.
+
 		if(!inrange)
 			to_chat(user, "You need to be adjacent to \the [target] to drill.")
 		else
-		// OCCULUS EDIT END
 
 			if(isobj(target))
 				var/obj/target_obj = target
@@ -350,8 +351,8 @@
 			else
 				to_chat(user, "You must stay still while the drill is engaged!")
 
-
 		return 1
+		// OCCULUS EDIT END
 
 /obj/item/mech_equipment/mounted_system/extinguisher
 	icon_state = "mech_exting"

--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -14,54 +14,59 @@
 	. = ..()
 
 	if(. && !carrying)
-		if(istype(target, /obj))
 
+		// OCCULUS EDIT: Range wasn't being checked...
+		if(!inrange)
+			to_chat(user, "You need to be adjacent to \the [target] to use the hydraulic clamp.")
+		else
+		// OCCULUS EDIT END
 
-			var/obj/O = target
-			if(O.buckled_mob)
-				return
-			if(locate(/mob/living) in O)
-				to_chat(user,"<span class='warning'>You can't load living things into the cargo compartment.</span>")
-				return
-
-			if(istype(target, /obj/structure/scrap))
-				owner.visible_message(SPAN_NOTICE("\The [owner] begins compressing \the [O] with \the [src]."))
-				if(do_after(owner, 20, O, 0, 1))
-					if(istype(O, /obj/structure/scrap))
-						var/obj/structure/scrap/S = O
-						S.make_cube()
-						owner.visible_message(SPAN_NOTICE("\The [owner] compresses \the [O] into a cube with \the [src]."))
-				return
-
-			if(O.anchored)
-				to_chat(user, "<span class='warning'>[target] is firmly secured.</span>")
-				return
-
-
-			owner.visible_message(SPAN_NOTICE("\The [owner] begins loading \the [O]."))
-			if(do_after(owner, 20, O, 0, 1))
-				O.forceMove(src)
-				carrying = O
-				owner.visible_message(SPAN_NOTICE("\The [owner] loads \the [O] into its cargo compartment."))
-
-
-		//attacking - Cannot be carrying something, cause then your clamp would be full
-		else if(istype(target,/mob/living))
-			var/mob/living/M = target
-			if(user.a_intent == I_HURT)
-				admin_attack_log(user, M, "attempted to clamp [M] with [src] ", "Was subject to a clamping attempt.", ", using \a [src], attempted to clamp")
-				owner.setClickCooldown(owner.arms ? owner.arms.action_delay * 3 : 30) //This is an inefficient use of your powers
-				if(prob(33))
-					owner.visible_message(SPAN_DANGER("[owner] swings its [src] in a wide arc at [target] but misses completely!"))
+			if(istype(target, /obj))
+				var/obj/O = target
+				if(O.buckled_mob)
 					return
-				M.attack_generic(owner, (owner.arms ? owner.arms.melee_damage * 1.5 : 0), "slammed") //Honestly you should not be able to do this without hands, but still
-				M.throw_at(get_edge_target_turf(owner ,owner.dir),5, 2)
-				to_chat(user, "<span class='warning'>You slam [target] with [src.name].</span>")
-				owner.visible_message(SPAN_DANGER("[owner] slams [target] with the hydraulic clamp."))
-			else
-				step_away(M, owner)
-				to_chat(user, "You push [target] out of the way.")
-				owner.visible_message("[owner] pushes [target] out of the way.")
+				if(locate(/mob/living) in O)
+					to_chat(user,"<span class='warning'>You can't load living things into the cargo compartment.</span>")
+					return
+
+				if(istype(target, /obj/structure/scrap))
+					owner.visible_message(SPAN_NOTICE("\The [owner] begins compressing \the [O] with \the [src]."))
+					if(do_after(owner, 20, O, 0, 1))
+						if(istype(O, /obj/structure/scrap))
+							var/obj/structure/scrap/S = O
+							S.make_cube()
+							owner.visible_message(SPAN_NOTICE("\The [owner] compresses \the [O] into a cube with \the [src]."))
+					return
+
+				if(O.anchored)
+					to_chat(user, "<span class='warning'>[target] is firmly secured.</span>")
+					return
+
+
+				owner.visible_message(SPAN_NOTICE("\The [owner] begins loading \the [O]."))
+				if(do_after(owner, 20, O, 0, 1))
+					O.forceMove(src)
+					carrying = O
+					owner.visible_message(SPAN_NOTICE("\The [owner] loads \the [O] into its cargo compartment."))
+
+
+			//attacking - Cannot be carrying something, cause then your clamp would be full
+			else if(istype(target,/mob/living))
+				var/mob/living/M = target
+				if(user.a_intent == I_HURT)
+					admin_attack_log(user, M, "attempted to clamp [M] with [src] ", "Was subject to a clamping attempt.", ", using \a [src], attempted to clamp")
+					owner.setClickCooldown(owner.arms ? owner.arms.action_delay * 3 : 30) //This is an inefficient use of your powers
+					if(prob(33))
+						owner.visible_message(SPAN_DANGER("[owner] swings its [src] in a wide arc at [target] but misses completely!"))
+						return
+					M.attack_generic(owner, (owner.arms ? owner.arms.melee_damage * 1.5 : 0), "slammed") //Honestly you should not be able to do this without hands, but still
+					M.throw_at(get_edge_target_turf(owner ,owner.dir),5, 2)
+					to_chat(user, "<span class='warning'>You slam [target] with [src.name].</span>")
+					owner.visible_message(SPAN_DANGER("[owner] slams [target] with the hydraulic clamp."))
+				else
+					step_away(M, owner)
+					to_chat(user, "You push [target] out of the way.")
+					owner.visible_message("[owner] pushes [target] out of the way.")
 
 /obj/item/mech_equipment/clamp/attack_self(var/mob/user)
 	. = ..()
@@ -262,81 +267,88 @@
 /obj/item/mech_equipment/drill/afterattack(var/atom/target, var/mob/living/user, var/inrange, var/params)
 	. = ..()
 	if(.)
-		if(isobj(target))
-			var/obj/target_obj = target
-			if(target_obj.unacidable)
-				return
-		if(istype(target,/obj/item/weapon/material/drill_head))
-			var/obj/item/weapon/material/drill_head/DH = target
-			if(drill_head)
-				owner.visible_message(SPAN_NOTICE("\The [owner] detaches the [drill_head] mounted on the [src]."))
-				drill_head.forceMove(owner.loc)
-			DH.forceMove(src)
-			drill_head = DH
-			owner.visible_message(SPAN_NOTICE("\The [owner] mounts the [drill_head] on the [src]."))
-			return
 
-		if(drill_head == null)
-			to_chat(user, SPAN_WARNING("Your drill doesn't have a head!"))
-			return
-
-		var/obj/item/weapon/cell/C = owner.get_cell()
-		if(istype(C))
-			C.use(active_power_use * CELLRATE)
-		playsound(src, 'sound/weapons/circsawhit.ogg', 50, 1)	// OCCULUS EDIT: More feedback for drilling
-		owner.visible_message("<span class='danger'>\The [owner] starts to drill \the [target]</span>", "<span class='warning'>You hear a large drill.</span>")
-
-		var/T = target.loc
-
-		//Better materials = faster drill!
-		var/delay = 20//max(5, 20 - drill_head.material.brute_armor)
-		owner.setClickCooldown(delay) //Don't spamclick!
-		if(do_after(owner, delay, target) && drill_head)
-			if(src == owner.selected_system)
-				if(drill_head.durability <= 0)
-					drill_head.shatter()
-					drill_head = null
-					return
-				if(istype(target, /turf/simulated/wall))
-					var/turf/simulated/wall/W = target
-					if(max(W.material.hardness, W.reinf_material ? W.reinf_material.hardness : 0) > drill_head.material.hardness)
-						to_chat(user, "<span class='warning'>\The [target] is too hard to drill through with this drill head.</span>")
-					target.ex_act(2)
-					drill_head.durability -= 1
-					log_and_message_admins("used [src] on the wall [W].", user, owner.loc)
-				else if(istype(target, /turf/simulated/mineral))
-					for(var/turf/simulated/mineral/M in range(target,1))
-						if(get_dir(owner,M)&owner.dir)
-							M.GetDrilled()
-							drill_head.durability -= 1
-				else if(istype(target, /turf/simulated/floor/asteroid))
-					for(var/turf/simulated/floor/asteroid/M in range(target,1))
-						if(get_dir(owner,M)&owner.dir)
-							M.gets_dug()
-							drill_head.durability -= 1
-				else if(target.loc == T)
-					target.ex_act(2)
-					drill_head.durability -= 1
-					log_and_message_admins("[src] used to drill [target].", user, owner.loc)
-
-
-
-
-				if(owner.hardpoints.len) //if this isn't true the drill should not be working to be fair
-					for(var/hardpoint in owner.hardpoints)
-						var/obj/item/I = owner.hardpoints[hardpoint]
-						if(!istype(I))
-							continue
-						var/obj/structure/ore_box/ore_box = locate(/obj/structure/ore_box) in I //clamps work, but anythin that contains an ore crate internally is valid
-						if(ore_box)
-							for(var/obj/item/weapon/ore/ore in range(T,1))
-								if(get_dir(owner,ore)&owner.dir)
-									ore.Move(ore_box)
-
-				playsound(src, 'sound/weapons/rapidslice.ogg', 50, 1) // OCCULUS EDIT: more impactful noise
-
+		// OCCULUS EDIT: Range wasn't being checked...
+		if(!inrange)
+			to_chat(user, "You need to be adjacent to \the [target] to drill.")
 		else
-			to_chat(user, "You must stay still while the drill is engaged!")
+		// OCCULUS EDIT END
+
+			if(isobj(target))
+				var/obj/target_obj = target
+				if(target_obj.unacidable)
+					return
+			if(istype(target,/obj/item/weapon/material/drill_head))
+				var/obj/item/weapon/material/drill_head/DH = target
+				if(drill_head)
+					owner.visible_message(SPAN_NOTICE("\The [owner] detaches the [drill_head] mounted on the [src]."))
+					drill_head.forceMove(owner.loc)
+				DH.forceMove(src)
+				drill_head = DH
+				owner.visible_message(SPAN_NOTICE("\The [owner] mounts the [drill_head] on the [src]."))
+				return
+
+			if(drill_head == null)
+				to_chat(user, SPAN_WARNING("Your drill doesn't have a head!"))
+				return
+
+			var/obj/item/weapon/cell/C = owner.get_cell()
+			if(istype(C))
+				C.use(active_power_use * CELLRATE)
+			playsound(src, 'sound/weapons/circsawhit.ogg', 50, 1)	// OCCULUS EDIT: More feedback for drilling
+			owner.visible_message("<span class='danger'>\The [owner] starts to drill \the [target]</span>", "<span class='warning'>You hear a large drill.</span>")
+
+			var/T = target.loc
+
+			//Better materials = faster drill!
+			var/delay = 20//max(5, 20 - drill_head.material.brute_armor)
+			owner.setClickCooldown(delay) //Don't spamclick!
+			if(do_after(owner, delay, target) && drill_head)
+				if(src == owner.selected_system)
+					if(drill_head.durability <= 0)
+						drill_head.shatter()
+						drill_head = null
+						return
+					if(istype(target, /turf/simulated/wall))
+						var/turf/simulated/wall/W = target
+						if(max(W.material.hardness, W.reinf_material ? W.reinf_material.hardness : 0) > drill_head.material.hardness)
+							to_chat(user, "<span class='warning'>\The [target] is too hard to drill through with this drill head.</span>")
+						target.ex_act(2)
+						drill_head.durability -= 1
+						log_and_message_admins("used [src] on the wall [W].", user, owner.loc)
+					else if(istype(target, /turf/simulated/mineral))
+						for(var/turf/simulated/mineral/M in range(target,1))
+							if(get_dir(owner,M)&owner.dir)
+								M.GetDrilled()
+								drill_head.durability -= 1
+					else if(istype(target, /turf/simulated/floor/asteroid))
+						for(var/turf/simulated/floor/asteroid/M in range(target,1))
+							if(get_dir(owner,M)&owner.dir)
+								M.gets_dug()
+								drill_head.durability -= 1
+					else if(target.loc == T)
+						target.ex_act(2)
+						drill_head.durability -= 1
+						log_and_message_admins("[src] used to drill [target].", user, owner.loc)
+
+
+
+
+					if(owner.hardpoints.len) //if this isn't true the drill should not be working to be fair
+						for(var/hardpoint in owner.hardpoints)
+							var/obj/item/I = owner.hardpoints[hardpoint]
+							if(!istype(I))
+								continue
+							var/obj/structure/ore_box/ore_box = locate(/obj/structure/ore_box) in I //clamps work, but anythin that contains an ore crate internally is valid
+							if(ore_box)
+								for(var/obj/item/weapon/ore/ore in range(T,1))
+									if(get_dir(owner,ore)&owner.dir)
+										ore.Move(ore_box)
+
+					playsound(src, 'sound/weapons/rapidslice.ogg', 50, 1) // OCCULUS EDIT: more impactful noise
+
+			else
+				to_chat(user, "You must stay still while the drill is engaged!")
 
 
 		return 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #206

Currently, mechs do not check if their target is in range when using the drill or the hydraulic clamp. It seems that a variable, inrange, was created and forgotten about. A check has been implemented and now mechs will only drill/clamp if they are actually adjacent to their target.

![image](https://user-images.githubusercontent.com/77511162/106970912-db8a8b80-671b-11eb-8b74-d5b821117040.png)
![image](https://user-images.githubusercontent.com/77511162/106970919-dfb6a900-671b-11eb-9650-7eb556780b29.png)
![image](https://user-images.githubusercontent.com/77511162/106970933-e3e2c680-671b-11eb-8e47-a2e20d66315c.png)
![image](https://user-images.githubusercontent.com/77511162/106970941-e6ddb700-671b-11eb-8837-af6a386a9ffa.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Quantum drilling and clamping is funny, but not intended

## Changelog
```changelog
fix: Mech drills and clamps no longer ignore range
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
