### PR TITLE
Fix and tweak to roach reviving

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/roach/blattedin.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/blattedin.dm
@@ -11,15 +11,16 @@
 
 	heating_point = T0C + 260
 	heating_products = list("carbon", "protein")
-
+/* Occulus Edit: Removes processing revives (touch-based revive in modular folder)
 /datum/reagent/toxin/blattedin/affect_blood(var/mob/living/carbon/M, var/alien, var/removed)
 	if(istype(M, /mob/living/carbon/superior_animal/roach))
 		var/mob/living/carbon/superior_animal/roach/bug = M
 		if(bug.stat == DEAD)
-			if((bug.blattedin_revives_left >= 0) && prob(70))//Roaches sometimes can come back to life from healing vapors
+			if((bug.blattedin_revives_left > 0) && prob(70))//Roaches sometimes can come back to life from healing vapors
 				bug.blattedin_revives_left = max(0, bug.blattedin_revives_left - 1)
 				bug.rejuvenate()
 		else
 			bug.heal_organ_damage(heal_strength*removed)
 	else
 		.=..()
+*/

--- a/zzzz_modular_occulus/code/modules/mob/living/carbon/superior_animal/roach/blattedin.dm
+++ b/zzzz_modular_occulus/code/modules/mob/living/carbon/superior_animal/roach/blattedin.dm
@@ -5,7 +5,7 @@
 	if(istype(M, /mob/living/carbon/superior_animal/roach))
 		var/mob/living/carbon/superior_animal/roach/bug = M
 		if(bug.stat == DEAD)
-			if((bug.blattedin_revives_left >= 0) && prob(70))//Roaches sometimes can come back to life from healing vapors
+			if((bug.blattedin_revives_left > 0) && prob(70))//Roaches sometimes can come back to life from healing vapors
 				bug.blattedin_revives_left = max(0, bug.blattedin_revives_left - 1)
 				bug.rejuvenate()
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes roaches reviving when their revives left is at 0, as well as removes the affect_blood, so that only affect_touch revives them

## Why It's Good For The Game

Bugfix, as well as making roach revives less unpredictable

## Changelog
```changelog
del: Roaches no longer revive from blattedin in the bloodstream, only direct contact
fix:  Roaches no longer revive when their blattedin_revives_left is 0
```

Related emojiocracy: https://discord.com/channels/777375833084919839/777989657064636463/810189692938616832