### PR TITLE
Jamini artistfix2

### DIFF
--- a/code/game/machinery/autolathe/artist_bench.dm
+++ b/code/game/machinery/autolathe/artist_bench.dm
@@ -10,7 +10,7 @@
 /obj/machinery/autolathe/artist_bench
 	name = "artist's bench"
 	desc = "Insert wood, steel, glass, plasteel, plastic and a bit of your soul to create a beautiful work of art. \
-			Requires a stock of at least 5 sheets of each of the aforementioned materials before you begin sacrificing your soul."	// OCCULUS EDIT - Makes its requirements clear
+			Requires a stock of at least 20 sheets of each of the aforementioned materials before you begin sacrificing your soul."	// OCCULUS EDIT - Makes its requirements clear
 	icon = 'icons/obj/machines/autolathe.dmi'
 	icon_state = "bench"
 	circuit = /obj/item/weapon/electronics/circuitboard/artist_bench
@@ -21,7 +21,7 @@
 	categories = list("Artwork")
 
 	suitable_materials = list(MATERIAL_WOOD, MATERIAL_STEEL, MATERIAL_GLASS, MATERIAL_PLASTEEL, MATERIAL_PLASTIC)
-	var/min_mat = 5 // OCCULUS EDIT - Makes its requirements less dumb
+	var/min_mat = 20
 	var/min_insight = 40
 	var/datum/component/inspiration/inspiration
 	var/obj/item/oddity
@@ -397,9 +397,9 @@
 
 /obj/machinery/autolathe/artist_bench/loaded
 	stored_material = list(
-		MATERIAL_STEEL = 5,
-		MATERIAL_PLASTIC = 5,
-		MATERIAL_GLASS = 5,
-		MATERIAL_PLASTEEL = 5,
-		MATERIAL_WOOD = 5
+		MATERIAL_STEEL = 20,
+		MATERIAL_PLASTIC = 20,
+		MATERIAL_GLASS = 20,
+		MATERIAL_PLASTEEL = 20,
+		MATERIAL_WOOD = 20
 		)

--- a/code/game/machinery/autolathe/artist_bench.dm
+++ b/code/game/machinery/autolathe/artist_bench.dm
@@ -281,7 +281,7 @@
 			stats_amt += 3//max = 3*4*2+6 = 30 points, min 3*4+6 = 18
 		for(var/i in 1 to stats_amt)
 			var/stat = pick(ALL_STATS)
-			oddity_stats[stat] = min(MAX_STAT_VALUE, oddity_stats[stat]+rand(1,2))
+			oddity_stats[stat] = min(MAX_STAT_VALUE, oddity_stats[stat]+ 1) //Occulus Edit - Nerfing Artist oddity stats a bit!
 
 		O.oddity_stats = oddity_stats
 		O.AddComponent(/datum/component/inspiration, O.oddity_stats, O.perk)

--- a/code/game/objects/items/oddities.dm
+++ b/code/game/objects/items/oddities.dm
@@ -40,13 +40,13 @@
 			for(var/stat in oddity_stats)
 				oddity_stats[stat] = rand(1, oddity_stats[stat])
 		AddComponent(/datum/component/inspiration, oddity_stats, perk)
-
+/* Occulus Edit - This exists in the inspiration component examine code
 /obj/item/weapon/oddity/examine(user)
 	..()
 	if(perk)
 		var/datum/perk/oddity/OD = GLOB.all_perks[perk]
 		to_chat(user, SPAN_NOTICE("Strange words echo in your head: <span style='color:orange'>[OD]. [OD.desc]"))
-
+End Occulus Edit */
 
 //Oddities are separated into categories depending on their origin. They are meant to be used both in maints and derelicts, so this is important
 //This is done by subtypes, because this way even densiest code monkey will not able to misuse them

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -240,8 +240,7 @@
 	for(var/stat in stat_change)
 		owner.stats.changeStat(stat, stat_change[stat])
 
-	if(!owner.stats.getPerk(PERK_ARTIST))
-		INVOKE_ASYNC(src, .proc/oddity_stat_up, resting)
+	INVOKE_ASYNC(src, .proc/oddity_stat_up, resting)//Occulus Edit. Artists should still gain stats from perks. 
 
 	if(owner.stats.getPerk(PERK_ARTIST))
 		to_chat(owner, SPAN_NOTICE("You have created art and improved your stats."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Artist and art bench fixes
fix for #273 

## Why It's Good For The Game

Some issues found in early testing that need addressed.

## Changelog
```changelog
fix: re-implemented 20 minimum materials needed. AS some art pieces actually need that much!
fix: Artists now can benefit from oddities.
balance: reduced maximum stats on art oddities.
fix: Oddity duplicate examine text fixed. The artist PR added a second examine proc that already exists in inspiration_component
```