### PR TITLE
Adds autodoc machine

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2798,6 +2798,7 @@
 #include "zzzz_modular_occulus\code\game\jobs\job\medical.dm"
 #include "zzzz_modular_occulus\code\game\jobs\job\science.dm"
 #include "zzzz_modular_occulus\code\game\jobs\job\security.dm"
+#include "zzzz_modular_occulus\code\game\machinery\autodoc.dm"
 #include "zzzz_modular_occulus\code\game\machinery\jukebox.dm"
 #include "zzzz_modular_occulus\code\game\machinery\smartfridge.dm"
 #include "zzzz_modular_occulus\code\game\machinery\vending.dm"

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -78782,6 +78782,7 @@
 	pixel_y = 26
 	},
 /obj/machinery/camera/network/medbay,
+/obj/machinery/autodoc,
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/reception)
 "dCd" = (

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -49732,7 +49732,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
-/area/eris/medical/psych)
+/area/eris/medical/psych{
+	name = "\improper Autodoc Room"
+	})
 "clS" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -49763,7 +49765,9 @@
 	req_access = newlist()
 	},
 /turf/simulated/floor/tiled/white/cargo,
-/area/eris/medical/psych)
+/area/eris/medical/psych{
+	name = "\improper Autodoc Room"
+	})
 "clT" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -50575,7 +50579,9 @@
 	},
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
-/area/eris/medical/psych)
+/area/eris/medical/psych{
+	name = "\improper Autodoc Room"
+	})
 "cnO" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -52390,10 +52396,14 @@
 /area/eris/medical/medbay/uppercor)
 "csg" = (
 /turf/simulated/wall/r_wall,
-/area/eris/medical/psych)
+/area/eris/medical/psych{
+	name = "\improper Autodoc Room"
+	})
 "csh" = (
 /turf/simulated/wall,
-/area/eris/medical/psych)
+/area/eris/medical/psych{
+	name = "\improper Autodoc Room"
+	})
 "csi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -70159,7 +70169,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
-/area/eris/medical/psych)
+/area/eris/medical/psych{
+	name = "\improper Autodoc Room"
+	})
 "dii" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -70308,7 +70320,9 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white/gray_platform,
-/area/eris/medical/psych)
+/area/eris/medical/psych{
+	name = "\improper Autodoc Room"
+	})
 "diB" = (
 /obj/structure/sign/faction/moebius{
 	pixel_x = -32
@@ -76534,7 +76548,9 @@
 /obj/structure/bed/padded,
 /obj/item/weapon/bedsheet/medical,
 /turf/simulated/floor/tiled/white/gray_platform,
-/area/eris/medical/psych)
+/area/eris/medical/psych{
+	name = "\improper Autodoc Room"
+	})
 "dwD" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/firstaid/o2{
@@ -78968,6 +78984,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/landmark/join/start/psychiatrist,
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/patients_rooms)
 "dCw" = (
@@ -79732,7 +79749,9 @@
 	},
 /obj/structure/medical_stand,
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/psych)
+/area/eris/medical/psych{
+	name = "\improper Autodoc Room"
+	})
 "dEl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -79746,7 +79765,9 @@
 	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/psych)
+/area/eris/medical/psych{
+	name = "\improper Autodoc Room"
+	})
 "dEm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 2;
