### PR TITLE
Blacklists the shellshock, unspaghettis leveraction sawing code

### DIFF
--- a/zzz_modular_syzygy/code/game/objects/items/NZR.dm
+++ b/zzz_modular_syzygy/code/game/objects/items/NZR.dm
@@ -42,6 +42,7 @@
 /obj/item/weapon/gun/energy/shrapnel
 	name = "NZR SDF \"Shellshock\" energy shotgun"
 	desc = "An Novozyme Republic Self Defence Force design, this mat-fab shotgun tends to burn through cells with use."
+	spawn_blacklisted = TRUE
 
 /obj/item/weapon/bluespace_harpoon/mounted/blitz
 	name = "NZR BSD \"Trident\""

--- a/zzz_modular_syzygy/levergun.dm
+++ b/zzz_modular_syzygy/levergun.dm
@@ -48,7 +48,7 @@
 	update_icon()
 
 /obj/item/weapon/gun/projectile/shotgun/leveraction/attackby(var/obj/item/A as obj, mob/user as mob)
-	if(QUALITY_SAWING in A.tool_qualities)
+	if(QUALITY_SAWING in A.tool_qualities && sawn_result)
 		to_chat(user, SPAN_NOTICE("You begin to shorten the barrel of \the [src]."))
 		if(A.use_tool(user, src, WORKTIME_FAST, QUALITY_SAWING, FAILCHANCE_NORMAL, required_stat = STAT_COG))
 			qdel(src)

--- a/zzz_modular_syzygy/levergun.dm
+++ b/zzz_modular_syzygy/levergun.dm
@@ -20,6 +20,7 @@
 	price_tag = 1000
 	recoil_buildup = 20
 	one_hand_penalty = 15 //full sized shotgun level
+	var/sawn_result = /obj/item/weapon/gun/projectile/shotgun/leveraction/sawn	//snowflake way to make this not hardcoded
 
 /obj/item/weapon/gun/projectile/shotgun/leveraction/consume_next_projectile()
 	if(chambered)
@@ -51,7 +52,8 @@
 		to_chat(user, SPAN_NOTICE("You begin to shorten the barrel of \the [src]."))
 		if(A.use_tool(user, src, WORKTIME_FAST, QUALITY_SAWING, FAILCHANCE_NORMAL, required_stat = STAT_COG))
 			qdel(src)
-			new /obj/item/weapon/gun/projectile/shotgun/leveraction/sawn(usr.loc)
+			var/thingy_that_gets_spawned_to_represent_the_thing_getting_sawed = new sawn_result(usr.loc)
+			user.put_in_hands(thingy_that_gets_spawned_to_represent_the_thing_getting_sawed)
 			to_chat(user, SPAN_WARNING("You shorten the barrel of \the [src]!"))
 	else
 		..()

--- a/zzz_modular_syzygy/sawnlevergun.dm
+++ b/zzz_modular_syzygy/sawnlevergun.dm
@@ -16,3 +16,4 @@
 	recoil_buildup = 1.4 //The sawn-off at least keeps the shoulder stock. This insane thing has a pistol grip!
 	one_hand_penalty = 10 //compact shotgun level
 	max_shells = 3	//one less shot due to shortened mag tube to go with the shortened barrel
+	sawn_result = null

--- a/zzzz_modular_occulus/code/modules/projectiles/guns/projectile/rifle/magnumlever.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/guns/projectile/rifle/magnumlever.dm
@@ -15,16 +15,7 @@
 	armor_penetration = 1.35 //A hair over 20 armor pen.
 	recoil_buildup = 20
 	one_hand_penalty = 15 //full sized shotgun level
-
-/obj/item/weapon/gun/projectile/shotgun/leveraction/magnum/attackby(var/obj/item/A as obj, mob/user as mob)
-	if(QUALITY_SAWING in A.tool_qualities)
-		to_chat(user, SPAN_NOTICE("You begin to shorten the barrel of \the [src]."))
-		if(A.use_tool(user, src, WORKTIME_FAST, QUALITY_SAWING, FAILCHANCE_NORMAL, required_stat = STAT_COG))
-			qdel(src)
-			new /obj/item/weapon/gun/projectile/shotgun/leveraction/sawn/magnum(usr.loc)
-			to_chat(user, SPAN_WARNING("You shorten the barrel of \the [src]!"))
-	else
-		..()
+	sawn_result = /obj/item/weapon/gun/projectile/shotgun/leveraction/sawn/magnum
 
 /datum/design/autolathe/gun/leveraction/magnum
 	name = "lever-action rifle"

--- a/zzzz_modular_occulus/code/modules/projectiles/guns/projectile/rifle/magnumleversawn.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/guns/projectile/rifle/magnumleversawn.dm
@@ -11,3 +11,4 @@
 	price_tag = 300	//becomes less valuable when you ruin it
 	damage_multiplier = 1 //34 damage, 6 or so less than the unsawn version.
 	armor_penetration = 1.05 //Around 15 armor penetration, less punchthrough because of the shorter barrel.
+	sawn_result = null


### PR DESCRIPTION
## About The Pull Request

Exactly what it says on the tin. Sawing off a lever action gun should now also deposit it directly into your hands.

## Why It's Good For The Game

Removing debug items and cleaning up jank is good!

## Changelog Toriate
```changelog
del: Removed the shellshock from the loot tables.
fix: Sawing off lever actions should be less janky now.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
