### PR TITLE
Teleport module nerf

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2855,6 +2855,7 @@
 #include "zzzz_modular_occulus\code\modules\clothing\head\head.dm"
 #include "zzzz_modular_occulus\code\modules\clothing\head\hood.dm"
 #include "zzzz_modular_occulus\code\modules\clothing\masks\masks.dm"
+#include "zzzz_modular_occulus\code\modules\clothing\spacesuits\rig\modules\ninja.dm"
 #include "zzzz_modular_occulus\code\modules\clothing\suit\hooded.dm"
 #include "zzzz_modular_occulus\code\modules\clothing\suit\suits.dm"
 #include "zzzz_modular_occulus\code\modules\clothing\under\under.dm"

--- a/zzzz_modular_occulus/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/zzzz_modular_occulus/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -1,0 +1,3 @@
+/obj/item/rig_module/teleporter
+	spawn_blacklisted = TRUE
+	use_power_cost = 2000


### PR DESCRIPTION
## About The Pull Request

Blacklist teleport modules from random spawns
Teleport modules now cost 2,000 cell power per use.

## Why It's Good For The Game

This particular module has been problematic for a while. It should be much rarer/more expensive to acquire now, and have a significantly reduced number of jumps.

## Changelog
```changelog
balance: teleport modules can no longer be found in maint pools
balance: teleport modules now cost 2,000 energy, up from 40.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