@@ -79773,7 +79794,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/psych)
+/area/eris/medical/psych{
+	name = "\improper Autodoc Room"
+	})
 "dEp" = (
 /obj/machinery/alarm{
 	pixel_y = 26
@@ -79782,7 +79805,9 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/psych)
+/area/eris/medical/psych{
+	name = "\improper Autodoc Room"
+	})
 "dEq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -79829,7 +79854,9 @@
 "dEz" = (
 /obj/machinery/autodoc,
 /turf/simulated/floor/tiled/white/gray_platform,
-/area/eris/medical/psych)
+/area/eris/medical/psych{
+	name = "\improper Autodoc Room"
+	})
 "dEA" = (
 /obj/structure/multiz/ladder/up,
 /turf/simulated/floor/tiled/techmaint,
@@ -79845,7 +79872,9 @@
 "dED" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
-/area/eris/medical/psych)
+/area/eris/medical/psych{
+	name = "\improper Autodoc Room"
+	})
 "dEE" = (
 /obj/machinery/atmospherics/pipe/zpipe/up,
 /obj/structure/disposalpipe/up{
@@ -86555,10 +86584,10 @@
 /obj/machinery/firealarm{
 	pixel_y = 28
 	},
-/obj/item/seeds/random,
 /obj/item/weapon/paper{
 	name = "Seed Alien1 Growth Stage Value:"
 	},
+/obj/structure/closet/secure_closet/personal/agrolyte,
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics)
 "dUE" = (

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -49742,10 +49742,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/medical{
-	name = "Psychology Cabinet";
-	req_one_access = list(5)
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -49753,6 +49749,19 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "Medical_Psych";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
+/obj/machinery/door/airlock/glass_medical{
+	id_tag = "MedbayFoyer";
+	name = "Autodoc Bay";
+	req_access = newlist()
+	},
 /turf/simulated/floor/tiled/white/cargo,
 /area/eris/medical/psych)
 "clT" = (
@@ -50556,7 +50565,14 @@
 	},
 /area/eris/engineering/engine_room)
 "cnN" = (
-/obj/machinery/door/firedoor,
+/obj/machinery/door/blast/shutters{
+	density = 0;
+	dir = 2;
+	icon_state = "shutter0";
+	id = "Medical_Psych";
+	name = "Privacy Shutters";
+	opacity = 0
+	},
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
 /area/eris/medical/psych)
@@ -70133,7 +70149,16 @@
 	name = "AI Upload Foyer"
 	})
 "dih" = (
-/turf/simulated/floor/wood,
+/obj/structure/table/standard,
+/obj/spawner/medical,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
 /area/eris/medical/psych)
 "dii" = (
 /obj/structure/cable/green{
@@ -70232,9 +70257,11 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/medbay)
 "dis" = (
-/obj/structure/closet/secure_closet/personal/patient,
-/turf/simulated/floor/wood,
-/area/eris/medical/psych)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/brown_perforated,
+/area/eris/medical/medbreak)
 "dit" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawn,
@@ -70275,7 +70302,12 @@
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/eris/hallway/side/atmosphericshallway)
 "diA" = (
-/turf/simulated/floor/carpet,
+/obj/structure/table/standard,
+/obj/spawner/medical,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white/gray_platform,
 /area/eris/medical/psych)
 "diB" = (
 /obj/structure/sign/faction/moebius{
@@ -74520,10 +74552,17 @@
 	desc = "A remote control switch.";
 	id = "MedbayExam";
 	name = "Examination Door Control";
+	pixel_x = -6;
 	pixel_y = -24
 	},
 /obj/structure/table/standard,
 /obj/item/weapon/paper_bin,
+/obj/machinery/button/remote/blast_door{
+	id = "Medical_Psych";
+	name = "Autodoc Shutters";
+	pixel_x = 6;
+	pixel_y = -24
+	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/reception)
 "dse" = (
@@ -75396,10 +75435,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
-"dun" = (
-/obj/structure/table/woodentable,
-/turf/simulated/floor/carpet,
-/area/eris/medical/psych)
 "duo" = (
 /turf/simulated/open,
 /area/eris/medical/morgue)
@@ -76496,10 +76531,9 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/command/bridge)
 "dwC" = (
-/obj/structure/bed/chair/comfy/brown{
-	dir = 1
-	},
-/turf/simulated/floor/carpet,
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet/medical,
+/turf/simulated/floor/tiled/white/gray_platform,
 /area/eris/medical/psych)
 "dwD" = (
 /obj/structure/table/standard,
@@ -76788,14 +76822,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3port)
-"dxo" = (
-/obj/machinery/button/remote/blast_door{
-	id = "Medical_Psych";
-	name = "Privacy Shutters";
-	pixel_y = -25
-	},
-/turf/simulated/floor/wood,
-/area/eris/medical/psych)
 "dxp" = (
 /obj/machinery/camera/network/third_section{
 	dir = 4
@@ -78190,10 +78216,6 @@
 /obj/spawner/scrap/dense/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck1port)
-"dAK" = (
-/obj/structure/bed/chair/comfy/brown,
-/turf/simulated/floor/wood,
-/area/eris/medical/psych)
 "dAL" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/requests_console{
@@ -78211,12 +78233,6 @@
 	},
 /turf/simulated/floor/hull,
 /area/space)
-"dAN" = (
-/obj/structure/table/woodentable,
-/obj/item/weapon/paper_bin,
-/obj/item/weapon/pen,
-/turf/simulated/floor/carpet,
-/area/eris/medical/psych)
 "dAO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 1;
@@ -78782,7 +78798,6 @@
 	pixel_y = 26
 	},
 /obj/machinery/camera/network/medbay,
