### PR TITLE
Burn decal cobwebs with welding/cauterizing tools (like lighters)

### DIFF
--- a/zzzz_modular_occulus/code/game/objects/effects/decals/Cleanable/misc_occulus.dm
+++ b/zzzz_modular_occulus/code/game/objects/effects/decals/Cleanable/misc_occulus.dm
@@ -1,0 +1,9 @@
+/obj/effect/decal/cleanable/cobweb/attackby(obj/item/I, mob/user)
+    if((QUALITY_WELDING in I.tool_qualities) || (QUALITY_CAUTERIZING in I.tool_qualities))
+        to_chat(user, SPAN_NOTICE("You burn away the cobweb."))
+        clean_blood()
+
+/obj/effect/decal/cleanable/cobweb2/attackby(obj/item/I, mob/user)
+    if((QUALITY_WELDING in I.tool_qualities) || (QUALITY_CAUTERIZING in I.tool_qualities))
+        to_chat(user, SPAN_NOTICE("You burn away the cobweb."))
+        clean_blood()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This pull adds modular code to allow the decal cobwebs to be burned away with tools that have cauterizing (lighters) or welding qualities. This does not touch the cobwebs created by giant spiders.

Modular change: zzzz_modular_occulus/code/game/objects/effects/decals/Cleanable/misc_occulus.dm must be included

![image](https://user-images.githubusercontent.com/77511162/107486514-214bb780-6b53-11eb-95cb-0289efa858b5.png)
![image](https://user-images.githubusercontent.com/77511162/107486526-2577d500-6b53-11eb-9c17-b89958e47c61.png)
![image](https://user-images.githubusercontent.com/77511162/107486533-2a3c8900-6b53-11eb-887e-a63d3fead767.png)
![image](https://user-images.githubusercontent.com/77511162/107486549-2d377980-6b53-11eb-9596-6d151ab8b852.png)

I notice that cobweb and cobweb2 are different objects -- later on I will try to learn what I need to merge them together 

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

You can now burn away cobwebs with a lighter or welder or other tool with cauterizing/welding.

I ran into a cobweb on the server and I tried to burn it away with my Zippo. I could not. My immersion was broken

## Changelog
```changelog
add: Decal cobwebs can now be burnt away with cauterizing/welding tools (like lighters)
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
