### PR TITLE
Allow .40 ammo to stack to 15 casings

### DIFF
--- a/zzzz_modular_occulus/code/modules/projectiles/ammunition/bullets.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/ammunition/bullets.dm
@@ -2,3 +2,6 @@
 	icon = 'zzzz_modular_occulus/icons/obj/ammo.dmi'
 	icon_state = "75"
 	spent_icon = "75-spent"
+
+/obj/item/ammo_casing/magnum
+	maxamount = 15


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #221 

This modular code allows .40 ammo to stack to 15, as they were previously reported to be able to do so. It may be that the original coder that reduced them to 6 had only revolvers in mind.

I do notice that other bullets are also limited to less than 15, but this may be for balance reasons, like shotgun shells and anti-materiel rifles. Allowing other ammo types to stack up to 15 might be a topic for a small discussion.

![image](https://user-images.githubusercontent.com/77511162/111057671-4172dd00-8457-11eb-9c66-f6ecc8410daf.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

This saves .40 ammo users some headache when trying to organize their loose ammo.

## Changelog
```changelog
tweak: .40 ammo can stack to 15 casings, up from 6
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
