### PR TITLE
New formula for self-surgery for more reliance on skills

### DIFF
--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -110,12 +110,17 @@
 
 	// Self-surgery increases failure chance
 	if(owner && user == owner)
-		difficulty_adjust = 20
+		// OCCULUS EDIT START: More severe difficulty for self-surgery
+		if (BP_IS_ROBOTIC(src))	// Prosthetics are not as difficult to operate on
+			difficulty_adjust = 30 + max((STAT_LEVEL_PROF - (user.stats.getStat(STAT_MEC) * 1.16)), 0)
+		else
+			difficulty_adjust = 30 + max(STAT_LEVEL_GODLIKE - (user.stats.getStat(STAT_BIO) * 0.7), 0)
 
 		// ...unless you are a carrion
 		// It makes sense that lings have a way of making their flesh cooperate
 		if(is_carrion(user))
-			difficulty_adjust = -50
+			difficulty_adjust = -100	// OCCULUS EDIT: To accomodate for skill requirement changes
+		// OCCULUS EDIT END
 
 	var/atom/surgery_target = get_surgery_target()
 	if(S.required_tool_quality && (S.required_tool_quality in tool.tool_qualities))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This PR has the intent of making self-surgery more difficult.

The goals are that MEC 60 should be the target level for no chance of failure on prosthetic self-surgery and BIO 100 should be the target for organic self-surgery. The modified code only touches self-surgery instances -- regular surgery chances are unaffected. Also consider that the quality of your tools and their precision do affect your success chances.

Debug messages are in these screenshots but are not in the final code. Changes are non-modular.

![image](https://user-images.githubusercontent.com/77511162/110190175-fe2dc400-7def-11eb-932c-76e1dabf2a8b.png)
![image](https://user-images.githubusercontent.com/77511162/110190178-0128b480-7df0-11eb-9287-e4d1b8178d28.png)

Previous, self-surgery's only difference was a +20% chance of failure. A new formula allows chances to scale depending on your BIO or MEC, depending on if you're operating on an organic limb or a prosthetic limb.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I was asked to make changes after some folks successfully performed self-surgery with low BIO skill, including one guy at BIO 0! That's a silly thing. You need to be very good at BIO to be able to perform surgery on yourself.

## Changelog
```changelog
balance: Self-surgery is now more dependant on your MEC or BIO levels.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
