### PR TITLE
Changes self-harm breakdown to explicitly set flags

### DIFF
--- a/code/modules/sanity/breakdowns.dm
+++ b/code/modules/sanity/breakdowns.dm
@@ -203,11 +203,11 @@
 
 /datum/breakdown/negative/selfharm/occur()
 	spawn(delay)
-		holder.owner.suppress_communication = 1	// OCCULUS EDIT: was ++holder.owner.suppress_communication
+		holder.owner.suppress_communication = TRUE	// OCCULUS EDIT: was ++holder.owner.suppress_communication
 	return ..()
 
 /datum/breakdown/negative/selfharm/conclude()
-	holder.owner.suppress_communication = 0	// OCCULUS EDIT: was --holder.owner.suppress_communication
+	holder.owner.suppress_communication = FALSE	// OCCULUS EDIT: was --holder.owner.suppress_communication
 	..()
 
 

--- a/code/modules/sanity/breakdowns.dm
+++ b/code/modules/sanity/breakdowns.dm
@@ -203,11 +203,11 @@
 
 /datum/breakdown/negative/selfharm/occur()
 	spawn(delay)
-		++holder.owner.suppress_communication
+		holder.owner.suppress_communication = 1	// OCCULUS EDIT: was ++holder.owner.suppress_communication
 	return ..()
 
 /datum/breakdown/negative/selfharm/conclude()
-	--holder.owner.suppress_communication
+	holder.owner.suppress_communication = 0	// OCCULUS EDIT: was --holder.owner.suppress_communication
 	..()
 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

In a recent round, a player had an issue where they couldn't talk after the self-harm breakdown ended. It was discovered that their 'suppress_communication' flag was set to -1 rather than 0.

Inspecting the code, it seems that the self-harm breakdown, instead of setting 'suppress_communication' to 1 or 0, instead currently increments or decrements the flag with ++ and --. While this idea may be sound in theory, in practice, it's possible for the breakdown to conclude before it occurs, which left said player in a state where they couldn't communication between the flag was set to -1.

This change explicitly sets the communication suppression to 1 or 0 to avoid that situation.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Players who get lucky enough for a fast end to self-harm will no longer be at risk of permanent silence.

## Changelog
```changelog
fix: Self-harm breakdown can no longer accidentally cause permanent muteness
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
