### PR TITLE
Aegis and Cargo Maptweaks

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -103521,12 +103521,10 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/eris/crew_quarters/bar)
 "fmD" = (
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/spawner/scrap/sparse,
+/obj/structure/catwalk,
+/obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/plating/under,
-/area/eris/maintenance/section1deck4central)
+/area/eris/maintenance/section1deck5central)
 "fmL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -104252,6 +104250,13 @@
 /obj/structure/railing,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
+"ika" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/oil,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/eris/maintenance/section1deck4central)
 "ikb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/railing{
@@ -104295,6 +104300,10 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engine_room)
+"iwP" = (
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/eris/maintenance/section1deck4central)
 "ixv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
@@ -104576,8 +104585,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/obj/spawner/scrap/sparse,
-/turf/simulated/floor/plating/under,
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "jDU" = (
 /obj/machinery/door/firedoor,
@@ -104964,8 +104974,14 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
 	},
-/obj/spawner/scrap/sparse,
-/turf/simulated/floor/plating/under,
+/obj/spawner/pouch,
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/light/small,
+/obj/item/clothing/mask/gas/sexyclown,
+/obj/item/clothing/mask/gas/sexymime,
+/obj/item/clothing/mask/muzzle,
+/obj/item/weapon/handcuffs/zipties,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "lcL" = (
 /obj/structure/table/standard,
@@ -105388,14 +105404,10 @@
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/eris/quartermaster/storage)
 "mAW" = (
-/obj/structure/railing{
+/obj/structure/bed/chair{
 	dir = 8
 	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/spawner/junk/low_chance,
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "mCf" = (
 /obj/machinery/access_button{
@@ -105672,7 +105684,11 @@
 /turf/simulated/open,
 /area/eris/crew_quarters/bar)
 "nlp" = (
-/obj/spawner/pouch,
+/obj/structure/curtain/open/bed{
+	anchored = 1;
+	color = "#18273B";
+	name = "curtain"
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "nlx" = (
@@ -105720,6 +105736,12 @@
 /area/eris/maintenance/section4deck4central)
 "nsy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/curtain/open/bed{
+	anchored = 1;
+	color = "#18273B";
+	name = "curtain"
+	},
+/obj/structure/low_wall,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "ntp" = (
@@ -106174,8 +106196,7 @@
 /obj/structure/sign/atmos_air{
 	pixel_y = -32
 	},
-/obj/spawner/junk/low_chance,
-/turf/simulated/floor/plating/under,
+/turf/simulated/wall,
 /area/eris/maintenance/section1deck4central)
 "pbX" = (
 /obj/structure/table/standard,
@@ -106298,9 +106319,9 @@
 /turf/simulated/open,
 /area/eris/quartermaster/storage)
 "pxq" = (
-/obj/structure/catwalk,
-/obj/spawner/junk/low_chance,
-/turf/simulated/floor/plating/under,
+/obj/structure/table/steel,
+/obj/machinery/microwave,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "pyy" = (
 /obj/structure/table/woodentable,
@@ -106326,13 +106347,10 @@
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section1deck4central)
 "pCO" = (
-/obj/structure/railing{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 4
 	},
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "pGF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -106344,7 +106362,10 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/eris/maintenance/section4deck4central)
 "pJu" = (
-/obj/structure/bed/chair,
+/obj/structure/table/steel,
+/obj/item/stack/medical/bruise_pack/handmade,
+/obj/item/stack/medical/ointment,
+/obj/spawner/booze/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "pJI" = (
@@ -106546,7 +106567,9 @@
 /obj/machinery/door/airlock/maintenance_common{
 	name = "Central Maintenance"
 	},
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/techmaint{
+	name = "fucking tile"
+	},
 /area/eris/maintenance/section1deck4central)
 "qFD" = (
 /obj/structure/closet/cabinet,
@@ -106629,6 +106652,7 @@
 /obj/item/weapon/reagent_containers/food/drinks/cans/thirteenloko{
 	pixel_x = 5
 	},
+/obj/spawner/booze/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "rcr" = (
@@ -107179,8 +107203,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck1port)
 "tfd" = (
-/obj/spawner/junk/low_chance,
-/turf/simulated/floor/tiled/dark/techfloor,
+/obj/structure/curtain/open/bed{
+	anchored = 1;
+	color = "#18273B";
+	name = "curtain"
+	},
+/obj/structure/low_wall,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "tin" = (
 /obj/effect/window_lwall_spawn/smartspawn,
@@ -107281,6 +107310,13 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/office)
+"tAK" = (
+/obj/effect/floor_decal/industrial/warning/dust{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/eris/maintenance/section1deck4central)
 "tGj" = (
 /obj/machinery/light,
 /obj/structure/table/glass,
@@ -107409,12 +107445,8 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/security/main)
 "ueE" = (
-/obj/structure/railing{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/spawner/junk/low_chance,
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "uie" = (
 /obj/structure/railing{
@@ -107551,11 +107583,14 @@
 /turf/simulated/floor/bluegrid,
 /area/eris/hallway/main/section3)
 "uyJ" = (
-/obj/structure/railing{
-	dir = 1
+/obj/structure/low_wall,
+/obj/structure/curtain/open/bed{
+	anchored = 1;
+	color = "#18273B";
+	name = "curtain"
 	},
-/obj/spawner/junk/low_chance,
-/turf/simulated/floor/plating/under,
+/obj/spawner/booze/low_chance,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "uCf" = (
 /obj/structure/disposalpipe/segment,
@@ -107716,6 +107751,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/maintenance/section2deck1port)
+"vhf" = (
+/obj/effect/decal/cleanable/blood,
+/turf/simulated/floor/tiled/dark/techfloor,
+/area/eris/maintenance/section1deck4central)
 "vhC" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/hull,
@@ -108266,8 +108305,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/obj/spawner/scrap/sparse,
-/turf/simulated/floor/plating/under,
+/obj/structure/bed/padded,
+/obj/item/weapon/bedsheet,
+/obj/effect/decal/cleanable/blood{
+	basecolor = "#FFFFFF";
+	dryname = "dried fluid";
+	name = "fluid"
+	},
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "xue" = (
 /obj/structure/railing{
@@ -119660,7 +119705,7 @@ xLv
 akZ
 pcE
 xLv
-akZ
+fmD
 pcE
 dzq
 aaa
@@ -120064,7 +120109,7 @@ xLv
 akZ
 vAe
 xLv
-akZ
+fmD
 gTM
 dzq
 aaa
@@ -120266,7 +120311,7 @@ hcY
 akZ
 pcE
 uuk
-akZ
+fmD
 pcE
 dzi
 aaa
@@ -120468,7 +120513,7 @@ xLv
 akZ
 vAe
 rWu
-akZ
+fmD
 gTM
 dzi
 aaa
@@ -120670,7 +120715,7 @@ hcY
 akZ
 rjs
 rWu
-akZ
+fmD
 rjs
 dzi
 aaa
@@ -120872,7 +120917,7 @@ oOh
 fcw
 pcE
 uuk
-akZ
+fmD
 vAe
 dzi
 aaa
@@ -159649,7 +159694,7 @@ aaa
 aaa
 csS
 eLF
-pxq
+eLF
 eLF
 eLF
 kSN
@@ -160055,7 +160100,7 @@ csS
 mZS
 qnY
 cvH
-pJu
+hsA
 pCM
 kAo
 hLb
@@ -160255,15 +160300,15 @@ aaa
 aaa
 csS
 cvH
-cyw
+cvH
 cvH
 pJu
 csU
 uYv
 iaa
+ika
 iaa
-iaa
-iaa
+tAK
 tqo
 csS
 aaa
@@ -160458,13 +160503,13 @@ aaa
 csS
 rzU
 cvH
-cyw
-aLc
+cvH
+mAW
 csU
 eJJ
 pze
-tfd
 pze
+iwP
 pze
 gUI
 csS
@@ -160658,16 +160703,16 @@ aaa
 aaa
 aaa
 csS
-cyw
 cvH
+pxq
 mAW
 pCO
 xlB
 lmn
+iwP
 pze
 pze
-tfd
-pze
+vhf
 rKC
 csS
 aaa
@@ -160861,12 +160906,12 @@ aaa
 aaa
 csS
 mZS
-cvH
+xlB
 uyJ
 paB
 xlB
 eJJ
-tfd
+pze
 wZK
 wZK
 pze
@@ -161063,8 +161108,8 @@ aaa
 aaa
 csS
 cvH
+tfd
 cvH
-fmD
 jBw
 xlB
 eJJ
@@ -161266,14 +161311,14 @@ aaa
 xFf
 cvH
 nlp
-uyJ
+cvH
 kYr
 xlB
 eJJ
 pze
 rKC
 eJJ
-tfd
+pze
 rKC
 csS
 aaa

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -9788,10 +9788,6 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck2starboard)
 "axs" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "silk_road";
-	name = "conveyor switch (Silk Road)"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
@@ -9799,7 +9795,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/steel,
+/obj/structure/closet/crate/radiation,
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/hangarsupply)
 "axt" = (
 /obj/structure/disposalpipe/segment,
@@ -28550,6 +28551,10 @@
 /area/eris/medical/morgue)
 "boj" = (
 /obj/machinery/light,
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled/dark,
 /area/eris/medical/morgue)
 "bok" = (
@@ -34151,9 +34156,6 @@
 /obj/spawner/firstaid,
 /obj/spawner/firstaid/low_chance,
 /obj/spawner/firstaid/low_chance,
-/obj/structure/railing/grey{
-	dir = 4
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/hangarsupply)
@@ -35313,7 +35315,6 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section4deck4port)
 "bEM" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
@@ -35780,7 +35781,6 @@
 /turf/simulated/open,
 /area/eris/engineering/atmos)
 "bFK" = (
-/obj/structure/disposalpipe/segment,
 /obj/spawner/mob/spiders/cluster/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
@@ -37515,7 +37515,29 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
+/obj/spawner/boxes/low_chance,
+/obj/spawner/boxes/low_chance,
+/obj/spawner/boxes/low_chance,
+/obj/spawner/boxes/low_chance,
+/obj/spawner/contraband/low_chance,
+/obj/item/weapon/caution{
+	name = "Caution Sign"
+	},
+/obj/item/weapon/caution{
+	name = "Caution Sign"
+	},
+/obj/structure/closet/crate,
+/obj/item/weapon/caution{
+	name = "Caution Sign"
+	},
+/obj/item/weapon/caution{
+	name = "Caution Sign"
+	},
+/obj/structure/railing/grey{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/hangarsupply)
 "bJo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -41189,9 +41211,6 @@
 	id = "silk_road_shutters";
 	name = "Silk Road Shutters Control";
 	pixel_y = -24
-	},
-/obj/structure/railing/grey{
-	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel/cargo,
@@ -46536,6 +46555,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/effect/decal/cleanable/blood/drip,
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
 "cep" = (
@@ -47348,6 +47368,7 @@
 "cfW" = (
 /obj/structure/closet/crate/internals,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/decal/cleanable/blood,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/hangarsupply)
 "cfX" = (
@@ -47539,10 +47560,10 @@
 /obj/spawner/lowkeyrandom/low_chance,
 /obj/spawner/lowkeyrandom/low_chance,
 /obj/spawner/lowkeyrandom/low_chance,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/railing/grey{
 	dir = 4
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/hangarsupply)
 "cgq" = (
@@ -55909,9 +55930,9 @@
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/office)
 "cAR" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/disposalpipe/junction{
 	dir = 2;
-	icon_state = "pipe-c"
+	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -55966,6 +55987,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cAZ" = (
@@ -56590,6 +56614,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cCo" = (
@@ -57023,11 +57050,11 @@
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/eris/crew_quarters/bar)
 "cDk" = (
-/obj/structure/disposalpipe/junction{
-	dir = 2;
-	icon_state = "pipe-j2"
-	},
 /obj/structure/railing,
+/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cDl" = (
@@ -57115,20 +57142,20 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section4deck3port)
 "cDw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/railing{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/item/clothing/head/hardhat/orange{
+	desc = "A piece of headgear used in dangerous working conditions to protect the head. Comes with a built-in flashlight. This one has a FTU logo on it.";
+	name = "FTU hard hat"
 	},
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/section3deck4central)
+/obj/effect/decal/cleanable/blood/drip,
+/turf/simulated/floor/tiled/steel/monofloor,
+/area/eris/quartermaster/hangarsupply)
 "cDx" = (
 /obj/machinery/vending/powermat,
 /turf/simulated/floor/carpet/turcarpet,
@@ -57322,10 +57349,6 @@
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/crew_quarters/fitness)
 "cDS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 8;
-	icon_state = "pipe-c"
-	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating/under,
@@ -57434,9 +57457,9 @@
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/hallway/side/section3starboard)
 "cEe" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j2"
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -72911,8 +72934,15 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/medical/medbreak)
 "dol" = (
-/turf/simulated/floor/plating/under,
-/area/eris/medical/morgue)
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "silk_road";
+	name = "conveyor switch (Silk Road)"
+	},
+/turf/simulated/floor/tiled/steel,
+/area/eris/quartermaster/hangarsupply)
 "dom" = (
 /obj/structure/lattice,
 /obj/structure/cable/green{
@@ -75135,14 +75165,11 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/security/checkpoint/supply)
 "dtw" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 4
+/obj/structure/morgue,
+/obj/machinery/camera/network/medbay{
+	dir = 1
 	},
-/obj/machinery/disposal/deliveryChute{
-	dir = 8;
-	name = "Morgue Express"
-	},
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/medical/morgue)
 "dtx" = (
 /obj/spawner/junk/low_chance,
@@ -75442,7 +75469,11 @@
 /turf/simulated/floor/plating/under,
 /area/turret_protected/ai)
 "duo" = (
-/turf/simulated/open,
+/obj/structure/disposalpipe/segment{
+	dir = 2;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
 /area/eris/medical/morgue)
 "dup" = (
 /obj/structure/disposalpipe/segment{
@@ -75902,10 +75933,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck3port)
 "dvn" = (
-/obj/machinery/camera/network/medbay{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/gray_platform,
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/medical/morgue)
 "dvo" = (
 /obj/machinery/firealarm{
@@ -79937,13 +79967,10 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck5central)
 "dEN" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/structure/disposaloutlet{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/medical/morgue)
 "dEP" = (
 /obj/machinery/light{
@@ -92560,7 +92587,18 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/eris/crew_quarters/clothingstorage)
 "eiN" = (
-/turf/simulated/floor/plating/under,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "CargoTotalLockdown";
+	layer = 2.6;
+	name = "Cargo Total Lockdown";
+	opacity = 0
+	},
+/turf/simulated/floor/plating,
 /area/eris/quartermaster/misc)
 "eiO" = (
 /obj/structure/disposalpipe/segment{
@@ -93396,11 +93434,17 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck1central)
 "ekq" = (
-/obj/machinery/disposal/deliveryChute{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "CargoTotalLockdown";
+	layer = 2.6;
+	name = "Cargo Total Lockdown";
+	opacity = 0
 	},
-/obj/structure/disposalpipe/trunk,
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/plating,
 /area/eris/quartermaster/misc)
 "ekr" = (
 /obj/structure/disposaloutlet{
@@ -94241,7 +94285,6 @@
 /turf/simulated/floor/plating,
 /area/eris/crew_quarters/clownoffice)
 "emH" = (
-/obj/structure/plasticflaps/mining,
 /turf/simulated/floor/plating/under,
 /area/eris/quartermaster/misc)
 "emI" = (
@@ -94332,13 +94375,6 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck1central)
-"emU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
-/turf/simulated/floor/plating/under,
-/area/eris/quartermaster/misc)
 "emV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/spawner/junk/low_chance,
@@ -94383,7 +94419,6 @@
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/xenobiology/xenoflora)
 "ena" = (
-/obj/structure/plasticflaps/mining,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -98565,6 +98600,9 @@
 /obj/structure/catwalk,
 /obj/machinery/camera/network/third_section{
 	dir = 1
+	},
+/obj/structure/disposalpipe/down{
+	dir = 4
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/storage)
@@ -103502,11 +103540,11 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/crew_quarters/clothingstorage)
 "foB" = (
+/obj/structure/ore_box,
+/obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/railing/grey{
 	dir = 4
 	},
-/obj/structure/ore_box,
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/hangarsupply)
 "foI" = (
@@ -103650,6 +103688,9 @@
 /obj/landmark/storyevent/hidden_vent_antag,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/clothingstorage)
+"fSC" = (
+/turf/simulated/floor/tiled/steel/cargo,
+/area/eris/quartermaster/misc)
 "fVl" = (
 /obj/spawner/scrap/dense,
 /turf/simulated/floor/tiled/techmaint,
@@ -103768,6 +103809,13 @@
 /obj/spawner/scrap/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
+"gzZ" = (
+/obj/structure/disposalpipe/up{
+	dir = 1
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "gBc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 8;
@@ -104498,6 +104546,13 @@
 /obj/spawner/scrap/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section4deck1central)
+"jxB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/quartermaster/misc)
 "jzP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small{
@@ -104587,6 +104642,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/eris/quartermaster/office)
+"jPK" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/medical/morgue)
 "jQO" = (
 /obj/machinery/status_display/supply_display{
 	pixel_x = -32
@@ -104736,6 +104797,15 @@
 /obj/structure/catwalk,
 /turf/simulated/open,
 /area/eris/engineering/atmos)
+"kxR" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/disposalpipe/up{
+	dir = 1
+	},
+/turf/simulated/open,
+/area/eris/quartermaster/storage)
 "kAo" = (
 /turf/simulated/open,
 /area/eris/maintenance/section1deck4central)
@@ -104908,6 +104978,17 @@
 /obj/item/weapon/storage/freezer/contains_food,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/rnd/research)
+"leL" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 1
+	},
+/obj/structure/disposalpipe/up,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing,
+/turf/simulated/floor/tiled/steel/cargo,
+/area/eris/quartermaster/storage)
 "leS" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
@@ -105122,6 +105203,15 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
+"mag" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/disposalpipe/down{
+	dir = 8
+	},
+/turf/simulated/open,
+/area/eris/quartermaster/misc)
 "maq" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -105419,6 +105509,13 @@
 	},
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/eris/crew_quarters/bar)
+"mSn" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/simulated/floor/tiled/steel/cargo,
+/area/eris/quartermaster/misc)
 "mTL" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_medical{
@@ -105637,37 +105734,19 @@
 /turf/space,
 /area/space)
 "nuy" = (
-/obj/structure/closet/crate,
-/obj/item/weapon/caution{
-	name = "Caution Sign"
-	},
-/obj/item/weapon/caution{
-	name = "Caution Sign"
-	},
-/obj/item/weapon/caution{
-	name = "Caution Sign"
-	},
-/obj/item/weapon/caution{
-	name = "Caution Sign"
-	},
-/obj/item/weapon/caution{
-	name = "Caution Sign"
-	},
-/obj/item/weapon/caution{
-	name = "Caution Sign"
-	},
-/obj/spawner/contraband/low_chance,
-/obj/spawner/boxes,
-/obj/spawner/boxes,
-/obj/spawner/boxes/low_chance,
-/obj/spawner/boxes/low_chance,
-/obj/spawner/boxes/low_chance,
-/obj/spawner/boxes/low_chance,
 /obj/structure/railing/grey{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/steel/cargo,
+/obj/structure/disposalpipe/up{
+	dir = 1
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 4
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 8
+	},
+/turf/simulated/floor/plating/under,
 /area/eris/quartermaster/hangarsupply)
 "nvd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -105731,6 +105810,15 @@
 /obj/machinery/neotheology/biomass_container,
 /turf/simulated/floor/tiled/white/gray_platform,
 /area/eris/medical/surgery)
+"nPo" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel/cargo,
+/area/eris/quartermaster/storage)
 "nQQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -106199,6 +106287,16 @@
 /area/eris/crew_quarters/library{
 	name = "\improper Cafe"
 	})
+"pwx" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/open,
+/area/eris/quartermaster/storage)
 "pxq" = (
 /obj/structure/catwalk,
 /obj/spawner/junk/low_chance,
@@ -106264,6 +106362,11 @@
 	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/maintenance/section2deck3port)
+"pKV" = (
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/medical/morgue)
 "pMF" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black,
 /turf/simulated/floor/hull,
@@ -106786,6 +106889,15 @@
 	},
 /turf/simulated/floor/plating,
 /area/eris/quartermaster/office)
+"sgA" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/disposalpipe/up{
+	dir = 8
+	},
+/turf/simulated/open,
+/area/eris/quartermaster/storage)
 "ske" = (
 /obj/structure/table/woodentable,
 /obj/machinery/chemical_dispenser/soda,
@@ -106988,6 +107100,17 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/wood,
 /area/eris/maintenance/section4deck4central)
+"sYM" = (
+/obj/machinery/disposal/deliveryChute{
+	dir = 1
+	},
+/obj/structure/disposalpipe/up,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing,
+/turf/simulated/floor/tiled/steel/cargo,
+/area/eris/quartermaster/storage)
 "sZg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -107035,6 +107158,16 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
+"tdr" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-y"
+	},
+/turf/simulated/open,
+/area/eris/quartermaster/storage)
 "tea" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/meter,
