### PR TITLE
Aegis artifact now dispenses masterpiece donuts

### DIFF
--- a/zzzz_modular_occulus/code/modules/game/Objects/Items/Devices/artifacts.dm
+++ b/zzzz_modular_occulus/code/modules/game/Objects/Items/Devices/artifacts.dm
@@ -1,14 +1,27 @@
 /obj/item/biosyphon
 	desc = "A device found within the Northern Light when it was first explored. No expert has any idea how or where it makes anything - but given that it only prints donuts it naturally became Aegis property"
-	
+
+/obj/item/biosyphon/Process()
+	if(world.time >= (last_produce + cooldown))
+		var/path = pick(/obj/item/weapon/reagent_containers/food/snacks/donut/stat_buff/mec,
+		/obj/item/weapon/reagent_containers/food/snacks/donut/stat_buff/cog,
+		/obj/item/weapon/reagent_containers/food/snacks/donut/stat_buff/bio,
+		/obj/item/weapon/reagent_containers/food/snacks/donut/stat_buff/rob,
+		/obj/item/weapon/reagent_containers/food/snacks/donut/stat_buff/tgh,
+		/obj/item/weapon/reagent_containers/food/snacks/donut/stat_buff/vig)
+
+		var/obj/item/weapon/reagent_containers/food/snacks/donut/stat_buff/D = new path(get_turf(src))
+		visible_message(SPAN_NOTICE("[name] dispenses [D]."))
+		last_produce = world.time
+
 /obj/item/device/radio/random_radio
 	desc = "Radio that can pick up message from secure channels, or other places and times. No one's sure where it knows loot is, but is that really a question you want to ask?"
-	
+
 /obj/item/device/techno_tribalism
 	name = "The Cube"
 	desc = "An unknown device that feeds on rare tools, tool mods and other tech items. After being fed enough, will produce a strange technological part that doesn't seem to fit in anything."
-	
+
 /obj/item/device/von_krabin
 	name = "Von-Krabin Stimulator"
 	desc = "Named after the doctor who found this within the vessel, it seems to stimulate cognitive functions through unknown means."
-	
+


### PR DESCRIPTION
## About The Pull Request

The Aegis artifact now dispenses masterpiece donuts. These boost stats by 6 for 20 minutes, but don't stack.

## Why It's Good For The Game

A small buff for the fairly useless Aegis artifact

## Changelog
```changelog
balance: The aegis artifact has been upgraded!
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
