### PR TITLE
Open surgery UI when clicking an open organ with help intent

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -208,7 +208,11 @@
 				show_ssd = H.species.show_ssd
 				var/obj/item/organ/external/O = H.get_organ(M.targeted_organ)
 				target_organ_exists = (O && O.is_usable())
-			if(show_ssd && !client && !teleop)
+			// OCCULUS EDIT START: Open the surgery UI if the organ is open by clicking the organ.
+			if (target_organ_exists and H.get_organ(M.targeted_organ).open)
+				H.get_organ(M.targeted_organ).ui_interact(H)
+			// OCCULUS EDIT END
+			else if(show_ssd && !client && !teleop)
 				M.visible_message(SPAN_NOTICE("[M] shakes [src] trying to wake [t_him] up!"), \
 				SPAN_NOTICE("You shake [src], but they do not respond... Maybe they have S.S.D?"))
 			else if(lying || src.sleeping)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -204,13 +204,16 @@
 			var/show_ssd
 			var/target_organ_exists = FALSE
 			var/mob/living/carbon/human/H = src
+			var/playsound = TRUE	// OCCULUS EDIT: Just to skip the shaky noise while doing surgery
+
 			if(istype(H))
 				show_ssd = H.species.show_ssd
 				var/obj/item/organ/external/O = H.get_organ(M.targeted_organ)
 				target_organ_exists = (O && O.is_usable())
 			// OCCULUS EDIT START: Open the surgery UI if the organ is open by clicking the organ.
-			if (target_organ_exists and H.get_organ(M.targeted_organ).open)
-				H.get_organ(M.targeted_organ).ui_interact(H)
+			if (target_organ_exists && H.get_organ(M.targeted_organ).open)
+				H.get_organ(M.targeted_organ).ui_interact(M)
+				playsound = FALSE
 			// OCCULUS EDIT END
 			else if(show_ssd && !client && !teleop)
 				M.visible_message(SPAN_NOTICE("[M] shakes [src] trying to wake [t_him] up!"), \
@@ -247,7 +250,10 @@
 			AdjustStunned(-3)
 			AdjustWeakened(-3)
 
-			playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+			// OCCULUS EDIT: playsound exists so it doesn't play the noise when you open surgeryh UI
+			if (playsound)
+				playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+			// OCCULUS EDIT END
 
 /mob/living/carbon/proc/eyecheck()
 	return 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This is non-modular code that opens the surgery UI if you click the open organ with an empty hand while on help intent.

The purpose of this code is twofold:

1. If you accidentally close the surgery UI, you no longer have to close and re-open the organ to bring the UI back up.
2. Multiple surgeons can now interact in a surgery.

There is also an addition of a variable called 'playsound' that determines if the sound for shaking/hugging/whatever is played. This is TRUE by default and is only set to false if you are clicking on the open organ with help intent.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

It's possible for you to be in a situation where it's good for more than one surgeon to be working on a patient. Specifically, this will allow a situation like a roboticist to be able to insert augmentations after a separate surgeon has opened a patient without needing to close/re-open the incision themself.

## Changelog
```changelog
add: The Surgery UI can now be opened by clicking on the open body part with an empty hand on help intent.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
