### PR TITLE
Revert "5881" Reverts overpenetration issues caused by bad Eris code

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -76,7 +76,7 @@
 	var/recentwield = 0 // to prevent spammage
 	var/proj_step_multiplier = 1
 	var/list/proj_damage_adjust = list() //What additional damage do we give to the bullet. Type(string) -> Amount(int)
-	var/noricochet = FALSE // wether or not bullets fired from this gun can ricochet off of walls
+
 /obj/item/weapon/gun/get_item_cost(export)
 	if(export)
 		return ..() * 0.5 //Guns should be sold in the player market.
@@ -295,7 +295,6 @@
 		if(istype(projectile, /obj/item/projectile))
 			var/obj/item/projectile/P = projectile
 			P.adjust_damages(proj_damage_adjust)
-			P.adjust_ricochet(noricochet)
 
 		if(pointblank)
 			process_point_blank(projectile, user, target)

--- a/code/modules/projectiles/guns/projectile/revolver/sky_driver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver/sky_driver.dm
@@ -13,8 +13,7 @@
 	price_tag = 20000
 	damage_multiplier = 1.1 //because pistol round
 	penetration_multiplier = 20
-	pierce_multiplier = 5
+	pierce_multiplier =  5
 	recoil_buildup = 50
 	spawn_frequency = 0
 	spawn_blacklisted = TRUE
-	noricochet = TRUE

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -118,11 +118,6 @@
 			continue
 		damage_types[damage_type] += newdamages[damage_type]
 
-/obj/item/projectile/proc/adjust_ricochet(noricochet)
-	if(noricochet)
-		can_ricochet = FALSE
-		return
-
 /obj/item/projectile/proc/on_hit(atom/target, def_zone = null)
 	if(!isliving(target))	return 0
 	if(isanimal(target))	return 0

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -17,7 +17,7 @@
 		shake_camera(L, 1, 1, 0.5)
 
 /obj/item/projectile/bullet/attack_mob(var/mob/living/target_mob, distance, miss_modifier)
-	if(damage_types[BRUTE] > 20 && prob(damage_types[BRUTE]*penetrating))
+	if(penetrating > 0 && damage_types[BRUTE] > 20 && prob(damage_types[BRUTE]))
 		mob_passthrough_check = 1
 	else
 		var/obj/item/weapon/grab/G = locate() in target_mob
@@ -49,15 +49,15 @@
 	var/chance = 0
 	if(istype(A, /turf/simulated/wall))
 		var/turf/simulated/wall/W = A
-		chance = round(penetrating*damage/W.material.integrity*180)
+		chance = round(damage/W.material.integrity*180)
 	else if(istype(A, /obj/machinery/door))
 		var/obj/machinery/door/D = A
-		chance = round(penetrating*damage/D.maxhealth*180)
+		chance = round(damage/D.maxhealth*180)
 		if(D.glass) chance *= 2
 	else if(istype(A, /obj/structure/girder))
 		chance = 100
 	else if(istype(A, /obj/machinery) || istype(A, /obj/structure))
-		chance = damage*penetrating
+		chance = damage
 
 	if(prob(chance))
 		if(A.opacity)

--- a/code/modules/projectiles/projectile/bullettypes.dm
+++ b/code/modules/projectiles/projectile/bullettypes.dm
@@ -14,11 +14,11 @@ There are important things regarding this file:
 	damage_types = list(BRUTE = 28)
 	armor_penetration = 10
 	can_ricochet = TRUE
-	penetrating = 1
 
 /obj/item/projectile/bullet/pistol/hv
 	damage_types = list(BRUTE = 32)
 	armor_penetration = 20
+	penetrating = 1
 	step_delay = 0.75
 
 /obj/item/projectile/bullet/pistol/practice
@@ -48,7 +48,7 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/srifle
 	damage_types = list(BRUTE = 25)
 	armor_penetration = 25
-	penetrating = 1
+	penetrating = 2
 	can_ricochet = TRUE
 
 /obj/item/projectile/bullet/srifle/nomuzzle
@@ -66,6 +66,7 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/srifle/hv
 	damage_types = list(BRUTE = 30)
 	armor_penetration = 30
+	penetrating = 4
 	step_delay = 0.75
 
 /obj/item/projectile/bullet/srifle/rubber
@@ -100,6 +101,7 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/clrifle/hv
 	damage_types = list(BRUTE = 32)
 	armor_penetration = 20
+	penetrating = 2
 	step_delay = 0.75
 	can_ricochet = TRUE
 
@@ -135,6 +137,7 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/lrifle/hv
 	damage_types = list(BRUTE = 30)
 	armor_penetration = 30
+	penetrating = 2
 	step_delay = 0.75
 
 /obj/item/projectile/bullet/lrifle/rubber
@@ -153,7 +156,6 @@ There are important things regarding this file:
 	damage_types = list(BRUTE = 34)
 	armor_penetration = 15
 	can_ricochet = TRUE
-	penetrating = 1
 
 /obj/item/projectile/bullet/magnum/practice
 	name = "practice bullet"
@@ -167,6 +169,7 @@ There are important things regarding this file:
 /obj/item/projectile/bullet/magnum/hv
 	damage_types = list(BRUTE = 39)
 	armor_penetration = 20
+	penetrating = 1
 	step_delay = 0.75
 
 /obj/item/projectile/bullet/magnum/rubber
@@ -186,7 +189,7 @@ There are important things regarding this file:
 	armor_penetration = 50
 	stun = 3
 	weaken = 3
-	penetrating = 1
+	penetrating = 5
 	hitscan = TRUE //so the PTR isn't useless as a sniper weapon
 
 /obj/item/projectile/bullet/antim/scrap


### PR DESCRIPTION
This reverts commit 7b98b242329d938a42c63c5ec143333dd8dea780.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #233

Bad Eris code as part of an upstream pull in #193 seems to be causing silly amounts of overpenetration due to bad math -- Kallin has indicated that he will try to salvage 5881 but currently it is going to be reverted due to all ballistic ammo penetrating (issue was reported while using a Paco with .35 rubber ammo -- testing the revert using the same weapon and ammo did not see the overpenetration issue)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Reverts to old penetration code -- rubbers will no longer pierce through walls and hit welding tanks/other fun things

## Changelog
```changelog
del: Undoes Eris #5881 which was causing overpenetration of bullets that should not have penetration
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
