### PR TITLE
Insanity Devices Fix

### DIFF
--- a/code/game/objects/items/devices/mind_fryer.dm
+++ b/code/game/objects/items/devices/mind_fryer.dm
@@ -36,7 +36,7 @@ GLOBAL_LIST_EMPTY(active_mind_fryers)
 
 /obj/item/device/mind_fryer/Process()
 	for(var/mob/living/carbon/human/H in view(src))
-		if(H.get_species() != "Human" || (H in victims) || (owner && H.mind == owner))
+		if((H in victims) || (owner && H.mind == owner)) //Occulus edit
 			continue
 		icon_state = "mind_fryer_running"
 		H.sanity.onPsyDamage(2)
@@ -54,9 +54,10 @@ GLOBAL_LIST_EMPTY(active_mind_fryers)
 		break
 
 /obj/item/device/mind_fryer/proc/reg_break(mob/living/carbon/human/victim)
+/*  Occulus Edit Start
 	if(victim.get_species() != "Human")
 		return
-
+Occulus Edit End */
 	if(owner && owner.current)
 		if(victim == owner.current)
 			return

--- a/code/game/objects/items/weapons/implant/implants/carrion/mindboil_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/mindboil_spider.dm
@@ -31,7 +31,7 @@ GLOBAL_LIST_EMPTY(active_mindboil_spiders)
 		else
 			attack_from = src
 		for(var/mob/living/carbon/human/H in view(5, attack_from))
-			if(H.get_species() != "Human" || (H in victims) || (H == owner_mob))
+			if((H in victims) || (H == owner_mob)) //Occulus Edit
 				continue
 			H.sanity.onPsyDamage(1) //Half the ammount of mind fryer, can be mass produced
 
@@ -53,9 +53,10 @@ GLOBAL_LIST_EMPTY(active_mindboil_spiders)
 		break
 
 /obj/item/weapon/implant/carrion_spider/mindboil/proc/reg_break(mob/living/carbon/human/victim)
+/* Occulus Edit Start
 	if(victim.get_species() != "Human")
 		return
-
+ Occulus Edit End */
 	if(victim == owner_mob)
 		return
 

--- a/code/game/objects/items/weapons/implant/implants/carrion/mindboil_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/mindboil_spider.dm
@@ -53,10 +53,10 @@ GLOBAL_LIST_EMPTY(active_mindboil_spiders)
 		break
 
 /obj/item/weapon/implant/carrion_spider/mindboil/proc/reg_break(mob/living/carbon/human/victim)
-/* Occulus Edit Start
+/*  Occulus Edit Start
 	if(victim.get_species() != "Human")
 		return
- Occulus Edit End */
+Occulus Edit End */
 	if(victim == owner_mob)
 		return
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -182,9 +182,10 @@
 		break
 
 /obj/item/weapon/gun/energy/psychic/proc/reg_break(mob/living/carbon/human/victim)
+/*  Occulus Edit Start
 	if(victim.get_species() != "Human")
 		return
-
+Occulus Edit End */
 	if(!contract)
 		return
 


### PR DESCRIPTION
## About The Pull Request

Makes the Mindboil spiderling, Mindfryer, and Psychic laser cannon work on non-human humanoids and allows them to count for derail objectives

## Why It's Good For The Game

Allows me to turn everyone's brains to mush without using brute force

## Changelog
```changelog
fix: non-human humanoids are now capable of insanity via arachnophobia 
fix: non-human humanoids are now capable of insanity via sparkly pixie machines
```
