### PR TITLE
Autodoc: Skip empty operations

### DIFF
--- a/code/modules/surgery/autodoc.dm
+++ b/code/modules/surgery/autodoc.dm
@@ -186,14 +186,32 @@
 /datum/autodoc/Process()
 	if(!patient)
 		stop()
+
+
+	/* OCCULUS EDIT START: Skip empty patchnotes. This is not the most ideal
+	   solution -- ideally, picked_patchnotes would not be populated with
+	   empty notes, but unfortunately the code is unintuitive and not
+	   programmed this way. I am not yet skilled enough to disentangle the
+	   code to rewrite it properly. */
+
 	if(current_step > picked_patchnotes.len)
 		stop()
+		to_chat(patient, SPAN_NOTICE("Operations complete."))	// OCCULUS EDIT: Tell the patient when it's over
 		scan_user(patient)
-	if(world.time > (start_op_time + processing_speed))
-		start_op_time = world.time
-		patient.updatehealth()
-		if(process_note(picked_patchnotes[current_step]))
+	else
+
+		var/datum/autodoc_patchnote/next_note = picked_patchnotes[current_step]
+
+		if(!next_note.surgery_operations)
 			current_step++
+		else
+			if(world.time > (start_op_time + processing_speed))
+				start_op_time = world.time
+				patient.updatehealth()
+				if(process_note(next_note))
+					current_step++
+
+	// OCCULUS EDIT END
 
 /datum/autodoc/proc/fail()
 	current_step++


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #259 

This non-modular code improves the autodoc code so that it skips empty operations rather than making the user wait for it to process before saying 'oh, nothing to do!'

This is not the most ideal way to do it -- ideally, the code would be rewritten in a way that notes not in the `picked_patchnotes` variable do not cause the UI to explode. Unfortunately, excluding empty patchnotes results in the autodoc UI becoming unresponsive. I am not skilled enough to disentangle the code to rewrite it, since it also involves .tmpl files.

Nonetheless, this code no longer makes players wait for multiple treatments when they have only selected one.

Finally, this also fixes a runtime in the autodoc code where it would try to check for a non-existent surgery operation (due to faulty code logic.) The runtime is harmless as the code was terminating anyway but it still fixes it nonetheless.

Thank you very much to Flipp for the thorough investigation into why the code was misbehaving.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

On the player side of things, you are no longer waiting a very long time if you want to fix only a certain thing, which is the case for many deckhands/vagabonds using the machine. If you have multiple injuries and you only want to fix your ribs, this will only fix your ribs instead of iterating over every other possible treatment for 30 seconds each time and _then_ saying there's nothing to fix.

## Changelog
```changelog
fix: Autodoc will no longer attempt (empty) operations that you haven't selected.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
