### PR TITLE
Fixed stash spawning

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2891,6 +2891,7 @@
 #include "zzzz_modular_occulus\code\modules\sprite_accessories\_accessories_sprite.dm"
 #include "zzzz_modular_occulus\code\modules\sprite_accessories\_accessory_hair.dm"
 #include "zzzz_modular_occulus\code\modules\sprite_accessories\_accessory_tesh.dm"
+#include "zzzz_modular_occulus\code\modules\stashes\stashes.dm"
 #include "zzzz_modular_occulus\maps\submaps\deepmaint_rooms\core\core_rooms.dm"
 #include "zzzz_modular_occulus\maps\submaps\deepmaint_rooms\normal\normal_rooms.dm"
 // END_INCLUDE

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -52,7 +52,7 @@ var/global/list/default_medbay_channels = list(
 	var/syndie = 0//Holder to see if it's a syndicate encrypted radio
 	var/const/FREQ_LISTENING = 1
 	var/list/internal_channels
-	
+
 	//Eclipse-added vars
 	var/freqlock = FALSE		//Eclipse Edit: Should we lock the frequency to prevent people from changing the channel?
 
@@ -72,7 +72,7 @@ var/global/list/default_medbay_channels = list(
 	if(syndie)
 		internal_channels += unique_internal_channels.Copy()
 	add_hearing()
-	
+
 	//eclipse addition
 	if(audible_squelch_enabled)		//if it's disabled, should stay as null.ogg. Prevents it from playing squelch in the event another if-check fails.
 		audible_squelch_type = pick(all_radio_squelch_sounds)		//radios get a semi-unique radio squelch sound. granted, there's four sounds total, but if one radio receives it should maintain the same squelch sound all the time.

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -52,7 +52,7 @@ var/global/list/default_medbay_channels = list(
 	var/syndie = 0//Holder to see if it's a syndicate encrypted radio
 	var/const/FREQ_LISTENING = 1
 	var/list/internal_channels
-
+	
 	//Eclipse-added vars
 	var/freqlock = FALSE		//Eclipse Edit: Should we lock the frequency to prevent people from changing the channel?
 
@@ -72,7 +72,7 @@ var/global/list/default_medbay_channels = list(
 	if(syndie)
 		internal_channels += unique_internal_channels.Copy()
 	add_hearing()
-
+	
 	//eclipse addition
 	if(audible_squelch_enabled)		//if it's disabled, should stay as null.ogg. Prevents it from playing squelch in the event another if-check fails.
 		audible_squelch_type = pick(all_radio_squelch_sounds)		//radios get a semi-unique radio squelch sound. granted, there's four sounds total, but if one radio receives it should maintain the same squelch sound all the time.

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -454,6 +454,7 @@
 	name = "altyn helmet"
 	desc = "A titanium helmet of serbian origin. Still widely used despite being discontinued."
 	icon_state = "altyn"
+	armor = list(melee = 20, bullet = 15, energy = 0, bomb = 15, bio = 0, rad = 0) //Fixing a runtime.
 	var/list/armor_up = list(melee = 20, bullet = 15, energy = 0, bomb = 15, bio = 0, rad = 0)
 	var/list/armor_down = list(melee = 40, bullet = 40, energy = 0, bomb = 35, bio = 0, rad = 0) // slightly better than usual due to mask
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHEADHAIR

--- a/code/modules/clothing/head/armor.dm
+++ b/code/modules/clothing/head/armor.dm
@@ -454,7 +454,7 @@
 	name = "altyn helmet"
 	desc = "A titanium helmet of serbian origin. Still widely used despite being discontinued."
 	icon_state = "altyn"
-	armor = list(melee = 20, bullet = 15, energy = 0, bomb = 15, bio = 0, rad = 0) //Fixing a runtime.
+	armor = list(melee = 20, bullet = 15, energy = 0, bomb = 15, bio = 0, rad = 0) //Fixing a runtime. Occulus Edit
 	var/list/armor_up = list(melee = 20, bullet = 15, energy = 0, bomb = 15, bio = 0, rad = 0)
 	var/list/armor_down = list(melee = 40, bullet = 40, energy = 0, bomb = 35, bio = 0, rad = 0) // slightly better than usual due to mask
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|BLOCKHEADHAIR

--- a/code/modules/stashes/stash_spawner.dm
+++ b/code/modules/stashes/stash_spawner.dm
@@ -4,7 +4,7 @@
 /obj/item/stash_spawner
 	name = "Stash Spawner"
 	desc = "You shouldn't see this, report it!"
-	rarity_value = 3.5
+	rarity_value = 45 //Occulus Edit: Whoever set this to 3.5 caused basically all of them to spawn at roundstart. No beuno. Now they are about as rare as an atomcell
 	//Reference of the stash datum we're spawning from.
 	//These are all singletons in a global list, but each will be removed from that list when we take it
 	var/datum/stash/datum

--- a/zzzz_modular_occulus/code/modules/stashes/stashes.dm
+++ b/zzzz_modular_occulus/code/modules/stashes/stashes.dm
@@ -1,0 +1,150 @@
+/datum/stash/valueable/eridian
+	contents_list_extra = list(/obj/item/clothing/suit/space/void/mining = 1,
+	/obj/item/weapon/holochip/science/jive = 1,
+	/obj/item/weapon/holochip/science/sol = 1,
+	/obj/item/weapon/holochip/science/yiff = 1,
+	/obj/item/weapon/implant/core_implant/soulcrypt = 2,
+	/obj/item/weapon/implanter = 1)
+	lore = "The colony is safe, but C.T. says we should not go back. We are stuck on the Eridian Light.<br>\
+ Our split of the payment is at %D.<br>\
+ We do not know what sector the BSD will send us. <br>\
+ It took some convincing, but we got some extra holochips as part of the deal. <br>\
+ Do not worry about having the right hardware for them. That is taken care of.<br>\
+ Keep it from the cultists."
+
+/datum/stash/junk/clowning
+	contents_list_extra = list(/obj/item/clothing/under/rank/clown = 1,
+	/obj/item/clothing/shoes/clown_shoes = 1,
+	/obj/item/weapon/bananapeel = 8,
+	/obj/item/clothing/mask/gas/clown_hat = 1)
+	lore = "Killed taht tee-totaling bastard good, we did.<br>\
+	<br>\
+	Teach him to cut the rum ration. Like how rowdy we were now ya screaming pig?<br>\
+	<br>\
+	The boys took his shit off him and we'll sort it out later, once we pretend the good stuff was missing after we divvy with the crew. <br>\
+	Keeping it here to be safe. %D"
+
+/datum/stash/junk/plush
+	contents_list_extra = list(/obj/item/toy/plushie/soygel = 1,
+	/obj/item/toy/plushie/mouse = 1,
+	/obj/item/toy/plushie/kitten = 1,
+	/obj/item/toy/plushie/lizard =1,
+	/obj/item/toy/plushie/spider =1)
+	contents_list_external = list(/obj/item/remains/human = 1)
+	lore = "I am taking my friends and getting off this hulk! <br>\
+ 	We are doomed if we stay here, you should come too!<br>\
+ 	I would feel horrible if you were left behind. <br>\
+ 	My friends and I will meet you at %D. Please do not be late!"
+
+/datum/stash/weapon/mutiny/chemist
+	lore = "They had me pull out her crypt, Karen. They pulled it out and smashed it in front of me.<br>\
+ 	My oath may be to do no harm, but I will not stand by and let them annihilate any more souls.<br>\
+ 	I have stashed a few vials and weapons at %D. Distribute them to the crew, they will know what to do."
+	contents_list_extra = list(/obj/item/weapon/storage/pill_bottle/bicaridine = 1,
+	/obj/item/weapon/storage/pill_bottle/dermaline = 1,
+	/obj/item/weapon/storage/pill_bottle/dexalin_plus = 1,
+	/obj/item/weapon/storage/pill_bottle/dylovene = 1,
+	/obj/item/weapon/storage/pill_bottle/tramadol = 1)
+
+/datum/stash/junk/oddity
+	contents_list_extra = list(/obj/spawner/oddities = 4)
+	lore = "I lifted this from the cargo office before that monster could fire me or worse. <br>\
+	If I get caught, you can find them at %D."
+
+/datum/stash/junk/toolmods
+	contents_list_extra = list(/obj/spawner/tool_upgrade = 4)
+	lore = "Adrian. This should help keep that new bitch of a CE over at EES off your ass. <br>\
+	I do not know of a single engineer who can resist these things. It is like catnip to them...<br>\
+	...no offense intended.<br>\
+	Anyway the goods are at %D."
+
+/datum/stash/junk/music
+	contents_list_extra = list(/obj/item/device/synthesized_instrument/guitar = 1,
+	/obj/item/weapon/storage/box/donkpockets = 1)
+	lore = "The main halls are too noisy with the import of the new specimins. <br>\
+	How am I supposed to think, much less COMPOSE with those giant cockroaches they have in the pens screeching at all hours? <br>\
+	Seriously, screw solgov and this stupid project. <br>\
+	I am going to take a little trip into maintainence with just myself, my instrument, and some food. Tell the boss I'll be back okay? <br>\
+	If anything happens you can find me at %D."
+
+/datum/stash/valueable/pirate/song
+	contents_list_extra = list(/obj/item/device/synthesized_instrument/guitar = 1)
+	lore = "Jayme Dawson was the Captain of the Christian and her crew <br>\
+	And he flew and fought the Christian in the War of '82 <br>\
+	Now the Christian was the tightest ship 'tween here and Charlemagne <br>\
+	And the crew of Jayme Dawson was the same <br>\
+	<br>\
+	On patrol in sector seven, keeping watch on Barber's sun <br>\
+	They were jumped by three light cruisers though they wern't a match for one <br>\
+	As they came to general quarters and they sent out the alarm <br>\
+	Dawson's crew was sure they'd finally bought the farm <br>\
+	<br>\
+	No one living saw that battle though the fleet was quick to leave <br>\
+	When they reached the site they found a scene no sane man could believe <br>\
+	Dead in space lay three light cruisers, cut to ribbons all around <br>\
+	But no sign of Dawson's Christian could be found <br>\
+	<br>\
+	There are stories of the Dutchman, the Celeste and Barnham's Pride <br>\
+	There are stories of the Horseman and the Lady at his side <br>\
+	But the tale that chills my spirit, more because I know it's true <br>\
+	Is the tale of Jayme Dawson and his crew <br>\
+	Yes, the tale of Dawson's Christian and her crew.<br>\
+	<br>\
+	D%"
+
+
+/datum/stash/valueable/pirate/song2
+	contents_list_extra = list(/obj/item/device/synthesized_instrument/guitar = 1)
+	lore = "I was second mate on Hera's Dream, a freighter of the line <br>\
+	We were shipping precious metals to the colony on Nine <br>\
+	It was on the second watch of that most uneventful flight <br>\
+	When the pirate ships appeared out of the night <br>\
+	<br>\
+	Now to me there was no question, for they had us four to one <br>\
+	And you can't fight dirty pirates when your freighter has no gun <br>\
+	So we stood by to be boarded by a party yet unseen <br>\
+	When another ship appeared upon our screen <br>\
+	<br>\
+	First we thought it just a pirate, but the vector was all wrong <br>\
+	Then we thought it might be rescue, but the signal wasn't strong <br>\
+	When she didn't answer hailing, we all felt an unknown dread <br>\
+	For we saw her shields were up and glowing red <br>\
+	<br>\
+	Now the courage of that single ship is shown by very few <br>\
+	But we never knew a ship could fly the way the stranger flew <br>\
+	Never fearing guns or numbers, like a tiger to its meat <br>\
+	The stranger then attacked the pirate fleet. <br>\
+	<br>\
+	D%"
+
+
+/datum/stash/valueable/pirate/song3
+	contents_list_extra = list(/obj/item/device/synthesized_instrument/guitar = 1)
+
+	lore = "And the strangers beams burned brighter than all beams I'd seen before <br>\
+	And the strangers shields were harder than the heart of any whore <br>\
+	As the battle rent the eather, while we watched and shook our heads <br>\
+	The pirate ships were cut to bloody shreds <br>\
+	<br>\
+	Just as quickly as it started then the fighting was all done <br>\
+	For the pirate fleet was shattered and the stranger's ship had won <br>\
+	Though we tried to call and thank her, not an answer could we draw <br>\
+	Then she dropped her shields and this is what we saw <br>\
+	<br>\
+	There were thirty holes clear through her and a gash along one side <br>\
+	And we knew that when it happened, that no crew were left alive <br>\
+	For the markings all said Christian, deep inside us each one knew <br>\
+	'Twas the tomb of Jayme Dawson and his crew <br>\
+	<br>\
+	Now instead of flying off, the stranger then began to fade <br>\
+	First the hull, and then the bulkheads as we cowered there afraid <br>\
+	For as the Christian disappeared, the last to slip from view <br>\
+	Were the bones of Jayme Dawson and his crew <br>\
+	<br>\
+	There are stories of the Dutchman, the Celeste and Barnham's Pride <br>\
+	There are stories of the Horseman and the Lady at his side <br>\
+	But the tale that chills my spirit, and I swear to God it's true <br>\
+	Is the tale of Jayme Dawson and his crew <br>\
+	Yes, the tale of Dawson's Christian and her crew. <br>\
+	<br>\
+	D%"


### PR DESCRIPTION
## About The Pull Request

Increased rarity of stashes to 50. Inline with atomcells. This should let them spawn again from the radio!
Added several new stash types
Fixed a runtime caused by a dumb serbian helmet nobody likes.

## Why It's Good For The Game

Eris doesn't understand how their own loot system works. Who the hell sets stashes to spawn at rarity 3.5?

## Changelog
```changelog
add: A number of potential stashes
tweak: stash papers now have a rarity value of 50
fix: fixed a runtime caused by a serbian helmet
```