### PR TITLE
Moves hypospray kits from contraband to regular list in MiniPharma Plus

### DIFF
--- a/zzzz_modular_occulus/code/game/machinery/vending.dm
+++ b/zzzz_modular_occulus/code/game/machinery/vending.dm
@@ -5,12 +5,32 @@
 	icon_deny = "med-deny"
 	req_access = list(access_medical_equip)
 	product_ads = "Go save some lives!;The best stuff for your medbay.;Only the finest tools.;Natural chemicals!;This stuff saves lives.;Don't you want some?;Ping!"
-	products = list(/obj/item/weapon/reagent_containers/glass/bottle/antitoxin = 4,/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline = 4,
-					/obj/item/weapon/reagent_containers/glass/bottle/stoxin = 4,/obj/item/weapon/reagent_containers/glass/bottle/toxin = 4,
-					/obj/item/weapon/reagent_containers/syringe/spaceacillin = 4,/obj/item/weapon/reagent_containers/syringe = 12,
-					/obj/item/device/scanner/health = 5,/obj/item/weapon/reagent_containers/glass/beaker = 4, /obj/item/weapon/reagent_containers/dropper = 2,
-					/obj/item/stack/medical/advanced/bruise_pack = 3, /obj/item/stack/medical/advanced/ointment = 3, /obj/item/stack/medical/splint = 2)
-	contraband = list(/obj/item/weapon/reagent_containers/pill/tox = 3, /obj/item/weapon/reagent_containers/pill/antitox = 6, /obj/item/weapon/reagent_containers/pill/stox = 4,/obj/item/weapon/storage/hypospraykit/regular = 2,
-					/obj/item/weapon/storage/hypospraykit/fire = 2,/obj/item/weapon/storage/hypospraykit/brute = 2, /obj/item/weapon/storage/hypospraykit/toxin = 2, /obj/item/weapon/storage/hypospraykit/o2 = 2)
+
+	products = list(
+					/obj/item/weapon/reagent_containers/glass/bottle/antitoxin = 4,
+					/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline = 4,
+					/obj/item/weapon/reagent_containers/glass/bottle/stoxin = 4,
+					/obj/item/weapon/reagent_containers/glass/bottle/toxin = 4,
+					/obj/item/weapon/reagent_containers/syringe/spaceacillin = 4,
+					/obj/item/weapon/reagent_containers/syringe = 12,
+					/obj/item/device/scanner/health = 5,
+					/obj/item/weapon/reagent_containers/glass/beaker = 4,
+					/obj/item/weapon/reagent_containers/dropper = 2,
+					/obj/item/stack/medical/advanced/bruise_pack = 3,
+					/obj/item/stack/medical/advanced/ointment = 3,
+					/obj/item/stack/medical/splint = 2,
+					/obj/item/weapon/storage/hypospraykit/regular = 2,
+					/obj/item/weapon/storage/hypospraykit/fire = 2,
+					/obj/item/weapon/storage/hypospraykit/brute = 2,
+					/obj/item/weapon/storage/hypospraykit/toxin = 2,
+					/obj/item/weapon/storage/hypospraykit/o2 = 2
+					)
+
+	contraband = list(
+					/obj/item/weapon/reagent_containers/pill/tox = 3,
+					/obj/item/weapon/reagent_containers/pill/antitox = 6,
+					/obj/item/weapon/reagent_containers/pill/stox = 4
+					)
+
 	idle_power_usage = 211 //refrigerator - believe it or not, this is actually the average power consumption of a refrigerated vending machine according to NRCan.
 	auto_price = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #241 

Rynn confirmed that hypospray kits being under the contraband list was not intentional and asked me to fix it for him since he was busy. I also cleaned up the list to be more readable.

![image](https://user-images.githubusercontent.com/77511162/107590813-1e92a600-6bd7-11eb-85f6-3d687eafa994.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Medical players can now vend hypospray kits without hacking the machine

## Changelog
```changelog
fix: MiniPharma Plus now vends hypospray kits without needing to be hacked
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
