### PR TITLE
Prosthetics fabricator can print stomachs now + small clarity tweaks

### DIFF
--- a/code/game/machinery/bioprinter.dm
+++ b/code/game/machinery/bioprinter.dm
@@ -21,7 +21,8 @@
 		OP_LUNGS =   list(/obj/item/organ/internal/lungs,  40),
 		OP_KIDNEYS = list(/obj/item/organ/internal/kidneys,20),
 		OP_EYES =    list(/obj/item/organ/internal/eyes,   30),
-		OP_LIVER =   list(/obj/item/organ/internal/liver,  50)
+		OP_LIVER =   list(/obj/item/organ/internal/liver,  50),
+		OP_STOMACH = list(/obj/item/organ/internal/stomach,50)	// OCCULUS EDIT: Add stomachs to the list
 		)
 
 /obj/machinery/bioprinter/prosthetics
@@ -49,6 +50,7 @@
 
 		if(prints_prosthetics)
 			O.nature = MODIFICATION_SILICON
+			O.name = "synthetic [O.name]"	// OCCULUS EDIT: More identifiably synthetic
 		else if(loaded_dna)
 			visible_message("<span class='notice'>The printer injects the stored DNA into the biomass.</span>.")
 			O.transplant_data = list()
@@ -57,7 +59,7 @@
 			O.transplant_data["blood_type"] = loaded_dna["blood_type"]
 			O.transplant_data["blood_DNA"] =  loaded_dna["blood_DNA"]
 
-		visible_message("<span class='info'>The bioprinter spits out a new organ.</span>")
+		visible_message("<span class='info'>The [src.name] spits out a new [O.name].</span>") // OCCULUS EDIT: More clarity on what's happening
 
 	else
 		to_chat(user, SPAN_WARNING("There is not enough matter in the printer."))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This non-modular code accomplishes the following:

1. All organ fabricators (both Church and robotics' prosthetics fabricator) can now print stomachs.
2. Synthetic organs are now clearly marked as synthetic to avoid confusion.
3. The fabricator output message is more clear about what's going on.

![image](https://user-images.githubusercontent.com/77511162/110251646-6f37bd80-7f4f-11eb-8016-5c980bc468a9.png)
![image](https://user-images.githubusercontent.com/77511162/110251676-9a221180-7f4f-11eb-9936-4d140e914d0a.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

In a recent round, there was an issue where a stomach went septic from necrosis. Robotics was asked to print a new stomach, but it was discovered that stomachs couldn't actually be printed. There was also momentary confusion about which new organ (in the case of also needing lungs) was synthetic.

## Changelog
```changelog
add: Organ fabricators (organic and prosthetic) can now print stomachs.
tweak: Synthetic organs are now more clearly marked in case you find any in the trash.
tweak: Organ fabricators are a little more clear in their production messages.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
