### PR TITLE
QoL for injuries -- more clarity/colors on examine

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -249,9 +249,15 @@
 			continue
 		else if(temp.wounds.len > 0 || temp.open)
 			if(temp.is_stump() && temp.parent)
-				wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] [T.has] [temp.get_wounds_desc()] on [T.his] [temp.parent.name].</span><br>"
+				// OCCULUS EDIT START: Better clarity for injuries.
+				// OLD: 'He has a pair of tiny bruises, a massive salved burn, and a large bruise on his right arm'
+				// NEW: 'His right arm has a pair of tiny buises, a massive salved burn, and a large bruise.'
+				// old code: wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] [T.has] [temp.get_wounds_desc()] on [T.his] [temp.parent.name].</span><br>"
+				wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.His] [temp.parent.name] [T.has] [temp.get_wounds_desc()].</span><br>"
 			else
-				wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] [T.has] [temp.get_wounds_desc()] on [T.his] [temp.name].</span><br>"
+				// old code: wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] [T.has] [temp.get_wounds_desc()] on [T.his] [temp.name].</span><br>"
+				wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.His] [temp.name] [T.has] [temp.get_wounds_desc()].</span><br>"
+				// OCCULUS EDIT END
 			if(temp.status & ORGAN_BLEEDING)
 				is_bleeding["[temp.name]"] = "<span class='danger'>[T.His] [temp.name] is bleeding!</span><br>"
 		else

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -253,10 +253,10 @@
 				// OLD: 'He has a pair of tiny bruises, a massive salved burn, and a large bruise on his right arm'
 				// NEW: 'His right arm has a pair of tiny buises, a massive salved burn, and a large bruise.'
 				// old code: wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] [T.has] [temp.get_wounds_desc()] on [T.his] [temp.parent.name].</span><br>"
-				wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.His] [temp.parent.name] [T.has] [temp.get_wounds_desc()].</span><br>"
+				wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.His] <b>[temp.parent.name]</b> [T.has] [temp.get_wounds_desc()].</span><br>"
 			else
 				// old code: wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.He] [T.has] [temp.get_wounds_desc()] on [T.his] [temp.name].</span><br>"
-				wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.His] [temp.name] [T.has] [temp.get_wounds_desc()].</span><br>"
+				wound_flavor_text["[temp.name]"] = "<span class='warning'>[T.His] <b>[temp.name]</b> [T.has] [temp.get_wounds_desc()].</span><br>"
 				// OCCULUS EDIT END
 			if(temp.status & ORGAN_BLEEDING)
 				is_bleeding["[temp.name]"] = "<span class='danger'>[T.His] [temp.name] is bleeding!</span><br>"

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -945,12 +945,12 @@ Note that amputating the affected organ does in fact remove the infection from t
 		var/this_wound_desc = W.desc
 
 		if(W.damage_type == BURN && W.salved)
-			this_wound_desc = "salved [this_wound_desc]"
+			this_wound_desc = "<font color='AE9C45'>salved</font> [this_wound_desc]" // OCCULUS EDIT: This is a golden yellow
 
 		if(W.bleeding())
-			this_wound_desc = "<b><i>bleeding</i></b> [this_wound_desc]"	// OCCULUS EDIT: bold and italicize 'bleeding'
+			this_wound_desc = "<b>bleeding</b> [this_wound_desc]"	// OCCULUS EDIT: bold 'bleeding'
 		else if(W.bandaged)
-			this_wound_desc = "bandaged [this_wound_desc]"
+			this_wound_desc = "<font color='6073B1'>bandaged</font> [this_wound_desc]" // OCCULUS EDIT: This is a somewhat light blue
 
 		if(W.germ_level > 600)
 			this_wound_desc = "badly infected [this_wound_desc]"

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -944,8 +944,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 		if(W.internal && !open) continue // can't see internal wounds
 		var/this_wound_desc = W.desc
 
-		if(W.damage_type == BURN && W.salved)
-			this_wound_desc = "<font color='AE9C45'>salved</font> [this_wound_desc]" // OCCULUS EDIT: This is a golden yellow
+		if(W.salved)	// Always show salved wounds -- this is important for Jamini's incoming injury clearing PR
+		//if(W.damage_type == BURN && W.salved)
+			this_wound_desc = "<font color='F5793A'>salved</font> [this_wound_desc]" // OCCULUS EDIT: This is orange
 
 		if(W.bleeding())
 			this_wound_desc = "<b>bleeding</b> [this_wound_desc]"	// OCCULUS EDIT: bold 'bleeding'

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -258,9 +258,9 @@
 	limb_efficiency += owner.get_specific_organ_efficiency(OP_NERVE, organ_tag) + owner.get_specific_organ_efficiency(OP_MUSCLE, organ_tag)
 	if(BP_IS_ROBOTIC(src))
 		limb_efficiency = limb_efficiency / 2
-		return 
+		return
 	limb_efficiency = (limb_efficiency + owner.get_specific_organ_efficiency(OP_BLOOD_VESSEL, organ_tag)) / 3
-	
+
 /obj/item/organ/external/proc/update_bionics_hud()
 	switch(organ_tag)
 		if(BP_L_ARM)
@@ -948,7 +948,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			this_wound_desc = "salved [this_wound_desc]"
 
 		if(W.bleeding())
