### PR TITLE
Correct tech origin of spy sensor and propaganda chip

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2812,6 +2812,7 @@
 #include "zzzz_modular_occulus\code\game\objects\effects\decals\Cleanable\misc_occulus.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\oddities.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\plush.dm"
+#include "zzzz_modular_occulus\code\game\objects\items\devices\traitor_devices.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\toys\balls.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\toys\costume.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\toys\laserpointer.dm"

--- a/zzzz_modular_occulus/code/game/objects/items/devices/traitor_devices.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/devices/traitor_devices.dm
@@ -1,0 +1,13 @@
+/obj/item/device/propaganda_chip
+	origin_tech = list(TECH_MAGNET = 3)
+
+	/* Changes from original file: origin_tech was listed as TECH_MAGNETS,
+	   which was a non-existent tech that broke the destructive analyzer.
+	*/
+
+/obj/item/device/spy_sensor
+	origin_tech = list(TECH_MAGNET = 5, TECH_COVERT = 2)
+
+	/* Changes from original file: origin_tech was listed as TECH_MAGNETS,
+	   which was a non-existent tech that broke the destructive analyzer.
+	*/


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #297 

Placing a propaganda chip or a spy sensor into the destructive analyzer caused the research console to lock up because of an invalid tech origin tag -- they were tagged as `TECH_MAGNETS` when they should've been tagged as `TECH_MAGNET`.

Modular code is included with an explanation of what is changed.

DME changes are included: there is a new active file at `zzzz_modular_occulus/code/game/objects/item/devices/traitor_devices.dm`

![image](https://user-images.githubusercontent.com/77511162/109422540-f7472180-79a9-11eb-9b4e-184ef5829e3b.png)
![image](https://user-images.githubusercontent.com/77511162/109422543-f9a97b80-79a9-11eb-92ea-9a078f4caedd.png)

Pictured above: spy sensor and propaganda chip in the analyzer and not breaking things

`
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Previously, if a propaganda chip or a spy sensor was placed into the destructive analyzer, admin invention would be required to clear the analyzer for use.

## Changelog
```changelog
fix: Propaganda chips and spy sensors no longer break the destructive analyzer by having bad tech origin tags.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
