### PR TITLE
medical storages now support mk2 hypos/vials

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2813,6 +2813,7 @@
 #include "zzzz_modular_occulus\code\game\objects\items\weapons\grenades\chem_grenade.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\weapons\storage\belt.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\weapons\storage\firstaid.dm"
+#include "zzzz_modular_occulus\code\game\objects\items\weapons\storage\pouches.dm"
 #include "zzzz_modular_occulus\code\game\objects\random\utility.dm"
 #include "zzzz_modular_occulus\code\game\objects\structures\evacsign.dm"
 #include "zzzz_modular_occulus\code\game\objects\structures\fitness.dm"

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/storage/belt.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/storage/belt.dm
@@ -1,4 +1,4 @@
-//Makes the medical belt able to fit the advanced rollerbed in it!
+//Makes the medical belt able to fit the advanced rollerbed in it! And the hyposprays too now!
 
 /obj/item/weapon/storage/belt/medical
 	can_hold = list(
@@ -23,5 +23,6 @@
 		/obj/item/weapon/tool/crowbar,
 		/obj/item/device/lighting/toggleable/flashlight,
 		/obj/item/weapon/extinguisher/mini,
-		/obj/item/roller/adv
+		/obj/item/roller/adv,
+		/obj/item/hypospray,
 	)

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/storage/pouches.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/storage/pouches.dm
@@ -31,5 +31,4 @@
 		/obj/item/ammo_casing/rocket,
 		/obj/item/ammo_casing/grenade,
 		/obj/item/hypospray,
-		/obj/item/weapon/reagent_containers/glass/beaker/hypovial/,
 		)

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/storage/pouches.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/storage/pouches.dm
@@ -1,0 +1,35 @@
+//Lets medical pouches and tube pouches hold new hyposprays of all varieties
+
+/obj/item/weapon/storage/pouch/medical_supply
+	can_hold = list(
+		/obj/item/device/scanner/health,
+		/obj/item/weapon/dnainjector,
+		/obj/item/weapon/reagent_containers/dropper,
+		/obj/item/weapon/reagent_containers/glass/beaker,
+		/obj/item/weapon/reagent_containers/glass/bottle,
+		/obj/item/weapon/reagent_containers/pill,
+		/obj/item/weapon/reagent_containers/syringe,
+		/obj/item/weapon/storage/pill_bottle,
+		/obj/item/stack/medical,
+		/obj/item/clothing/mask/surgical,
+		/obj/item/clothing/head/surgery,
+		/obj/item/clothing/gloves/latex,
+		/obj/item/weapon/reagent_containers/hypospray,
+		/obj/item/clothing/glasses/hud/health,
+		/obj/item/hypospray,
+		)
+
+/obj/item/weapon/storage/pouch/tubular
+	can_hold = list(
+		/obj/item/device/lighting/glowstick,
+		/obj/item/weapon/reagent_containers/syringe,
+		/obj/item/weapon/reagent_containers/glass/beaker/vial,
+		/obj/item/weapon/reagent_containers/hypospray,
+		/obj/item/weapon/pen,
+		/obj/item/weapon/storage/pill_bottle,
+		/obj/item/weapon/hatton_magazine,
+		/obj/item/ammo_casing/rocket,
+		/obj/item/ammo_casing/grenade,
+		/obj/item/hypospray,
+		/obj/item/weapon/reagent_containers/glass/beaker/hypovial/,
+		)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows medical storages (Belts, supply pouches, vial pouches) to now all properly support the new hyposprays and hypospray vials.

## Why It's Good For The Game
These already supported the original hypospray, now also support the new hypos.

## Changelog
```changelog
add: Medical storage clothing now supports new hypos and vials
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
