### PR TITLE
Changes the medical vendors to no longer have hyposprays, as per request.

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -50862,7 +50862,7 @@
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/medbay)
 "coC" = (
-/obj/machinery/vending/medical/occulus,
+/obj/machinery/vending/medical,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/medbay)
 "coD" = (
@@ -77216,7 +77216,7 @@
 /area/eris/maintenance/oldbridge)
 "dyu" = (
 /obj/item/weapon/autopsy_scanner,
-/obj/structure/closet/secure_closet/reinforced/CMOcculus,
+/obj/structure/closet/secure_closet/reinforced/CMO,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/command/mbo)
 "dyv" = (
@@ -79793,7 +79793,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/vending/medical/occulus,
+/obj/machinery/vending/medical,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/medbreak)
 "dEr" = (


### PR DESCRIPTION
## About The Pull Request

Re-opening https://github.com/Occulus-Server/Occulus-Eris/pull/261 without the maint changes.

## Why It's Good For The Game

Came up in discord, was told to re-open it, re-opened it.

## Changelog
```changelog
del: Reverted mapped medvendors to Eris version, Occulus version is still in code
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
