### PR TITLE
Pouch and belt storage nerf

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2831,6 +2831,8 @@
 #include "zzzz_modular_occulus\code\game\objects\items\weapons\implant\implants\carrion\smoker_spider.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\weapons\storage\belt.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\weapons\storage\firstaid.dm"
+#include "zzzz_modular_occulus\code\game\objects\items\weapons\storage\pouches.dm"
+#include "zzzz_modular_occulus\code\game\objects\items\weapons\storage\storage.dm"
 #include "zzzz_modular_occulus\code\game\objects\random\utility.dm"
 #include "zzzz_modular_occulus\code\game\objects\structures\curtains.dm"
 #include "zzzz_modular_occulus\code\game\objects\structures\evacsign.dm"

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/mekhane_armory.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/mekhane_armory.dm
@@ -61,6 +61,7 @@ ARMOR_PEN_MASSIVE			30
 	name = "Mekhane Shortsword"
 	force = WEAPON_FORCE_ROBUST	// Buffed one notch up
 	armor_penetration = ARMOR_PEN_GRAZING	// Nerfed down two notches
+	w_class = ITEM_SIZE_NORMAL // These specifically fit on toolbelts
 
 /obj/item/weapon/tool/sword/nt/longsword
 	name = "Mekhane Longsword"

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/storage/pouches.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/storage/pouches.dm
@@ -1,0 +1,46 @@
+/obj/item/weapon/storage/pouch/small_generic
+	desc = "Can hold a handful of objects."
+
+/obj/item/weapon/storage/pouch/medium_generic
+	desc = "Can hold a fair number of small objects."
+
+/obj/item/weapon/storage/pouch/baton_holster
+	can_hold = list(
+		/obj/item/weapon/melee,
+		/obj/item/weapon/tool/crowbar,
+		/obj/item/device/lighting/toggleable/flashlight,
+		/obj/item/weapon/tool/shovel/spade,
+		/obj/item/stack/rods
+		)
+
+/obj/item/clothing/suit
+	allowed = list(
+		/obj/item/weapon/clipboard,
+		/obj/item/weapon/storage/pouch,
+		/obj/item/weapon/gun,
+		/obj/item/weapon/melee,
+		/obj/item/weapon/material,
+		/obj/item/ammo_magazine,
+		/obj/item/ammo_casing,
+		/obj/item/weapon/handcuffs,
+		/obj/item/weapon/tank,
+		/obj/item/device/suit_cooling_unit,
+		/obj/item/weapon/cell,
+		/obj/item/weapon/storage/fancy,
+		/obj/item/weapon/flamethrower,
+		/obj/item/device/lighting,
+		/obj/item/device/scanner,
+		/obj/item/weapon/reagent_containers/spray,
+		/obj/item/device/radio,
+		/obj/item/clothing/mask,
+		/obj/item/weapon/storage/sheath)
+
+/obj/item/weapon/storage/sheath
+	can_hold = list(
+		/obj/item/weapon/tool/sword/,
+		/obj/item/weapon/tool/knife/)
+	cant_hold = list()
+	slot_flags = SLOT_BELT | SLOT_POCKET | SLOT_BACK
+
+/obj/item/weapon/tool/sword
+	w_class = ITEM_SIZE_BULKY

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/storage/storage.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/storage/storage.dm
@@ -1,0 +1,29 @@
+/obj/item/weapon/storage/pouch/get_storage_cost()
+	var/totalvolume = BASE_STORAGE_COST(w_class)
+	for(var/obj/item/I in contents)
+		totalvolume += I.get_storage_cost()/2
+	return totalvolume
+
+/obj/item/weapon/storage/pouch/ammo/get_storage_cost()
+	return BASE_STORAGE_COST(w_class)
+
+/obj/item/weapon/storage/pouch/small_generic/get_storage_cost()
+	return BASE_STORAGE_COST(w_class)
+
+/obj/item/weapon/storage/pouch/large_generic/get_storage_cost()
+	return BASE_STORAGE_COST(w_class)
+
+/obj/item/weapon/storage/pouch/holding/get_storage_cost()
+	return BASE_STORAGE_COST(w_class)
+
+/obj/item/weapon/storage/belt/get_storage_cost()
+	var/totalvolume = BASE_STORAGE_COST(w_class)
+	for(var/obj/item/I in contents)
+		totalvolume += I.get_storage_cost()/2
+	return totalvolume
+
+/obj/item/weapon/storage/toolbox/get_storage_cost()
+	var/totalvolume = BASE_STORAGE_COST(w_class)
+	for(var/obj/item/I in contents)
+		totalvolume += I.get_storage_cost()/2
+	return totalvolume

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/storage/storage.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/storage/storage.dm
@@ -10,9 +10,6 @@
 /obj/item/weapon/storage/pouch/small_generic/get_storage_cost()
 	return BASE_STORAGE_COST(w_class)
 
-/obj/item/weapon/storage/pouch/large_generic/get_storage_cost()
-	return BASE_STORAGE_COST(w_class)
-
 /obj/item/weapon/storage/pouch/holding/get_storage_cost()
 	return BASE_STORAGE_COST(w_class)
 
@@ -27,3 +24,6 @@
 	for(var/obj/item/I in contents)
 		totalvolume += I.get_storage_cost()/2
 	return totalvolume
+
+/obj/item/weapon/storage/pouch/large_generic
+	rarity_value = 40


### PR DESCRIPTION
## About The Pull Request

Storage Pouches, belts, and toolboxes take up more space depending on how full they are.
Small, Holding, and Ammo pouches are exempt from this.
Sheaths now fit in your pockets, on your back, and in suit storage
Baton Holsters can now fit flashlights, spades, and stacks of rods
All swords and knives now fit in sheaths

## Why It's Good For The Game

Stacking storage items allows people to get stupid amounts of storage on their person. Now putting your pouch or toolbelt in your bag has downsides.

Buffs a few less-used storage items by making them more desirable.

## Changelog
```changelog
balance: item belts now take up more space inside another container depending on how full they are
balance: most pouches now take up more space inside other containers depending on how full they are
balance: all swords now fit in sheaths
balance: baton holsters now hold more items
balance: sheaths now fit in your pockets, on your back, or in your suit storage!
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
