### PR TITLE
Carrion Regen Patch

### DIFF
--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -240,14 +240,14 @@
 	spawn(rand(1 MINUTES, 3 MINUTES))
 		if(last_owner == owner)
 			owner.rejuvenate()
-		/* Occulus Edit start, Removed in favour for kyphotorin injection
+		/* //Occulus Edit start, Removed in favour for kyphotorin injection
 			for(var/limb_tag in owner.species.has_limbs)
 				var/obj/item/organ/external/E = owner.get_organ(limb_tag)
 				if(E.is_stump())
 					qdel(E)
 					var/datum/organ_description/OD = owner.species.has_limbs[limb_tag]
 					OD.create_organ(owner)
-		*/
+		*/ //Occulus Edit end.
 			owner.status_flags &= ~(FAKEDEATH)
 			owner.update_lying_buckled_and_verb_status()
 			owner.update_icons()

--- a/code/modules/organs/internal/carrion.dm
+++ b/code/modules/organs/internal/carrion.dm
@@ -230,6 +230,7 @@
 
 	to_chat(owner, SPAN_NOTICE("We will attempt to regenerate our form."))
 
+	owner.reagents.add_reagent("kyphotorin", 15) //Occulus Edit
 	owner.status_flags |= FAKEDEATH
 	owner.update_lying_buckled_and_verb_status()
 	owner.emote("gasp")
@@ -239,13 +240,14 @@
 	spawn(rand(1 MINUTES, 3 MINUTES))
 		if(last_owner == owner)
 			owner.rejuvenate()
+		/* Occulus Edit start, Removed in favour for kyphotorin injection
 			for(var/limb_tag in owner.species.has_limbs)
 				var/obj/item/organ/external/E = owner.get_organ(limb_tag)
 				if(E.is_stump())
 					qdel(E)
 					var/datum/organ_description/OD = owner.species.has_limbs[limb_tag]
 					OD.create_organ(owner)
-
+		*/
 			owner.status_flags &= ~(FAKEDEATH)
 			owner.update_lying_buckled_and_verb_status()
 			owner.update_icons()


### PR DESCRIPTION
## About The Pull Request

Replaces stump Q.del proc from Stasis (Prevents stasis freezes)
Adds Kyphotorin add_reagent proc to stasis (Allows limb regen)

## Why It's Good For The Game

Makes the Regen Stasis no longer freeze because a limb is missing, Makes limbs regenerable by carrions.

## Changelog
```changelog
fix: Makes Carrion Stasis work atleast mostly as intended. Markings not included
```
