### PR TITLE
Making adrenaline no longer useless

### DIFF
--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -208,7 +208,7 @@
 	M.add_chemical_effect(CE_PAINKILLER, 40)
 	M.stats.addTempStat(STAT_TGH, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "adrenaline")
 
-
+/////OCCULUS EDIT END
 
 /datum/reagent/water/holywater/touch_turf(turf/T)
 	if(volume >= 5)

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -202,11 +202,11 @@
 /datum/reagent/adrenaline/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.SetParalysis(0)
 	M.SetWeakened(0)
+	M.add_chemical_effect(CE_PULSE, 1)
+	M.add_chemical_effect(CE_PAINKILLER, 40)
 	M.stats.addTempStat(STAT_TGH, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "adrenaline")
-	M.adjustToxLoss(rand(3))
 
-/datum/reagent/adrenaline/withdrawal_act(mob/living/carbon/M)
-	M.adjustOxyLoss(15)
+
 
 /datum/reagent/water/holywater/touch_turf(turf/T)
 	if(volume >= 5)

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -199,10 +199,12 @@
 	color = "#C8A5DC"
 	reagent_type = "Organic/Stimulator"
 
+/////OCCULUS EDIT: oxy loss on withdrawal removed, random toxin damage removed, added mild painkilling and increased heart rate effects
+
 /datum/reagent/adrenaline/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	M.SetParalysis(0)
 	M.SetWeakened(0)
-	M.add_chemical_effect(CE_PULSE, 1)
+	M.add_chemical_effect(CE_PULSE, 2)
 	M.add_chemical_effect(CE_PAINKILLER, 40)
 	M.stats.addTempStat(STAT_TGH, STAT_LEVEL_ADEPT * effect_multiplier, STIM_TIME, "adrenaline")
 


### PR DESCRIPTION

## About The Pull Request

Adrenaline's toxin damage has been removed, the oxyloss on withdrawal has been removed, and it's been given mild painkilling effects and drastically raises heart rate like it actually should.

## Why It's Good For The Game

It makes adrenaline actually useful as a chem, and there have been certain situations I've encountered where something like it would be needed. Also makes it useful as a minor stim.

## Changelog
```changelog
add: Added small painkilling effect to adrenaline as well as increasing heart rate dramatically
del: Removed the constant toxin damage from adrenaline and suffocation damage on withdrawal
```
