### PR TITLE
Prevent tracking of oil/blood/roachguts/etc if the source tile contains a catwalk or stairs

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -69,43 +69,61 @@ var/global/list/image/splatter_cache=list()
 /obj/effect/decal/cleanable/blood/Crossed(mob/living/carbon/human/perp)
 	if (!istype(perp))
 		return
+
+	///// OCCULUS EDIT: Don't track blood if the source has a catwalk or stairs, since it is
+	//                  difficult to spot and clean.
+
+	var/do_not_track = FALSE
+
+	if (perp.loc.contents)
+		for(var/content in perp.loc.contents)
+			if(istype(content,/obj/structure/catwalk) || istype(content,/obj/structure/multiz/stairs))
+				do_not_track = TRUE
+				amount = 0
+				break
+
 	if(amount < 1)
 		return
 
-	var/obj/item/organ/external/l_foot = perp.get_organ(BP_L_FOOT)
-	var/obj/item/organ/external/r_foot = perp.get_organ(BP_R_FOOT)
-	var/hasfeet = 1
-	if((!l_foot || l_foot.is_stump()) && (!r_foot || r_foot.is_stump()))
-		hasfeet = 0
-	if(perp.shoes && !perp.buckled)//Adding blood to shoes
-		var/obj/item/clothing/shoes/S = perp.shoes
-		if(istype(S))
-			S.blood_color = basecolor
-			S.track_blood = max(amount,S.track_blood)
-			if(!S.blood_overlay)
-				S.generate_blood_overlay()
-			if(!S.blood_DNA)
-				S.blood_DNA = list()
-				S.blood_overlay.color = basecolor
-				S.overlays += S.blood_overlay
-			if(S.blood_overlay && S.blood_overlay.color != basecolor)
-				S.blood_overlay.color = basecolor
-				S.overlays.Cut()
-				S.overlays += S.blood_overlay
-			S.blood_DNA |= blood_DNA.Copy()
+	if (!do_not_track)
 
-	else if (hasfeet)//Or feet
-		perp.feet_blood_color = basecolor
-		perp.track_blood = max(amount,perp.track_blood)
-		if(!perp.feet_blood_DNA)
-			perp.feet_blood_DNA = list()
-		perp.feet_blood_DNA |= blood_DNA.Copy()
-	else if (perp.buckled && istype(perp.buckled, /obj/structure/bed/chair/wheelchair))
-		var/obj/structure/bed/chair/wheelchair/W = perp.buckled
-		W.bloodiness = 4
+		var/obj/item/organ/external/l_foot = perp.get_organ(BP_L_FOOT)
+		var/obj/item/organ/external/r_foot = perp.get_organ(BP_R_FOOT)
+		var/hasfeet = 1
+		if((!l_foot || l_foot.is_stump()) && (!r_foot || r_foot.is_stump()))
+			hasfeet = 0
+		if(perp.shoes && !perp.buckled)//Adding blood to shoes
+			var/obj/item/clothing/shoes/S = perp.shoes
+			if(istype(S))
+				S.blood_color = basecolor
+				S.track_blood = max(amount,S.track_blood)
+				if(!S.blood_overlay)
+					S.generate_blood_overlay()
+				if(!S.blood_DNA)
+					S.blood_DNA = list()
+					S.blood_overlay.color = basecolor
+					S.overlays += S.blood_overlay
+				if(S.blood_overlay && S.blood_overlay.color != basecolor)
+					S.blood_overlay.color = basecolor
+					S.overlays.Cut()
+					S.overlays += S.blood_overlay
+				S.blood_DNA |= blood_DNA.Copy()
 
-	perp.update_inv_shoes(1)
-	amount--
+		else if (hasfeet)//Or feet
+			perp.feet_blood_color = basecolor
+			perp.track_blood = max(amount,perp.track_blood)
+			if(!perp.feet_blood_DNA)
+				perp.feet_blood_DNA = list()
+			perp.feet_blood_DNA |= blood_DNA.Copy()
+		else if (perp.buckled && istype(perp.buckled, /obj/structure/bed/chair/wheelchair))
+			var/obj/structure/bed/chair/wheelchair/W = perp.buckled
+			W.bloodiness = 4
+
+		perp.update_inv_shoes(1)
+
+		amount--
+
+	///// OCCULUS EDIT END
 
 /obj/effect/decal/cleanable/blood/proc/dry()
 	name = dryname


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The code that determines if you track footsteps after stepping in oil/blood/roachguts/etc has been modified to prevent any tracking if the turf containing the offending decal also contains a catwalk or stairs.

This is a non-modular change.

![image](https://user-images.githubusercontent.com/77511162/107481664-9071dd80-6b4c-11eb-9feb-4a61f772a959.png)

In the above image, the turf to my right contains both stairs and a gib that would normally cause tracks.

![image](https://user-images.githubusercontent.com/77511162/107481817-cc0ca780-6b4c-11eb-80e4-800f7b31d5e3.png)

In the above image, I moved through the tile square -- no blood was tracked.

![image](https://user-images.githubusercontent.com/77511162/107481849-d75fd300-6b4c-11eb-9f50-07a78319b0c5.png)

In the above image, I moved through a square that had gibs in it, and blood was tracked.

![image](https://user-images.githubusercontent.com/77511162/107481877-e3e42b80-6b4c-11eb-9999-11a28c8717fd.png)

In the above image, robot gibs were present in the catwalk square to my left.

![image](https://user-images.githubusercontent.com/77511162/107481922-f3637480-6b4c-11eb-8a3b-9c251c19ac31.png)

In the above image, oil was not tracked into the regular tiles because the new code prevented tracking since the source also contained a catwalk.

This code doesn't prevent gibs or blood from being spawned on tile or catwalk squares,

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The reason for this change is that it's very difficult to spot and clean gibs that are on staircases and catwalks, so the player shouldn't be punished by making tracks everywhere or having gross shoes.

The benefits to this are twofold:

1. There will be significantly less cases of bloody/oily/whatever tracks coming out of maintenance tunnels/staircases
2. The (probably) low population of clean freaks (like me) don't have to worry about constantly cleaning their shoes after stepping on gibs they could not see in maintenance/staircases

## Changelog
```changelog
tweak: Footprints no longer track if the tracking source also contains stairs or a catwalk
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
