### PR TITLE
Adjusted wound processing

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -44,7 +44,7 @@
 	var/skin_tone			// Skin tone.
 
 	// Wound and structural data.
-	var/wound_update_accuracy = 1		// how often wounds should be updated, a higher number means less often
+	var/wound_update_accuracy = 3		// how often wounds should be updated, a higher number means less often Occulus Edit: only update wounds every 3 ticks (potential lag reduction)
 	var/list/wounds = list()			// wound datum list.
 	var/number_wounds = 0				// number of wounds, which is NOT wounds.len!
 	var/list/children = list()			// Sub-limbs.
@@ -258,9 +258,9 @@
 	limb_efficiency += owner.get_specific_organ_efficiency(OP_NERVE, organ_tag) + owner.get_specific_organ_efficiency(OP_MUSCLE, organ_tag)
 	if(BP_IS_ROBOTIC(src))
 		limb_efficiency = limb_efficiency / 2
-		return 
+		return
 	limb_efficiency = (limb_efficiency + owner.get_specific_organ_efficiency(OP_BLOOD_VESSEL, organ_tag)) / 3
-	
+
 /obj/item/organ/external/proc/update_bionics_hud()
 	switch(organ_tag)
 		if(BP_L_ARM)
@@ -484,6 +484,8 @@ This function completely restores a damaged organ to perfect condition.
 		last_dam = brute_dam + burn_dam
 	if(germ_level)
 		return 1
+	if(wounds)//Occulus Edit - Need this to process wound healing over time!
+		return 1//Occulus Edit - Need this to process wound healing over time!
 	return 0
 
 /obj/item/organ/external/Process()
@@ -632,7 +634,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 
 	for(var/datum/wound/W in wounds)
 		// wounds can disappear after 10 minutes at the earliest
-		if(W.damage <= 0 && W.created + 10 * 10 * 60 <= world.time)
+		if(W.damage <= 0 && W.salved == 1 && W.bandaged == 1)//Occulus Edit: Wounds that have no damage, are salved, and are bandaged will disappear
 			wounds -= W
 			continue
 			// let the GC handle the deletion of the wound


### PR DESCRIPTION
## About The Pull Request

Organs with wounds now continue to update them until the wounds are gone
Wounds now go away after being at 0 damage, salved, and bandaged instead of vanishing as soon as they hit 0 damage after ten minutes from the cause.
Wounds now process every third tick instead of every tick

## Why It's Good For The Game

It is now possible to remove a page worth of old injuries by treating them properly

## Changelog
```changelog
tweak: Wounds now process every third tick
tweak: Wounds that are fully healed, bandaged, and salved will no longer show on examine
```
