### PR TITLE
Fixes blattedin reviving occuring when it should not

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/roach/blattedin.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/blattedin.dm
@@ -16,9 +16,11 @@
 	if(istype(M, /mob/living/carbon/superior_animal/roach))
 		var/mob/living/carbon/superior_animal/roach/bug = M
 		if(bug.stat == DEAD)
-			if((bug.blattedin_revives_left >= 0) && prob(70))//Roaches sometimes can come back to life from healing vapors
+			if((bug.blattedin_revives_left > 0) && prob(70))//Roaches sometimes can come back to life from healing vapors Occulus Edit Start
 				bug.blattedin_revives_left = max(0, bug.blattedin_revives_left - 1)
 				bug.rejuvenate()
+			else
+				bug.blattedin_revives_left = max(0, bug.blattedin_revives_left - 1)//Occulus Edit End
 		else
 			bug.heal_organ_damage(heal_strength*removed)
 	else

--- a/zzzz_modular_occulus/code/modules/mob/living/carbon/superior_animal/roach/blattedin.dm
+++ b/zzzz_modular_occulus/code/modules/mob/living/carbon/superior_animal/roach/blattedin.dm
@@ -5,9 +5,11 @@
 	if(istype(M, /mob/living/carbon/superior_animal/roach))
 		var/mob/living/carbon/superior_animal/roach/bug = M
 		if(bug.stat == DEAD)
-			if((bug.blattedin_revives_left >= 0) && prob(70))//Roaches sometimes can come back to life from healing vapors
+			if((bug.blattedin_revives_left > 0) && prob(70))//Roaches sometimes can come back to life from healing vapors
 				bug.blattedin_revives_left = max(0, bug.blattedin_revives_left - 1)
 				bug.rejuvenate()
+			else
+				bug.blattedin_revives_left = max(0, bug.blattedin_revives_left - 1)
 		else
 			bug.heal_organ_damage(heal_strength*removed)
 	else


### PR DESCRIPTION
## About The Pull Request


Blattedin now only revives roaches with revives left in their system.
Blattedin now no longer revives roaches that should not be revived.
Blattedin now only has a 70% chance to revive a roach

## Why It's Good For The Game

Addresses a bug in our bugs.

## Changelog
```changelog
fix:Blattedin revival fixed
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