-/obj/machinery/autodoc,
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/reception)
 "dCd" = (
@@ -79613,7 +79628,6 @@
 /area/eris/command/bridge)
 "dDZ" = (
 /obj/structure/table/standard,
-/obj/spawner/medical,
 /obj/machinery/light,
 /obj/item/weapon/access_update_tool,
 /turf/simulated/floor/tiled/white,
@@ -79707,21 +79721,31 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "West APC";
+	pixel_x = -28
+	},
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/medical_stand,
+/turf/simulated/floor/tiled/white,
 /area/eris/medical/psych)
 "dEl" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/wood,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/white,
 /area/eris/medical/psych)
 "dEm" = (
 /obj/structure/disposalpipe/segment{
@@ -79748,14 +79772,16 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/wood,
+/turf/simulated/floor/tiled/white,
 /area/eris/medical/psych)
 "dEp" = (
-/obj/structure/bed/psych,
 /obj/machinery/alarm{
 	pixel_y = 26
 	},
-/turf/simulated/floor/wood,
+/obj/machinery/camera/network/medbay{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/white,
 /area/eris/medical/psych)
 "dEq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -79790,24 +79816,6 @@
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/eris/engineering/foyer)
-"dEv" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/eris/medical/medbreak)
-"dEw" = (
-/obj/structure/closet/cabinet,
-/obj/spawner/booze,
-/obj/spawner/booze,
-/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
-/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
-	},
-/turf/simulated/floor/wood,
-/area/eris/medical/psych)
 "dEx" = (
 /obj/structure/multiz/ladder/up,
 /obj/machinery/camera/network/engineering{
@@ -79819,12 +79827,8 @@
 /turf/simulated/wall/r_wall,
 /area/eris/maintenance/section4deck2port)
 "dEz" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/carpet,
+/obj/machinery/autodoc,
+/turf/simulated/floor/tiled/white/gray_platform,
 /area/eris/medical/psych)
 "dEA" = (
 /obj/structure/multiz/ladder/up,
@@ -79838,27 +79842,9 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2port)
-"dEC" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "West APC";
-	pixel_x = -28
-	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/wood,
-/area/eris/medical/psych)
 "dED" = (
-/obj/structure/table/woodentable,
-/obj/item/device/lighting/toggleable/lamp/green,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/turf/simulated/floor/carpet,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating,
 /area/eris/medical/psych)
 "dEE" = (
 /obj/machinery/atmospherics/pipe/zpipe/up,
@@ -79876,12 +79862,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2port)
-"dEF" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/wood,
-/area/eris/medical/psych)
 "dEG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -79944,12 +79924,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/medical/morgue)
