### PR TITLE
Changing Cruciform restrictions

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2789,6 +2789,7 @@
 #include "zzzz_modular_occulus\code\datums\autolathe\guns.dm"
 #include "zzzz_modular_occulus\code\datums\objective\blitzshell.dm"
 #include "zzzz_modular_occulus\code\datums\perks\oddity.dm"
+#include "zzzz_modular_occulus\code\datums\setup_option\core_implants.dm"
 #include "zzzz_modular_occulus\code\datums\uplink\devices and tools.dm"
 #include "zzzz_modular_occulus\code\datums\uplink\medical.dm"
 #include "zzzz_modular_occulus\code\game\occulus-lore-fixes.dm"

--- a/zzzz_modular_occulus/code/datums/setup_option/core_implants.dm
+++ b/zzzz_modular_occulus/code/datums/setup_option/core_implants.dm
@@ -1,0 +1,2 @@
+/datum/category_item/setup_option/core_implant/cruciform
+	restricted_depts = SCIENCE | COMMAND


### PR DESCRIPTION
## About The Pull Request

As per emojicracy, Aegis can now be cruciformed.
Research department staff can no longer be cruciformed

## Why It's Good For The Game

Bringing our restrictions more in line with lore.
- NT focuses on soulcrypt technology. 
- Aegis here is not the Syndicate and MEK are not NT like on Eris prime

## Changelog
```changelog
tweak: cruciform restrictions
```