@@ -107049,6 +107182,11 @@
 /obj/spawner/junk/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/maintenance/section1deck4central)
+"tin" = (
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/medical/medbreak)
 "tkQ" = (
 /obj/machinery/light,
 /obj/structure/table/standard,
@@ -107069,6 +107207,16 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/quartermaster/hangarsupply)
+"tmt" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/open,
+/area/eris/quartermaster/storage)
 "tpD" = (
 /obj/structure/bed/chair/comfy/brown,
 /obj/structure/disposalpipe/segment,
@@ -107268,6 +107416,15 @@
 /obj/spawner/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
+"uie" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/disposalpipe/down{
+	dir = 8
+	},
+/turf/simulated/open,
+/area/eris/quartermaster/storage)
 "uiz" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 10
@@ -107297,6 +107454,15 @@
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating/under,
 /area/eris/quartermaster/office)
+"ulp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 8;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck4central)
 "uly" = (
 /obj/machinery/power/nt_obelisk,
 /obj/machinery/light{
@@ -107347,6 +107513,13 @@
 /obj/structure/catwalk,
 /turf/simulated/open,
 /area/eris/quartermaster/storage)
+"usi" = (
+/obj/structure/disposalpipe/down{
+	dir = 1
+	},
+/obj/structure/lattice,
+/turf/space,
+/area/space)
 "utr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -107543,6 +107716,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/maintenance/section2deck1port)
+"vhC" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/hull,
+/area/space)
 "vhD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
