### PR TITLE
Adds mind datum check to Insanity Devices

### DIFF
--- a/code/game/objects/items/devices/mind_fryer.dm
+++ b/code/game/objects/items/devices/mind_fryer.dm
@@ -36,7 +36,7 @@ GLOBAL_LIST_EMPTY(active_mind_fryers)
 
 /obj/item/device/mind_fryer/Process()
 	for(var/mob/living/carbon/human/H in view(src))
-		if((H in victims) || (owner && H.mind == owner)) //Occulus edit
+		if((H.get_species() != "Monkey" || (H in victims) || (owner && H.mind == owner)) //Occulus edit
 			continue
 		icon_state = "mind_fryer_running"
 		H.sanity.onPsyDamage(2)

--- a/code/game/objects/items/devices/mind_fryer.dm
+++ b/code/game/objects/items/devices/mind_fryer.dm
@@ -36,7 +36,7 @@ GLOBAL_LIST_EMPTY(active_mind_fryers)
 
 /obj/item/device/mind_fryer/Process()
 	for(var/mob/living/carbon/human/H in view(src))
-		if((H.get_species() != "Monkey" || (H in victims) || (owner && H.mind == owner)) //Occulus edit
+		if(H.get_species() != "Monkey" || (H in victims) || (owner && H.mind == owner)) //Occulus edit
 			continue
 		icon_state = "mind_fryer_running"
 		H.sanity.onPsyDamage(2)

--- a/code/game/objects/items/devices/mind_fryer.dm
+++ b/code/game/objects/items/devices/mind_fryer.dm
@@ -36,7 +36,7 @@ GLOBAL_LIST_EMPTY(active_mind_fryers)
 
 /obj/item/device/mind_fryer/Process()
 	for(var/mob/living/carbon/human/H in view(src))
-		if(H.get_species() != "Monkey" || (H in victims) || (owner && H.mind == owner)) //Occulus edit
+		if(!H.mind || (H in victims) || (owner && H.mind == owner)) //Occulus edit
 			continue
 		icon_state = "mind_fryer_running"
 		H.sanity.onPsyDamage(2)

--- a/code/game/objects/items/weapons/implant/implants/carrion/mindboil_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/mindboil_spider.dm
@@ -31,7 +31,7 @@ GLOBAL_LIST_EMPTY(active_mindboil_spiders)
 		else
 			attack_from = src
 		for(var/mob/living/carbon/human/H in view(5, attack_from))
-			if((H.get_species() != "Monkey" || (H in victims) || (H == owner_mob)) //Occulus Edit
+			if(H.get_species() != "Monkey" || (H in victims) || (H == owner_mob)) //Occulus Edit
 				continue
 			H.sanity.onPsyDamage(1) //Half the ammount of mind fryer, can be mass produced
 

--- a/code/game/objects/items/weapons/implant/implants/carrion/mindboil_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/mindboil_spider.dm
@@ -31,7 +31,7 @@ GLOBAL_LIST_EMPTY(active_mindboil_spiders)
 		else
 			attack_from = src
 		for(var/mob/living/carbon/human/H in view(5, attack_from))
-			if((H in victims) || (H == owner_mob)) //Occulus Edit
+			if((H.get_species() != "Monkey" || (H in victims) || (H == owner_mob)) //Occulus Edit
 				continue
 			H.sanity.onPsyDamage(1) //Half the ammount of mind fryer, can be mass produced
 

--- a/code/game/objects/items/weapons/implant/implants/carrion/mindboil_spider.dm
+++ b/code/game/objects/items/weapons/implant/implants/carrion/mindboil_spider.dm
@@ -31,7 +31,7 @@ GLOBAL_LIST_EMPTY(active_mindboil_spiders)
 		else
 			attack_from = src
 		for(var/mob/living/carbon/human/H in view(5, attack_from))
-			if(H.get_species() != "Monkey" || (H in victims) || (H == owner_mob)) //Occulus Edit
+			if(!H.mind || (H in victims) || (H == owner_mob)) //Occulus Edit
 				continue
 			H.sanity.onPsyDamage(1) //Half the ammount of mind fryer, can be mass produced
 


### PR DESCRIPTION

## About The Pull Request

Makes it so monkeys and null-minds dont go insane from insanity devices

## Why It's Good For The Game

No more free TC by dropping mindboilers in the monkey pit

## Changelog
```changelog
balance: Monkeys and nullminds are no longer capable of insanity via sparkly pixie machines
balance: Monkeys and nullminds are no longer capable of insanity via arachnaphobia
```
