### PR TITLE
Blattedin Fix

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2837,6 +2837,7 @@
 #include "zzzz_modular_occulus\code\modules\mining\ore.dm"
 #include "zzzz_modular_occulus\code\modules\mob\living\carbon\human\inventory.dm"
 #include "zzzz_modular_occulus\code\modules\mob\living\carbon\human\species\station.dm"
+#include "zzzz_modular_occulus\code\modules\mob\living\carbon\superior_animal\roach\blattedin.dm"
 #include "zzzz_modular_occulus\code\modules\mob\living\silicon\robot\inventory.dm"
 #include "zzzz_modular_occulus\code\modules\mob\living\simple_animal\hostile\nanoblob.dm"
 #include "zzzz_modular_occulus\code\modules\projectiles\gun.dm"

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -24,7 +24,7 @@
 		if(!loc)
 			return
 		var/datum/gas_mixture/environment = loc.return_air()
-
+		handle_chemicals_in_body() //Occulus edit - Allowing some chems to process on dead things.
 		if(stat != DEAD)
 			//Breathing, if applicable
 			handle_breathing()
@@ -33,7 +33,7 @@
 			handle_mutations_and_radiation()
 
 			//Chemicals in the body
-			handle_chemicals_in_body()
+			//handle_chemicals_in_body()Occulus edit - Allowing some chems to process on dead things. on_mob_life already checks if the target is dead and there is a flag for chems that work on dead things!
 
 			//Blood
 			handle_blood()

--- a/zzzz_modular_occulus/code/modules/mob/living/carbon/superior_animal/roach/blattedin.dm
+++ b/zzzz_modular_occulus/code/modules/mob/living/carbon/superior_animal/roach/blattedin.dm
@@ -1,0 +1,14 @@
+/datum/reagent/toxin/blattedin
+	affects_dead = 1
+
+/datum/reagent/toxin/blattedin/affect_touch(var/mob/living/carbon/M, var/alien, var/removed)
+	if(istype(M, /mob/living/carbon/superior_animal/roach))
+		var/mob/living/carbon/superior_animal/roach/bug = M
+		if(bug.stat == DEAD)
+			if((bug.blattedin_revives_left >= 0) && prob(70))//Roaches sometimes can come back to life from healing vapors
+				bug.blattedin_revives_left = max(0, bug.blattedin_revives_left - 1)
+				bug.rejuvenate()
+		else
+			bug.heal_organ_damage(heal_strength*removed)
+	else
+		.=..()


### PR DESCRIPTION
## About The Pull Request

Reagents can once again function on dead mobs. There is a flag in the reagents themselves that determines if it should or not.
Blattedin now revives roaches that come into contact with the blattedin clouds/smoke as originally intended.


## Why It's Good For The Game

Roach buffs! Specifically stuff that had been broken/bugged for a while!

## Changelog
```changelog
fix: chems now function on dead things. there is a flag that enables this. By default they do not.
tweak: Blattedin gas now respects the eris metabolism system. added on_touch proc to Blattedin. 
```