-"dEO" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/eris/medical/psych)
 "dEP" = (
 /obj/machinery/light{
 	dir = 1
@@ -86581,7 +86555,6 @@
 /obj/machinery/firealarm{
 	pixel_y = 28
 	},
-/obj/structure/closet/secure_closet/personal/agrolyte,
 /obj/item/seeds/random,
 /obj/item/weapon/paper{
 	name = "Seed Alien1 Growth Stage Value:"
@@ -100926,12 +100899,6 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/patients_rooms)
-"eBs" = (
-/obj/machinery/camera/network/medbay{
-	dir = 8
-	},
-/turf/simulated/floor/wood,
-/area/eris/medical/psych)
 "eBt" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -103603,7 +103570,6 @@
 /area/eris/engineering/atmos)
 "fJM" = (
 /obj/structure/table/standard,
-/obj/spawner/medical,
 /obj/machinery/vending/wallmed/lobby{
 	pixel_y = -28
 	},
@@ -104349,34 +104315,8 @@
 	pixel_x = -24;
 	req_access = list(38)
 	},
-/obj/item/weapon/caution{
-	name = "Caution Sign"
-	},
-/obj/item/weapon/caution{
-	name = "Caution Sign"
-	},
-/obj/item/weapon/caution{
-	name = "Caution Sign"
-	},
-/obj/item/weapon/caution{
-	name = "Caution Sign"
-	},
-/obj/item/weapon/caution{
-	name = "Caution Sign"
-	},
-/obj/spawner/contraband/low_chance,
-/obj/spawner/boxes,
-/obj/spawner/boxes,
-/obj/spawner/boxes/low_chance,
-/obj/spawner/boxes/low_chance,
-/obj/spawner/boxes/low_chance,
-/obj/spawner/boxes/low_chance,
-/obj/structure/railing/grey{
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/steel/cargo,
-/area/eris/quartermaster/hangarsupply)
+/turf/simulated/floor/tiled/dark,
+/area/eris/hallway/side/morguehallway)
 "jtf" = (
 /obj/structure/table/standard,
 /obj/machinery/chem_heater,
@@ -205683,7 +205623,7 @@ dDD
 eBr
 cgB
 dAD
-dEv
+dAx
 dDO
 duo
 duo
@@ -205884,8 +205824,8 @@ dCZ
 cGk
 cKs
 cgB
-cgB
-cgB
+dAD
+dis
 cgB
 duo
 bmx
@@ -206086,11 +206026,11 @@ cjx
 chG
 csm
 csh
-dis
-dEw
 csh
 csh
-csg
+csh
+bnl
+bmx
 abF
 aaa
 aaa
@@ -206287,12 +206227,12 @@ cqJ
 cpR
 dCo
 dDW
-csh
+cnN
 dEk
 dih
-dEC
-dEO
-csg
+dED
+abF
+abF
 abF
 abF
 aaa
@@ -206493,8 +206433,8 @@ clS
 dEl
 dEz
 dED
-diA
-cnN
+abF
+abF
 abF
 abF
 aaa
@@ -206694,9 +206634,9 @@ coS
 clR
 dEo
 diA
-dAN
-dwC
-cnN
+dED
+abF
+abF
 abF
 abF
 aaa
@@ -206895,10 +206835,10 @@ coS
 dDZ
 csh
 dEp
-diA
-dun
-diA
-cnN
+dwC
+dED
+abF
+abF
 abF
 abF
 aaa
@@ -207096,11 +207036,11 @@ cpR
 coS
 fJM
 csh
-dAK
-eBs
-dEF
-dxo
 csg
+csg
+csg
+abF
+abF
 abF
 abF
 aaa
@@ -207301,9 +207241,9 @@ csg
 csg
 csg
 csg
-csg
-csg
 aae
+aae
+abF
 abF
 duu
 duu

--- a/zzzz_modular_occulus/code/game/machinery/autodoc.dm
+++ b/zzzz_modular_occulus/code/game/machinery/autodoc.dm
@@ -18,11 +18,12 @@
 	autodoc_processor.holder = src
 	autodoc_processor.damage_heal_amount = 20
 
-
 /obj/machinery/autodoc/relaymove(mob/user)
 	if (user.stat)
 		return
 	src.go_out()
+	add_fingerprint(usr)
+	autodoc_processor.login()
 	return
 
 /obj/machinery/autodoc/attackby(obj/item/I, mob/living/user)
@@ -78,6 +79,9 @@
 	update_icon()
 
 /obj/machinery/autodoc/proc/set_occupant(var/mob/living/L)
+	autodoc_processor = new/datum/autodoc/capitalist_autodoc()
+	autodoc_processor.holder = src
+	autodoc_processor.damage_heal_amount = 20
 	L.forceMove(src)
 	src.occupant = L
 	src.add_fingerprint(usr)
@@ -125,7 +129,7 @@
 	update_icon()
 	return
 
-/obj/machinery/autodoc/verb/ativate_autodoc() //Allows the user to bring up the UI
+/obj/machinery/autodoc/verb/activate_autodoc() //Allows the user to bring up the UI
 	set name = "Activate Autodoc"
 	set category = "Object"
 	set src in view(0)

--- a/zzzz_modular_occulus/code/game/machinery/autodoc.dm
+++ b/zzzz_modular_occulus/code/game/machinery/autodoc.dm
@@ -1,0 +1,157 @@
+/obj/machinery/autodoc
+	name = "Autodoc"
+	icon = 'icons/obj/autodoc.dmi'
+	icon_state = "powered_off"
+	density = TRUE
+	anchored = TRUE
+//	circuit = /obj/item/weapon/electronics/circuitboard/autodoc
+	use_power = IDLE_POWER_USE
+	idle_power_usage = 60
+	active_power_usage = 10000
+	var/mob/living/carbon/occupant
+	var/datum/autodoc/capitalist_autodoc/autodoc_processor
+	var/locked
+
+/obj/machinery/autodoc/New()
+	. = ..()
+	autodoc_processor = new/datum/autodoc/capitalist_autodoc()
+	autodoc_processor.holder = src
+	autodoc_processor.damage_heal_amount = 20
+
+
+/obj/machinery/autodoc/relaymove(mob/user)
+	if (user.stat)
+		return
+	src.go_out()
+	return
+
+/obj/machinery/autodoc/attackby(obj/item/I, mob/living/user)
+	if(default_deconstruction(I, user))
+		return
+	if(default_part_replacement(I, user))
+		return
+	..()
+
+/obj/machinery/autodoc/verb/eject()
+	set src in view(1)
+	set category = "Object"
+	set name = "Eject Autodoc"
+
+	if (usr.incapacitated())
+		return
+	src.go_out()
+	add_fingerprint(usr)
+	autodoc_processor.login()
+	return
+
+/obj/machinery/autodoc/verb/move_inside()
+	set src in view(1)
+	set category = "Object"
+	set name = "Enter Autodoc"
+
+	if(usr.stat)
+		return
+	if(src.occupant)
+		to_chat(usr, SPAN_WARNING("The autodoc is already occupied!"))
+		return
+	if(usr.abiotic())
+		to_chat(usr, SPAN_WARNING("The subject cannot have abiotic items on."))
+		return
+	set_occupant(usr)
+	src.add_fingerprint(usr)
+	return
+
+/obj/machinery/autodoc/proc/go_out()
+	if (!occupant || locked)
+		return
+	if(autodoc_processor.active)
+		to_chat(usr, SPAN_WARNING("Autodoc is locked down! Abort all oberations if you need to go out or wait until all operations would be done."))
+		return
+	for(var/obj/O in src)
+		O.forceMove(loc)
+	occupant.forceMove(loc)
+	occupant.reset_view()
+	occupant.unset_machine()
+	occupant = null
+	autodoc_processor.set_patient(null)
+	update_use_power(1)
+	update_icon()
+
+/obj/machinery/autodoc/proc/set_occupant(var/mob/living/L)
+	L.forceMove(src)
+	src.occupant = L
+	src.add_fingerprint(usr)
+	if(!(stat & (NOPOWER|BROKEN)))
+		autodoc_processor.set_patient(L)
+		ui_interact(L)
+		update_use_power(2)
+		L.set_machine(src)
+	update_icon()
+
+/obj/machinery/autodoc/affect_grab(var/mob/user, var/mob/target)
+	if (src.occupant)
+		to_chat(user, SPAN_NOTICE("The autodoc is already occupied!"))
+		return
+	if(target.buckled)
+		to_chat(user, SPAN_NOTICE("Unbuckle the subject before attempting to move them."))
+		return
+	if(target.abiotic())
+		to_chat(user, SPAN_NOTICE("Subject cannot have abiotic items on."))
+		return
+	set_occupant(target)
+	src.add_fingerprint(user)
+	return TRUE
+
+/obj/machinery/autodoc/MouseDrop_T(var/mob/target, var/mob/user)
+	if(!ismob(target))
+		return
+	if (src.occupant)
+		to_chat(user, SPAN_WARNING("The autodoc is already occupied!"))
+		return
+	if (target.abiotic())
+		to_chat(user, SPAN_WARNING("Subject cannot have abiotic items on."))
+		return
+	if (target.buckled)
+		to_chat(user, SPAN_NOTICE("Unbuckle the subject before attempting to move them."))
+		return
+	user.visible_message(
+		SPAN_NOTICE("\The [user] begins placing \the [target] into \the [src]."),
+		SPAN_NOTICE("You start placing \the [target] into \the [src].")
+	)
+	if(!do_after(user, 30, src) || !Adjacent(target))
+		return
+	set_occupant(target)
+	src.add_fingerprint(user)
+	update_icon()
+	return
+
+/obj/machinery/autodoc/verb/ativate_autodoc() //Allows the user to bring up the UI
+	set name = "Activate Autodoc"
+	set category = "Object"
+	set src in view(0)
+	if(stat & (NOPOWER|BROKEN))
+		return
+	if(occupant)
+		ui_interact(occupant)
+
+/obj/machinery/autodoc/Process()
+	if(stat & (NOPOWER|BROKEN))
+		autodoc_processor.stop()
+		return
+	if(occupant)
+		locked = autodoc_processor.active
+	update_icon()
+
+/obj/machinery/autodoc/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = NANOUI_FORCE_OPEN, var/datum/topic_state/state = GLOB.default_state)
+	autodoc_processor.ui_interact(user, ui_key, ui, force_open, state)
+
+/obj/machinery/autodoc/Topic(href, href_list)
+	return autodoc_processor.Topic(href, href_list)
+
+/obj/machinery/autodoc/update_icon()
+	if(stat & (NOPOWER|BROKEN) || !occupant)
+		icon_state = "powered_off"
+	else
+		icon_state = "powered_on"
+	if(autodoc_processor.active)
+		icon_state = "active"


### PR DESCRIPTION
## About The Pull Request

This PR re-enables and fixes the autodoc machinery in code

Costs, directly identical to commercial hardsuit autodoc modules
#define AUTODOC_SCAN_COST           200
#define AUTODOC_DAMAGE_COST         800 (per 20 damage)
#define AUTODOC_EMBED_OBJECT_COST	1000 ((NOT CURRENTLY FUNCTIONAL. APPEARS BUGGED))
#define AUTODOC_FRACTURE_COST       1200
#define AUTODOC_IB_COST				1200 (per 10% blood)
#define AUTODOC_OPEN_WOUNDS_COST    600
#define AUTODOC_BLOOD_COST          800
#define AUTODOC_TOXIN_COST			600
#define AUTODOC_DIALYSIS_COST		1000

## Why It's Good For The Game

Adds a stationary autodoc in medical for lowpop rounds. The procedures are fairly expensive and quite slow, so it's difficult for anyone to simply spam. But in a pinch it can save you from certain death via a broken rib or the like. 

Functionally identical to a Commercial Hardsuit Autodoc.

## Changelog
```changelog
add: stationary autodoc in medical
```