### PR TITLE
Commits crimes against humanity against the people of Serbai

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2840,6 +2840,7 @@
 #include "zzzz_modular_occulus\code\modules\mob\living\carbon\human\species\station.dm"
 #include "zzzz_modular_occulus\code\modules\mob\living\silicon\robot\inventory.dm"
 #include "zzzz_modular_occulus\code\modules\mob\living\simple_animal\hostile\nanoblob.dm"
+#include "zzzz_modular_occulus\code\modules\organs\external\subtypes\robotic _types.dm"
 #include "zzzz_modular_occulus\code\modules\projectiles\gun.dm"
 #include "zzzz_modular_occulus\code\modules\projectiles\gun_hud_actions.dm"
 #include "zzzz_modular_occulus\code\modules\projectiles\guns\energy\egun.dm"

--- a/zzzz_modular_occulus/code/modules/organs/external/subtypes/robotic _types.dm
+++ b/zzzz_modular_occulus/code/modules/organs/external/subtypes/robotic _types.dm
@@ -1,0 +1,5 @@
+/obj/item/organ/external/robotic/serbian
+	name = "\"Serbian Arms\""
+	desc = "Battle hardened green and brown prosthesis rebranded several times."
+	force_icon = 'icons/mob/human_races/cyberlimbs/serbian.dmi'
+	model = "serbian"


### PR DESCRIPTION

## About The Pull Request
As of 11:12 standard time, 2421, the minor country of Space Serbai was compeletely eradicated following a 12-minute war with Serbia, who claimed that Serbai's knockoff "Serbain Arms Prosthetics" was a violation of Space Trademark law The ensuing war completely annihilated the entire Serbain people, and Serbia proceeded to seize and re-brand all such Serbain Arms prosthetics and rebrand them. 

## Why It's Good For The Game
space serbians have told me this is the only way

## Changelog
```changelog

spellcheck: "Serbain Arms'" "prostetics" are now Serbian Arms' Prosthetics

```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
