### PR TITLE
Fixes Roach Taming

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/roach/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/attack.dm
@@ -4,7 +4,7 @@
 		if(ishuman(A))
 			var/mob/living/carbon/human/H = L
 			var/obj/item/weapon/reagent_containers/food/snacks/grown/howdoitameahorseinminecraft = H.get_active_hand()
-			if(istype(howdoitameahorseinminecraft) && howdoitameahorseinminecraft.plantname == "ambrosia")
+			if(istype(howdoitameahorseinminecraft))
 				if(try_tame(H, howdoitameahorseinminecraft))
 					return FALSE //If they manage to tame the roach, stop the attack
 		if(istype(L) && !L.weakened && prob(15) && src.density) // Syzygy code to limit knockdown to only dense roaches.

--- a/code/modules/mob/living/carbon/superior_animal/roach/attack.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/attack.dm
@@ -3,8 +3,8 @@
 		var/mob/living/L = A
 		if(ishuman(A))
 			var/mob/living/carbon/human/H = L
-			var/obj/item/weapon/reagent_containers/food/snacks/grown/ambrosiavulgaris/howdoitameahorseinminecraft = H.get_active_hand()
-			if(istype(howdoitameahorseinminecraft))
+			var/obj/item/weapon/reagent_containers/food/snacks/grown/howdoitameahorseinminecraft = H.get_active_hand()
+			if(istype(howdoitameahorseinminecraft) && howdoitameahorseinminecraft.plantname == "ambrosia")
 				if(try_tame(H, howdoitameahorseinminecraft))
 					return FALSE //If they manage to tame the roach, stop the attack
 		if(istype(L) && !L.weakened && prob(15) && src.density) // Syzygy code to limit knockdown to only dense roaches.

--- a/code/modules/mob/living/carbon/superior_animal/roach/riding.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/riding.dm
@@ -8,7 +8,7 @@
 		buckled_mob.forceMove(get_turf(src))
 		buckled_mob.pixel_x = pixel_x
 
-/mob/living/carbon/superior_animal/roach/proc/try_tame(var/mob/living/carbon/user, var/obj/item/weapon/reagent_containers/food/snacks/grown/ambrosiavulgaris/thefood)
+/mob/living/carbon/superior_animal/roach/proc/try_tame(var/mob/living/carbon/user, var/obj/item/weapon/reagent_containers/food/snacks/grown/thefood)
 	if(!istype(thefood))
 		return FALSE
 	if(prob(40))


### PR DESCRIPTION
## About The Pull Request

Fixes a bug in roach taming. Where it only worked with roundstart ambrosia
Also loosened the requirements. Now any grown food can be used to tame a roach.

## Why It's Good For The Game

Mostly because it's a fun thing for vagabonds to do.

## Changelog
```changelog
fix: Roach taming should now function
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
