### PR TITLE
Adjusts EoTP

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2834,6 +2834,7 @@
 #include "zzzz_modular_occulus\code\modules\clothing\under\under.dm"
 #include "zzzz_modular_occulus\code\modules\clothing\under\jobs\medsci.dm"
 #include "zzzz_modular_occulus\code\modules\core_implant\cruciform\cruciform.dm"
+#include "zzzz_modular_occulus\code\modules\core_implant\cruciform\machinery\eotp.dm"
 #include "zzzz_modular_occulus\code\modules\core_implant\cruciform\rituals\base.dm"
 #include "zzzz_modular_occulus\code\modules\core_implant\cruciform\rituals\priest.dm"
 #include "zzzz_modular_occulus\code\modules\economy\power_cells.dm"

--- a/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -23,7 +23,7 @@ var/global/obj/machinery/power/eotp/eotp
 	idle_power_usage = 30
 	active_power_usage = 2500
 
-	var/list/rewards = list(ARMAMENTS, ODDITY, STAT_BUFF, MATERIAL_REWARD)	// OCCULUS EDIT - Disable the antag radar and positive breakdown rewards (ALERT and INSPIRATION deleted)
+	var/list/rewards = list(ARMAMENTS, ODDITY, STAT_BUFF, STAT_BUFF, STAT_BUFF, MATERIAL_REWARD)	// OCCULUS EDIT - Disable the antag radar and positive breakdown rewards (ALERT and INSPIRATION deleted)
 
 	var/list/materials = list(/obj/item/stack/material/gold = 60,
 							/obj/item/stack/material/uranium = 30,
@@ -180,12 +180,15 @@ var/global/obj/machinery/power/eotp/eotp
 					H.stats.addTempStat(random_stat, stat_buff_power, 20 MINUTES, "Eye_of_the_Protector")
 
 	else if(type_release == MATERIAL_REWARD)
+	//Occulus Edit - Nerfing material rewards
 		var/materials_reward = pick(materials)
-		var/reward_min_amount = materials[materials_reward]
+		var/materials_reward2 = pick(materials)
 		var/obj/item/stack/material/_item = new materials_reward(get_turf(src))
-		_item.amount = rand(reward_min_amount, _item.max_amount)
-		visible_message(SPAN_NOTICE("The [_item.name] appears in a flash of light near the [src]!"))	//OCCULUS EDIT - Typo fix, and some lore changing
-
+		var/obj/item/stack/material/_item2 = new materials_reward2(get_turf(src))
+		_item.amount = materials[materials_reward]
+		_item2.amount = materials[materials_reward2]
+		visible_message(SPAN_NOTICE("The [_item.name] appears in a flash of light near the [src]!"))
+	//Occulus Edit End
 	for(var/disciple in disciples)
 		to_chat(disciple, SPAN_NOTICE("A faint tingling sensation washes over you. Mekhane has bestowed a blessing upon his children. Check the [src] if you don't actually notice anything."))	//OCCULUS EDIT - Lore compliance change
 

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -42293,6 +42293,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/power/eotp,
 /turf/simulated/floor/plating,
 /area/eris/neotheology/bioreactor)
 "bTX" = (
@@ -54451,10 +54452,6 @@
 "cxA" = (
 /turf/simulated/wall,
 /area/eris/crew_quarters/barbackroom)
-"cxB" = (
-/obj/machinery/power/eotp,
-/turf/simulated/floor/tiled/dark/cargo,
-/area/eris/neotheology/chapelritualroom)
 "cxC" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/reinforced,
@@ -161456,7 +161453,7 @@ ccU
 byQ
 ccU
 cBm
-cxB
+cBm
 uly
 ccU
 ccU

--- a/zzzz_modular_occulus/code/game/objects/items/oddities.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/oddities.dm
@@ -19,10 +19,11 @@
 	name = "Mekhanite Seal"
 	desc = "An honorary badge given to the most devout of the Children of Mekhane."
 	oddity_stats = list(
-		STAT_COG = 6,
+		STAT_BIO = 6,
 		STAT_VIG = 6,
 		STAT_ROB = 4
-	)	// Nerf its stats to the ground
+	)// Nerf its stats to the ground
+	price_tag = 5000//price tag brought inline with secret doc value
 
 /obj/item/weapon/oddity/common/isometrics_lost
 	name = "greatest hits album"

--- a/zzzz_modular_occulus/code/modules/core_implant/cruciform/machinery/eotp.dm
+++ b/zzzz_modular_occulus/code/modules/core_implant/cruciform/machinery/eotp.dm
@@ -1,0 +1,6 @@
+/obj/machinery/power/eotp
+	materials = list(/obj/item/stack/material/gold = 10,
+							/obj/item/stack/material/phoron = 10,	// OCCULUS EDIT - REEEEE PLASMA/PHORON
+							/obj/item/stack/material/diamond = 10,
+							/obj/item/stack/material/plasteel = 30,
+							/obj/item/stack/material/silver = 10)


### PR DESCRIPTION
## About The Pull Request

EoTP now has triple the chance of granting a stat boon instead of another reward.
Material rewards for the EoTP have been reduced to sane levels. You now get two smaller stacks of materials.
Moved EoTP to the bioreactor.
Mekhanite Seals are now 5000cr instead of 8000cr, in line with secret documents.
Mekhanite Seals now give BIO instead of COG
EoTP no longer can give uranium at all, as none of the church recipes require it.

## Why It's Good For The Game

The EoTP has needed a bit of a nerf for a while now. Now it's a bit less rediculous.

## Changelog
```changelog
balance: Nerfed EoTP
map: Moved EoTP to the bioreactor
balance: Reduced value on Mek seals
balance: Changed Mek seals to BIO instead of COG
```