### PR TITLE
Aegis maptweaks

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -159,6 +159,9 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/bed/chair/sofa/teal/right{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/security/main)
 "aaA" = (
@@ -179,6 +182,9 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/table/standard,
+/obj/item/weapon/deck/cards,
+/obj/spawner/gun/normal/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/security/barracks{
 	name = "Aegis Barracks"
@@ -3208,6 +3214,7 @@
 /obj/machinery/light/small,
 /obj/item/weapon/bedsheet/red,
 /obj/structure/bed,
+/obj/spawner/knife/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/security/prison)
 "ahR" = (
@@ -5237,6 +5244,7 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
+/obj/item/weapon/storage/pill_bottle/tramadol,
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/security/exerooms)
 "amp" = (
@@ -20406,8 +20414,11 @@
 /obj/item/stack/material/steel{
 	amount = 120
 	},
-/obj/item/stack/material/steel{
+/obj/item/stack/material/glass{
 	amount = 120
+	},
+/obj/item/stack/material/plasteel{
+	amount = 10
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/security/warden)
@@ -21671,6 +21682,7 @@
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/misc,
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/security,
 /obj/item/weapon/reagent_containers/glass/beaker,
+/obj/machinery/smartfridge/disks,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/security/warden)
 "aZH" = (
@@ -103817,6 +103829,12 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/wood,
 /area/eris/maintenance/section4deck4central)
+"gMa" = (
+/obj/structure/bed/chair/sofa/teal/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/eris/security/main)
 "gOy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -104155,6 +104173,13 @@
 /obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/crew_quarters/clothingstorage)
+"ihK" = (
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eris/security/prison)
 "iiw" = (
 /obj/structure/multiz/stairs/active{
 	dir = 8
@@ -104300,6 +104325,12 @@
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled/steel/panels,
 /area/eris/engineering/post)
+"iOT" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/eris/security/barracks{
+	name = "Aegis Barracks"
+	})
 "iSq" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -104528,6 +104559,7 @@
 /obj/item/weapon/bedsheet/yellow,
 /obj/structure/bed,
 /obj/machinery/light/small,
+/obj/spawner/knife/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/security/prison)
 "jKd" = (
@@ -104934,6 +104966,13 @@
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section1deck4central)
+"lmw" = (
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/eris/security/prison)
 "lnT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
@@ -105026,6 +105065,12 @@
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/storage)
+"lDP" = (
+/obj/structure/bed/chair/sofa/teal/left{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/eris/security/main)
 "lFi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -105974,6 +106019,12 @@
 /obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section4deck4central)
+"oUv" = (
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/eris/security/prison)
 "oWd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -107201,6 +107252,14 @@
 /obj/effect/decal/warning_stripes,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/hangarsupply)
+"uef" = (
+/obj/structure/table/standard,
+/obj/spawner/pizza/low_chance,
+/obj/spawner/booze/low_chance,
+/obj/spawner/booze/low_chance,
+/obj/spawner/booze/low_chance,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/eris/security/main)
 "ueE" = (
 /obj/structure/railing{
 	dir = 1
@@ -124591,7 +124650,7 @@ aaa
 aaa
 aaa
 abH
-acg
+oUv
 acD
 add
 ady
@@ -126616,7 +126675,7 @@ adN
 aen
 ael
 ael
-aei
+lmw
 app
 app
 abH
@@ -127613,8 +127672,8 @@ aaa
 aaa
 aac
 aaj
-aaj
-aaj
+lDP
+gMa
 aab
 aaa
 aaG
@@ -128018,7 +128077,7 @@ aaa
 aac
 aaj
 aaj
-aaj
+uef
 aab
 aaq
 aaG
@@ -128030,7 +128089,7 @@ awa
 kGS
 acC
 acC
-acC
+ihK
 abH
 aei
 aeT
@@ -131250,7 +131309,7 @@ aaa
 aag
 aas
 aas
-aas
+iOT
 aaf
 aaR
 aaR
@@ -131654,7 +131713,7 @@ aaa
 aag
 aas
 aas
-aas
+iOT
 aag
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request

Some small tweaks to Aegis
- Added a bottle of tramadol to the Aegis infirmery
- Added 10 plasteel to the Aegis lathe area, allowing them to print a handful of silencers or tactical knives at roundstart.
- Added 120 glass to the Aegis lathe area
- Reduced Aegis lathe metal to 120 from 240
- Added a disk toaster to the Aegis lathe area
- Added a cryo computer to the permabrig so the cryopod works and stops spamming admins
- Added intercomms to the permabrig so people can't get memory holed. The console is outside of the brig proper so prisoners cannot retrieve weapons.
- Off-duty operatives have spruced up the forward posts slightly, as they were disused

![image](https://user-images.githubusercontent.com/1775680/111240458-a8b49c80-85d1-11eb-972b-bd03040a969d.png)


## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
add: Added a bottle of tramadol to the Aegis infirmery
add: Added 10 plasteel to the Aegis lathe area, allowing them to print a handful of silencers or tactical knives at roundstart.
add: Added 120 glass to the Aegis lathe area
remove: Reduced Aegis lathe metal to 120 from 240
add: Added a disk toaster to the Aegis lathe area
add: Added a cryo computer to the permabrig so the cryopod works and stops spamming admins
add: Added intercomms to the permabrig so people can't get memory holed. The console is outside of the brig proper so prisoners cannot retrieve weapons.
tweak: Off-duty operatives have spruced up the forward posts slightly, as they were disused
```