-			this_wound_desc = "bleeding [this_wound_desc]"
+			this_wound_desc = "<b><i>bleeding</i></b> [this_wound_desc]"	// OCCULUS EDIT: bold and italicize 'bleeding'
 		else if(W.bandaged)
 			this_wound_desc = "bandaged [this_wound_desc]"
 

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -274,12 +274,12 @@
 
 /datum/wound/cut/deep
 	max_bleeding_stage = 3
-	stages = list("ugly deep ripped cut" = 25, "deep ripped cut" = 20, "deep cut" = 15, "clotted cut" = 8, "scab" = 2, "fresh skin" = 0)
+	stages = list("ugly deep ripped cut" = 25, "deep ripped cut" = 20, "deep cut" = 15, "clotted cut" = 8, "scab" = 2, "shrinking scab" = 0) // OCCULUS EDIT: was 'fresh skin' for 0
 	damage_type = CUT
 
 /datum/wound/cut/flesh
 	max_bleeding_stage = 4
-	stages = list("ugly ripped flesh wound" = 35, "ugly flesh wound" = 30, "flesh wound" = 25, "blood soaked clot" = 15, "large scab" = 5, "fresh skin" = 0)
+	stages = list("ugly ripped flesh wound" = 35, "ugly flesh wound" = 30, "flesh wound" = 25, "blood soaked clot" = 15, "large scab" = 5, "shrinking large scab" = 0) // OCCULUS EDIT: was 'fresh skin' for 0
 	damage_type = CUT
 
 /datum/wound/cut/gaping
@@ -348,11 +348,11 @@ datum/wound/puncture/massive
 	return 0
 
 /datum/wound/burn/moderate
-	stages = list("ripped burn" = 10, "moderate burn" = 5, "healing moderate burn" = 2, "fresh skin" = 0)
+	stages = list("ripped burn" = 10, "moderate burn" = 5, "healing moderate burn" = 2, "fading burn spot" = 0) // OCCULUS EDIT: was 'fresh skin' for 0
 	damage_type = BURN
 
 /datum/wound/burn/large
-	stages = list("ripped large burn" = 20, "large burn" = 15, "healing large burn" = 5, "fresh skin" = 0)
+	stages = list("ripped large burn" = 20, "large burn" = 15, "healing large burn" = 5, "large fading burn spot" = 0) // OCCULUS EDIT: was 'fresh skin' for 0
 	damage_type = BURN
 
 /datum/wound/burn/severe

--- a/code/modules/organs/wound.dm
+++ b/code/modules/organs/wound.dm
@@ -274,12 +274,12 @@
 
 /datum/wound/cut/deep
 	max_bleeding_stage = 3
-	stages = list("ugly deep ripped cut" = 25, "deep ripped cut" = 20, "deep cut" = 15, "clotted cut" = 8, "scab" = 2, "shrinking scab" = 0) // OCCULUS EDIT: was 'fresh skin' for 0
+	stages = list("ugly deep ripped cut" = 25, "deep ripped cut" = 20, "deep cut" = 15, "clotted cut" = 8, "scab" = 2, "healing scab" = 0) // OCCULUS EDIT: was 'fresh skin' for 0
 	damage_type = CUT
 
 /datum/wound/cut/flesh
 	max_bleeding_stage = 4
-	stages = list("ugly ripped flesh wound" = 35, "ugly flesh wound" = 30, "flesh wound" = 25, "blood soaked clot" = 15, "large scab" = 5, "shrinking large scab" = 0) // OCCULUS EDIT: was 'fresh skin' for 0
+	stages = list("ugly ripped flesh wound" = 35, "ugly flesh wound" = 30, "flesh wound" = 25, "blood soaked clot" = 15, "large scab" = 5, "healing large scab" = 0) // OCCULUS EDIT: was 'fresh skin' for 0
 	damage_type = CUT
 
 /datum/wound/cut/gaping


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

The display text for injuries has been rearranged.

Previously:

'He has a small bruise on his upper body.'

Now:

![image](https://user-images.githubusercontent.com/77511162/108690874-da51b080-74c8-11eb-8509-715d95e106d3.png)

Bleeding wounds are now made bold:

![image](https://user-images.githubusercontent.com/77511162/108690898-e2a9eb80-74c8-11eb-9caa-f8bdbbb70d85.png)

Bandaged/salved wounds have their own color code (salved wounds may need better colors against white):

![image](https://user-images.githubusercontent.com/77511162/108691018-066d3180-74c9-11eb-9689-ba6ae799431f.png)
![image](https://user-images.githubusercontent.com/77511162/108691039-0a994f00-74c9-11eb-95de-ca7f606f9c51.png)

Additonally, the poor grammar of 'fresh skin' (eg. he has a pair of fresh skins on his head) has been adjusted to be more grammatically correct:

deep cut: 'healing scab'
flesh wound: 'healing large scab'
moderate burn: 'fading burn spot'
large burn: 'large fading burn spot'

This changes are non-modular.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

In an emergency situation, it's bad design for someone to need to read through an entire line to see where an injury is. This new code places the affected area at the start of the line while also highlighting important text, like if it's bleeding, if it's bandaged, and if it's salved.

## Changelog
```changelog
tweak: Injuries are displayed with more clarity
spellcheck: 'fresh skins' have been renamed to be more grammatically correct
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
