### PR TITLE
Removed broken machine chance from old circuitboards

### DIFF
--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -174,7 +174,7 @@
 	.=..()
 	if(. && prob(75))
 		name = T_BOARD("unknown")
-		build_path = pick(/obj/machinery/washing_machine, /obj/machinery/broken, /obj/machinery/shower, /obj/machinery/holoposter, /obj/machinery/holosign)
+		build_path = pick(/obj/machinery/washing_machine, /obj/machinery/shower, /obj/machinery/holoposter, /obj/machinery/holosign) //Occulus Eris: Fixing yet another dumb eris design
 
 
 /obj/item/weapon/electronics/ai_module/make_old()
@@ -219,7 +219,7 @@
 /obj/item/weapon/electronics/ai_module/broken
 	name = "\improper broken core AI module"
 	desc = "broken Core AI Module: 'Reconfigures the AI's core laws.'"
-
+/* Occulus Edit - LELELELELE ISN'T GIBBING PEOPLE RANDOMLY FUNNY LEL:ELELELE. No. Fuck off.
 /obj/machinery/broken/Initialize()
 	..()
 	explosion(loc, 1, 2, 3, 3)
@@ -231,7 +231,7 @@
 
 /obj/machinery/broken/make_old()
 	return
-
+End Occulus Edit*/
 /obj/item/weapon/electronics/ai_module/broken/transmitInstructions(mob/living/silicon/ai/target, mob/sender)
 	..()
 	IonStorm(0)


### PR DESCRIPTION
## About The Pull Request

Removed instant-murder chance on unknown circuitboards that got snuck into the loot rework

## Why It's Good For The Game

Randomly blowing people up is fucking stupid.

## Changelog
```changelog
fix: dumb eris design philosophy wasting my time.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
