### PR TITLE
Fixes code to check for coverage while injecting

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1361,13 +1361,27 @@ var/list/rank_prefix = list(\
 				if(head && head.item_flags & THICKMATERIAL)
 					. = 0
 			else
-				if(wear_suit && wear_suit.item_flags & THICKMATERIAL)
-					. = 0
+
+				///// OCCULUS EDIT START
+				// Fix injection code to not just check the 'wear_suit' variable
+				// Code partially hijacked from the armor protection methods
+
+				var/list/protective_gear = list(wear_suit, w_uniform, gloves, shoes)
+
+				for(var/gear in protective_gear)
+					if(gear && istype(gear ,/obj/item/clothing))
+						var/obj/item/clothing/C = gear
+						if(istype(C) && C.body_parts_covered & affecting.body_part)
+							if(C.item_flags & THICKMATERIAL)
+								. = 0
+
+				///// OCCULUS EDIT END
+
 	if(!. && error_msg && user)
 		if(BP_IS_LIFELIKE(affecting) && user.stats.getStat(STAT_BIO) < STAT_LEVEL_BASIC)
 			fail_msg = "Skin is tough and inelastic."
 		else if(!fail_msg)
-			fail_msg = "There is no exposed flesh or thin material [target_zone == BP_HEAD ? "on their head" : "on their body"] to inject into."
+			fail_msg = "There is no exposed flesh or thin material [target_zone == BP_HEAD ? "on their head" : "on that body part"] to inject into."	// OCCULUS EDIT: Be more clear about the failure
 		to_chat(user, SPAN_WARNING(fail_msg))
 
 /mob/living/carbon/human/print_flavor_text(var/shrink = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #40

Currently, any armor with the THICKMATERIAL flag worn on the suit slot will prevent syringe injections into any part of the body. This is due to the code only checking the worn suit slot for THICKMATERIAL rather than the body part you're trying to inject into.

This was solved by hijacking some code that determines armor coverage and modifying it to test for THICKMATERIAL presence. If there's no THICKMATERIAL flag, you can inject!

Testing log:

Test subject: Wearing /obj/item/clothing/suit/armor/vest (armor vest with THICKMATERIAL tag, covers upper and lower torso)

![image](https://user-images.githubusercontent.com/77511162/107882523-d8c82d00-6eb7-11eb-8810-33397eabecca.png)

1. Injection site: Upper torso -- 
![image](https://user-images.githubusercontent.com/77511162/107882540-e8e00c80-6eb7-11eb-99f4-322eb0d8f382.png)
2. Injection site: Lower torso -- 
![image](https://user-images.githubusercontent.com/77511162/107882545-eed5ed80-6eb7-11eb-89ad-8c1510717ba8.png)
3. Injection site: Right arm -- 
![image](https://user-images.githubusercontent.com/77511162/107882578-1f1d8c00-6eb8-11eb-93a8-60aa01fc3c15.png)
4. Injection site: Left foot -- 
![image](https://user-images.githubusercontent.com/77511162/107882590-2a70b780-6eb8-11eb-8566-315ca5b1cd91.png)

The code that checks if the head is covered was left untouched. This code adjustment does not impact implanting, since that is already handled separately and performing as expected.

This code contains non-modular changes.

Thanks to Leon9621 for the clue on where to look to fix this.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

You can now shoot up needles into your Aegis friends' exposed limbs without pulling their vests off first!

## Changelog
```changelog
fix: Thick armor no longer blocks injections on non-covered limbs
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
