### PR TITLE
Robot QoL Changes

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/_drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/_drone.dm
@@ -57,7 +57,7 @@ var/list/mob_hat_cache = list()
 	var/module_type = /obj/item/weapon/robot_module/drone
 	var/obj/item/hat
 	var/hat_x_offset = 0
-	var/hat_y_offset = -13
+	var/hat_y_offset = -9	// OCCULUS EDIT - Fixes hat offsets for drones
 	var/eyecolor = "blue"
 	var/armguard = ""
 	var/communication_channel = LANGUAGE_DRONE

--- a/code/modules/mob/living/silicon/robot/gripper.dm
+++ b/code/modules/mob/living/silicon/robot/gripper.dm
@@ -23,7 +23,8 @@
 		/obj/item/weapon/electronics/circuitboard,
 		/obj/item/device/assembly,//Primarily for making improved cameras, but opens many possibilities
 		/obj/item/weapon/computer_hardware,
-		/obj/item/stack/tile //Repair floors yay
+		/obj/item/stack/tile, //Repair floors yay
+		/obj/item/weapon/tool_upgrade	// OCCULUS EDIT - Make cyborgs be able to grab upgrades
 		)
 
 	var/obj/item/wrapped // Item currently being held.

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -440,6 +440,7 @@
 	icon = 'icons/obj/robot_items.dmi'
 	switched_on_qualities = list(QUALITY_WELDING = 40, QUALITY_CAUTERIZING = 15, QUALITY_WIRE_CUTTING = 15)
 	spawn_tags = null
+	max_fuel = 50	// OCCULUS EDIT - More welding fuel for borgs
 
 /obj/item/weapon/tool/shovel/robotic
 	icon = 'icons/obj/robot_items.dmi'

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -1033,7 +1033,8 @@ var/global/list/robot_modules = list(
 	channels = list("Engineering" = 1, "Common" = 1)
 	stat_modifiers = list(
 		STAT_COG = 15,
-		STAT_MEC = 40
+		STAT_MEC = 50,	// OCCULUS EDIT - Slight buff
+		STAT_ROB = 10	// OCCULUS EDIT - To help with collapsing burrows
 	)
 
 /obj/item/weapon/robot_module/drone/New(var/mob/living/silicon/robot/R)
@@ -1054,6 +1055,7 @@ var/global/list/robot_modules = list(
 	src.modules += new /obj/item/device/floor_painter(src)
 	src.modules += new /obj/item/weapon/rpd/borg(src)
 	src.modules += new /obj/item/borg/sight/meson(src)
+	src.emag += new /obj/item/weapon/hatton/robot(src)	// OCCULUS EDIT - Gives the drone some fun stuff when emagged
 
 	//src.emag = new /obj/item/weapon/gun/energy/phoroncutter/mounted(src)
 	//src.emag.name = "Phoron Cutter"

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -140,7 +140,7 @@
 /obj/structure/multiz/ladder/attack_hand(var/mob/M)
 	if (isrobot(M) && !isdrone(M))
 		var/mob/living/silicon/robot/R = M
-		climb(M, (climb_delay*6)/R.speed_factor) //Robots are not built for climbing, they should go around where possible
+		climb(M, (climb_delay)/R.speed_factor) //Robots are not built for climbing, they should go around where possible	// OCCULUS EDIT - Removed the *6 multiplier from robot climb delay
 		//I'd rather make them unable to use ladders at all, but eris' labyrinthine maintenance necessitates it
 	else
 		climb(M, climb_delay)


### PR DESCRIPTION
## About The Pull Request
1) Drones now have more stats to aid with collapsing burrows
2) Grippers can now grab toolmods, however as they are unable to interact with their own modules, they cannot install toolmods on their modules.
3) I originally wanted to give drones jetpacks but the code is broken, so I just let them have a hatton if they get emagged.
4) Drone hats are now properly positioned
5) Robot welders now have double the amount of fuel, so they're less beholden to fuel tanks
6) Robots no longer take 6 times as long to climb ladders

## Why It's Good For The Game
Synthetics have been heavily screwed over by Eris code. This is the least we can do to make playing them bearable.

## Changelog
```changelog Toriate
add: Emagging drones now gives them stuff
tweak: Synthetics should climb ladders 6x faster now
balance: Drones now get extra stats to aid in collapsing burrows
balance: Robot welders get more fuel
fix: Drone hats now show up properly on their sprite.
```
