### PR TITLE
Makes Glassification less silly

### DIFF
--- a/code/datums/topic/admin.dm
+++ b/code/datums/topic/admin.dm
@@ -809,6 +809,29 @@
 	log_admin("[key_name(usr)] forced [key_name(M)] to say: [speech]")
 	message_admins("\blue [key_name_admin(usr)] forced [key_name_admin(M)] to say: [speech]")
 
+/datum/admin_topic/forcesanity
+	keyword = "forcesanity"
+	require_perms = list(R_FUN)
+
+/datum/admin_topic/forcesanity/Run(list/input)
+	var/mob/living/carbon/human/H = locate(input["forcesanity"])
+	if(!ishuman(H))
+		to_chat(usr, "This can only be used on instances of type /human.")
+		return
+
+	var/datum/breakdown/B = input("What breakdown will [key_name(H)] suffer from?", "Sanity Breakdown") as null | anything in subtypesof(/datum/breakdown)
+	if(!B)
+		return
+	B = new B(H.sanity)
+	if(!B.can_occur())
+		to_chat(usr, "[B] could not occur. [key_name(H)] did not meet the right conditions.")
+		qdel(B)
+		return
+	if(B.occur())
+		H.sanity.breakdowns += B
+		to_chat(usr, SPAN_NOTICE("[B] has occurred for [key_name(H)]."))
+		return
+
 
 /datum/admin_topic/revive
 	keyword = "revive"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -220,7 +220,8 @@ ADMIN_VERB_ADD(/datum/admins/proc/show_player_panel, null, TRUE)
 	body += {"<br><br>
 			<b>Other actions:</b>
 			<br>
-			<A href='?src=\ref[src];forcespeech=\ref[M]'>Forcesay</A>
+			<A href='?src=\ref[src];forcespeech=\ref[M]'>Forcesay</A> |
+			<A href='?src=\ref[src];forcesanity=\ref[M]'>Sanity Break</A>
 			"}
 	body += "<br><br><b>Languages:</b><br>"
 	var/f = 1

--- a/code/modules/sanity/breakdowns.dm
+++ b/code/modules/sanity/breakdowns.dm
@@ -388,6 +388,8 @@
 /datum/breakdown/common/power_hungry/proc/check_shock()
 	finished = TRUE
 
+#define ACTVIEW_ONE TRUE
+#define ACTVIEW_BOTH 2
 
 /datum/breakdown/negative/glassification
 	name = "Glassification"
@@ -410,16 +412,8 @@
 /datum/breakdown/negative/glassification/update()
 	if(world.time < time)
 		return TRUE
-	if(active_view)
-		holder.owner.remoteviewer = FALSE
-		holder.owner.remoteview_target = null
-		holder.owner.reset_view(0)
-		target.remoteviewer = FALSE
-		target.remoteview_target = null
-		target.reset_view(0)
-		target = null
-		active_view = FALSE
-		time = world.time + cooldown
+	if(active_view) //Just in case the callback doesn't catch
+		reset_views()
 		return TRUE
 	. = ..()
 	if(!.)
@@ -428,16 +422,27 @@
 	if(targets.len)
 		target = pick(targets)
 		holder.owner.remoteviewer = TRUE
-		holder.owner.remoteview_target = target
-		holder.owner.reset_view(target)
+		holder.owner.set_remoteview(target)
 		to_chat(holder.owner, SPAN_WARNING("It seems as if you are looking through someone else's eyes."))
-		to_chat(target, SPAN_WARNING("It seems as if you are looking through someone else's eyes."))
-		target.remoteviewer = TRUE
-		target.remoteview_target = holder.owner
-		target.reset_view(holder.owner)
-		target.sanity.changeLevel(-rand(5,10))
-		active_view = TRUE
+		active_view = ACTVIEW_ONE
+		if(target.sanity.level < 50)
+			target.remoteviewer = TRUE
+			target.set_remoteview(holder.owner)
+			to_chat(target, SPAN_WARNING("It seems as if you are looking through someone else's eyes."))
+			active_view = ACTVIEW_BOTH
+		target.sanity.changeLevel(-rand(5,10)) //This phenomena will prove taxing on the viewed regardless
+		addtimer(CALLBACK(src, .proc/reset_views, TRUE), time_view)
 		time = world.time + time_view
+
+/datum/breakdown/negative/glassification/proc/reset_views()
+	holder.owner.set_remoteview()
+	holder.owner.remoteviewer = FALSE
+	if(active_view == ACTVIEW_BOTH)
+		target.set_remoteview()
+		target.remoteviewer = FALSE
+	target = null
+	active_view = FALSE
+	time = world.time + cooldown
 
 /datum/breakdown/common/herald
 	name = "Herald"


### PR DESCRIPTION
## About The Pull Request

Now it only lasts for precisely one second, and is only two way if the recipient's sanity is low enough.

Port of https://github.com/discordia-space/CEV-Eris/pull/5332

## Why It's Good For The Game
Makes Glassification far less obnoxious and immersion breaking.

## Changelog
```changelog Toriate
add: Glassification is now only bidirectional if the recipient happens to be at low sanity. Also lasts for one second only now.
```