@@ -107839,6 +108016,10 @@
 /obj/structure/bed,
 /turf/simulated/floor/carpet/bcarpet,
 /area/eris/maintenance/section4deck4central)
+"wuI" = (
+/obj/structure/disposalpipe/segment,
+/turf/simulated/open,
+/area/eris/quartermaster/misc)
 "wzr" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
@@ -107857,6 +108038,16 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/maintenance/section2deck1port)
+"wEt" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-y"
+	},
+/turf/simulated/open,
+/area/eris/quartermaster/storage)
 "wEJ" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -107919,6 +108110,16 @@
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/office)
+"wIJ" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/open,
+/area/eris/quartermaster/storage)
 "wLi" = (
 /obj/structure/catwalk,
 /obj/structure/sign/signnew/canisters{
@@ -107934,11 +108135,19 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
 "wMa" = (
-/obj/structure/closet/crate/radiation,
+/obj/machinery/disposal/deliveryChute{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk,
 /obj/structure/railing/grey{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/effect/floor_decal/industrial/warning{
+	dir = 5
+	},
+/obj/effect/floor_decal/industrial/warning{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/hangarsupply)
 "wOW" = (
@@ -108060,6 +108269,16 @@
 /obj/spawner/scrap/sparse,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
+"xue" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 4;
+	icon_state = "pipe-y"
+	},
+/turf/simulated/open,
+/area/eris/quartermaster/misc)
 "xuA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -108091,6 +108310,20 @@
 	},
 /turf/simulated/open,
 /area/eris/quartermaster/storage)
+"xEf" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 2;
+	icon_state = "pipe-j2"
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck4central)
 "xEN" = (
 /obj/item/weapon/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -132801,7 +133034,7 @@ bRE
 bRE
 bRE
 bRE
-bRE
+cDw
 ceo
 cfW
 cgq
@@ -133409,7 +133642,7 @@ bZD
 cbS
 cdH
 hgZ
-iYm
+dol
 bJK
 auV
 aBv
@@ -165306,7 +165539,7 @@ bkW
 bpi
 bkW
 bkW
-bkW
+dtw
 bmx
 aaa
 abF
@@ -165508,8 +165741,8 @@ boh
 bpj
 boi
 boi
+boi
 dvn
-bmx
 aaa
 abF
 bVU
@@ -165711,8 +165944,8 @@ bpk
 bpT
 bnV
 boj
-bmx
-aaa
+dEN
+gzZ
 abF
 bVU
 ciV
@@ -165913,7 +166146,7 @@ bpl
 boi
 boi
 boi
-bmx
+dvn
 aaa
 aaa
 bVU
@@ -168964,7 +169197,7 @@ cZm
 crq
 crq
 cAM
-crq
+xEf
 dnm
 doZ
 cdC
@@ -169368,7 +169601,7 @@ bCH
 cJw
 cJw
 dpb
-bZy
+dpb
 cEV
 cGo
 bbk
@@ -169570,7 +169803,7 @@ cZX
 dcY
 cJw
 dpb
-bZy
+dpb
 bbk
 cGo
 bbk
@@ -169973,7 +170206,7 @@ cWb
 day
 ddc
 cxj
-bZy
+dpb
 dpb
 bbk
 bbk
@@ -170175,7 +170408,7 @@ cWe
 daz
 ddh
 cJw
-bZy
+dpb
 dpb
 bbk
 bvG
@@ -170377,7 +170610,7 @@ dsz
 daz
 ddq
 dfE
-bZy
+dpb
 cEe
 ccX
 bvH
@@ -170579,8 +170812,8 @@ cJw
 cxj
 cJw
 dfE
-bZy
 dpb
+bZy
 crg
 bvI
 cFY
@@ -170782,7 +171015,7 @@ dqx
 dqx
 dqx
 cAY
-cDw
+dqx
 dOj
 byN
 cxF
@@ -170983,7 +171216,7 @@ cEH
 cEH
 cEH
 cEH
-cEH
+ulp
 cDS
 cFL
 cBw
@@ -173203,9 +173436,9 @@ cip
 cip
 ckb
 cie
-cie
-ciC
-ciC
+sYM
+tmt
+pwx
 clH
 clH
 clH
@@ -173405,9 +173638,9 @@ ciq
 ciq
 ckf
 cie
-cie
-ciC
-ciC
+leL
+wEt
+kxR
 clH
 clH
 clH
@@ -204494,8 +204727,8 @@ dAv
 dAv
 dAv
 dAv
-dEN
-bmx
+dtA
+bnl
 abF
 abF
 cmE
@@ -204696,8 +204929,8 @@ cgB
 dEg
 dEq
 dDO
-dol
-bmx
+dtA
+pKV
 abF
 abF
 cmE
@@ -204898,8 +205131,8 @@ cgC
 dEh
 dEt
 dDO
-dol
-bmx
+dtA
+pKV
 abF
 aaa
 cmE
@@ -205099,9 +205332,9 @@ cKh
 cgB
 dEj
 dAx
-cgB
-dtw
-bmx
+tin
+dtA
+pKV
 abF
 aaa
 cmE
@@ -205303,7 +205536,7 @@ dAA
 dAx
 cgB
 dtA
-bmx
+bnl
 abF
 aaa
 cmE
@@ -205505,7 +205738,7 @@ dAC
 dAx
 cgB
 dtA
-bmx
+bnl
 abF
 aaa
 cmE
@@ -205705,9 +205938,9 @@ csw
 cgB
 dAD
 dAx
-cgB
-dEN
-bmx
+tin
+dtA
+pKV
 abF
 aaa
 aaa
@@ -205908,9 +206141,9 @@ cgB
 dAD
 dAx
 dDO
-duo
-bmx
-bmx
+dtA
+pKV
+abF
 aaa
 aaa
 cmE
@@ -206111,10 +206344,10 @@ dAD
 dAx
 dDO
 duo
-duo
-bmx
-aaa
-aaa
+jPK
+vhC
+usi
+aad
 cmE
 dvA
 evm
@@ -206312,9 +206545,9 @@ cgB
 dAD
 dis
 cgB
-duo
 bmx
 bmx
+abF
 aaa
 aaa
 bVU
@@ -206514,8 +206747,8 @@ csh
 csh
 csh
 csh
-bnl
-bmx
+abF
+abF
 abF
 aaa
 aaa
@@ -213403,8 +213636,8 @@ cys
 ciD
 ciD
 cAd
-cie
-cie
+nPo
+nPo
 bAN
 cBk
 cBJ
@@ -213605,8 +213838,8 @@ cyJ
 ciC
 ciD
 ciC
-ciC
-ciC
+tdr
+wIJ
 bAN
 cBk
 cBJ
@@ -213807,8 +214040,8 @@ cyJ
 ciC
 ciD
 ciC
-ciC
-ciC
+sgA
+uie
 bAN
 cBk
 cBK
@@ -252998,7 +253231,7 @@ edX
 efB
 edX
 edX
-dvU
+ekq
 ayD
 ayQ
 ayQ
@@ -253200,7 +253433,7 @@ efB
 efB
 efB
 efB
-dvU
+ekq
 ayD
 ayQ
 azz
@@ -253806,7 +254039,7 @@ edY
 egJ
 edX
 edX
-dvU
+ekq
 emH
 enR
 azA
@@ -254005,11 +254238,11 @@ egh
 egn
 edZ
 edZ
-edZ
-edX
-edX
+mSn
+xue
+wuI
 eiN
-eiN
+jxB
 dvU
 azB
 eqV
@@ -254207,11 +254440,11 @@ epA
 egn
 edZ
 edZ
-edZ
-edX
+fSC
+mag
 edX
 ekq
-emU
+ena
 dvU
 azD
 asZ
@@ -254412,7 +254645,7 @@ eel
 egU
 edX
 edX
-dvU
+ekq
 ena
 enR
 azA
@@ -255018,7 +255251,7 @@ efB
 efB
 efB
 efB
-dvU
+ekq
 axq
 ayQ
 azE
@@ -255220,7 +255453,7 @@ edX
 efB
 edX
 edX
-dvU
+ekq
 axq
 ayQ
 ayQ

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -159,6 +159,9 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/bed/chair/sofa/teal/right{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/security/main)
 "aaA" = (
@@ -179,6 +182,9 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/table/standard,
+/obj/item/weapon/deck/cards,
+/obj/spawner/gun/normal/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/security/barracks{
 	name = "Aegis Barracks"
@@ -3208,6 +3214,7 @@
 /obj/machinery/light/small,
 /obj/item/weapon/bedsheet/red,
 /obj/structure/bed,
+/obj/spawner/knife/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/security/prison)
 "ahR" = (
@@ -5237,6 +5244,7 @@
 	pixel_x = -2;
 	pixel_y = 4
 	},
+/obj/item/weapon/storage/pill_bottle/tramadol,
 /turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/security/exerooms)
 "amp" = (
@@ -20406,8 +20414,11 @@
 /obj/item/stack/material/steel{
 	amount = 120
 	},
-/obj/item/stack/material/steel{
+/obj/item/stack/material/glass{
 	amount = 120
+	},
+/obj/item/stack/material/plasteel{
+	amount = 10
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/security/warden)
@@ -21671,6 +21682,7 @@
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/misc,
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/security,
 /obj/item/weapon/reagent_containers/glass/beaker,
+/obj/machinery/smartfridge/disks,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/security/warden)
 "aZH" = (
@@ -103817,6 +103829,12 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/wood,
 /area/eris/maintenance/section4deck4central)
+"gMa" = (
+/obj/structure/bed/chair/sofa/teal/corner{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/eris/security/main)
 "gOy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable{
@@ -104155,6 +104173,13 @@
 /obj/machinery/washing_machine,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/crew_quarters/clothingstorage)
+"ihK" = (
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/dark,
+/area/eris/security/prison)
 "iiw" = (
 /obj/structure/multiz/stairs/active{
 	dir = 8
@@ -104300,6 +104325,12 @@
 /obj/item/device/radio/beacon,
 /turf/simulated/floor/tiled/steel/panels,
 /area/eris/engineering/post)
+"iOT" = (
+/obj/item/weapon/stool,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/eris/security/barracks{
+	name = "Aegis Barracks"
+	})
 "iSq" = (
 /obj/machinery/access_button{
 	command = "cycle_interior";
@@ -104528,6 +104559,7 @@
 /obj/item/weapon/bedsheet/yellow,
 /obj/structure/bed,
 /obj/machinery/light/small,
+/obj/spawner/knife/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/security/prison)
 "jKd" = (
@@ -104934,6 +104966,13 @@
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section1deck4central)
+"lmw" = (
+/obj/item/device/radio/intercom{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/eris/security/prison)
 "lnT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
@@ -105026,6 +105065,12 @@
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/storage)
+"lDP" = (
+/obj/structure/bed/chair/sofa/teal/left{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/eris/security/main)
 "lFi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 5
@@ -105974,6 +106019,12 @@
 /obj/machinery/portable_atmospherics/powered/pump,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section4deck4central)
+"oUv" = (
+/obj/machinery/computer/cryopod{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/dark/gray_platform,
+/area/eris/security/prison)
 "oWd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -107201,6 +107252,14 @@
 /obj/effect/decal/warning_stripes,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/hangarsupply)
+"uef" = (
+/obj/structure/table/standard,
+/obj/spawner/pizza/low_chance,
+/obj/spawner/booze/low_chance,
+/obj/spawner/booze/low_chance,
+/obj/spawner/booze/low_chance,
+/turf/simulated/floor/tiled/dark/techfloor_grid,
+/area/eris/security/main)
 "ueE" = (
 /obj/structure/railing{
 	dir = 1
@@ -124591,7 +124650,7 @@ aaa
 aaa
 aaa
 abH
-acg
+oUv
 acD
 add
 ady
@@ -126616,7 +126675,7 @@ adN
 aen
 ael
 ael
-aei
+lmw
 app
 app
 abH
@@ -127613,8 +127672,8 @@ aaa
 aaa
 aac
 aaj
-aaj
-aaj
+lDP
+gMa
 aab
 aaa
 aaG
@@ -128018,7 +128077,7 @@ aaa
 aac
 aaj
 aaj
-aaj
+uef
 aab
 aaq
 aaG
@@ -128030,7 +128089,7 @@ awa
 kGS
 acC
 acC
-acC
+ihK
 abH
 aei
 aeT
@@ -131250,7 +131309,7 @@ aaa
 aag
 aas
 aas
-aas
+iOT
 aaf
 aaR
 aaR
@@ -131654,7 +131713,7 @@ aaa
 aag
 aas
 aas
-aas
+iOT
 aag
 aaa
 aaa

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -52479,7 +52479,7 @@
 	name = "Cargo Maintenance";
 	req_access = list(31)
 	},
-/turf/simulated/floor/tiled/techmaint,
+/turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/office)
 "csr" = (
 /obj/structure/bed/chair/office/dark{
@@ -54534,7 +54534,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/steel/gray_platform,
+/turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/office)
 "cxI" = (
 /obj/machinery/door/firedoor,
@@ -54952,7 +54952,7 @@
 	dir = 4
 	},
 /obj/machinery/computer/supplycomp/order,
-/turf/simulated/floor/tiled/steel/gray_platform,
+/turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/office)
 "cyH" = (
 /obj/machinery/atmospherics/pipe/zpipe/down{
@@ -55059,7 +55059,7 @@
 /area/eris/crew_quarters/bar)
 "cyW" = (
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/steel/gray_platform,
+/turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/office)
 "cyX" = (
 /obj/structure/disposalpipe/segment{
@@ -55351,7 +55351,7 @@
 /obj/item/weapon/packageWrap,
 /obj/item/weapon/packageWrap,
 /obj/item/device/destTagger,
-/turf/simulated/floor/tiled/steel/gray_platform,
+/turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/office)
 "czC" = (
 /obj/structure/cable/yellow{
@@ -76594,7 +76594,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/glass,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/office)
 "dwG" = (
 /obj/structure/bed/chair/comfy/black{
@@ -77427,7 +77427,7 @@
 "dyM" = (
 /obj/structure/table/standard,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/steel/brown_platform,
+/turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/office)
 "dyN" = (
 /obj/structure/closet/emcloset,
@@ -103637,7 +103637,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel/gray_platform,
+/turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/office)
 "fGN" = (
 /obj/structure/disposalpipe/segment{
@@ -106884,7 +106884,7 @@
 "seo" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/vending/cigarette,
-/turf/simulated/floor/tiled/steel/gray_platform,
+/turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/office)
 "sgb" = (
 /obj/machinery/button/remote/blast_door{
@@ -107934,7 +107934,7 @@
 /area/eris/maintenance/section1deck4central)
 "wan" = (
 /obj/machinery/vending/printomat,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/office)
 "wax" = (
 /obj/machinery/door/airlock/maintenance_engineering{


### PR DESCRIPTION
## About The Pull Request

Some small tweaks to Aegis and bigger tweaks to cargo
- Added a bottle of tramadol to the Aegis infirmery
- Added 10 plasteel to the Aegis lathe area, allowing them to print a handful of silencers or tactical knives at roundstart.
- Added 120 glass to the Aegis lathe area
- Reduced Aegis lathe metal to 120 from 240
- Added a disk toaster to the Aegis lathe area
- Added a cryo computer to the permabrig so the cryopod works and stops spamming admins
- Added intercomms to the permabrig so people can't get memory holed. The console is outside of the brig proper so prisoners cannot retrieve weapons.
- Off-duty operatives have spruced up the forward posts slightly, as they were disused
- replaced most of the cargo hole with a disposal system
- tweaked the morgue express to stop bodies floating in midair
- made the disposal chutes near cargo now send things to sorting rather than to the incinerator
-  Converted an existing maint room off the dorms into a "maint village" by request
- fixed some tiles by cargo

![image](https://user-images.githubusercontent.com/1775680/111240458-a8b49c80-85d1-11eb-972b-bd03040a969d.png)
![image](https://user-images.githubusercontent.com/1775680/111546464-1a195a00-874e-11eb-9e21-0f646af0fa5e.png)
![image](https://user-images.githubusercontent.com/1775680/111546522-30bfb100-874e-11eb-9935-58b04d2906f2.png)
![image](https://user-images.githubusercontent.com/1775680/111546542-36b59200-874e-11eb-8a49-860c71c4aad3.png)
![image](https://user-images.githubusercontent.com/1775680/111546565-3f0dcd00-874e-11eb-88a4-680352c09786.png)
![image](https://user-images.githubusercontent.com/1775680/111546575-4339ea80-874e-11eb-86f9-76636dd45e77.png)
![image](https://user-images.githubusercontent.com/1775680/111546578-47660800-874e-11eb-9983-1266b6b44ab2.png)
![image](https://user-images.githubusercontent.com/1775680/111546590-4a60f880-874e-11eb-9eb0-34abf9e72b3f.png)
![image](https://user-images.githubusercontent.com/1775680/111548148-a2006380-8750-11eb-82e4-af75a6544e9b.png)



## Why It's Good For The Game

Map adjustments based on feedback requested.

## Changelog
```changelog
add: Added a bottle of tramadol to the Aegis infirmery
add: Added 10 plasteel to the Aegis lathe area, allowing them to print a handful of silencers or tactical knives at roundstart.
add: Added 120 glass to the Aegis lathe area
remove: Reduced Aegis lathe metal to 120 from 240
add: Added a disk toaster to the Aegis lathe area
add: Added a cryo computer to the permabrig so the cryopod works and stops spamming admins
add: Added intercomms to the permabrig so people can't get memory holed. The console is outside of the brig proper so prisoners cannot retrieve weapons.
tweak: Off-duty operatives have spruced up the forward posts slightly, as they were disused
tweak: replaced most of the cargohole with a disposal system
tweak: tweaked the morgue express to stop bodies floating in midair
fix: made the disposal chutes near cargo now send things to sorting rather than to the incinerator
tweak: the maint room near dorms has been converted to a living space taken over by the maint dwellers.
fix: Fixed some exposed plating by cargo
```


