### PR TITLE
Add check to prevent self-CPR

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -58,6 +58,11 @@
 			if(can_operate(src, M) == CAN_OPERATE_ALL && do_surgery(src, M, null, TRUE))
 				return 1
 			else if(istype(H) && health < HEALTH_THRESHOLD_CRIT && health > HEALTH_THRESHOLD_DEAD)
+				// OCCULUS EDIT: Prevent self-CPR.
+				if(H == src)
+					to_chat(H, SPAN_NOTICE("You cannot perform CPR on yourself."))
+					return
+				// OCCULUS EDIT END
 				if(!H.check_has_mouth())
 					to_chat(H, SPAN_DANGER("You don't have a mouth, you cannot perform CPR!"))
 					return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Theoretically fixes #36 

I was unable to meet the conditions to perform CPR while still conscious, but this code should, in theory, prevent self-CPR if you manage to be conscious when it happens. This code does not normal prevent CPR usage on other mobs.

Code is non-modular.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

The ability to do CPR on yourself is nonsense

## Changelog
```changelog
fix: Self-CPR is no longer possible
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
