### PR TITLE
Activates #239 (burn cobwebs)

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2803,6 +2803,7 @@
 #include "zzzz_modular_occulus\code\game\machinery\smartfridge.dm"
 #include "zzzz_modular_occulus\code\game\machinery\vending.dm"
 #include "zzzz_modular_occulus\code\game\machinery\telecomms\presets.dm"
+#include "zzzz_modular_occulus\code\game\objects\effects\decals\Cleanable\misc_occulus.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\oddities.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\plush.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\toys\balls.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Pull #239 was not actually active because I forgot to include DME changes in the original pull. This activates the code.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Now you can burn decal cobwebs (big spider ones are untouched) with welding/cauterizing tools (like lighters

## Changelog
```changelog
fix: Cobweb burning with welding/cauterizing tools (lighters) wasn't actually active, whoopsy doopsy
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
