### PR TITLE
Add two spriteless items to the blacklist

### DIFF
--- a/zzzz_modular_occulus/code/modules/loot_spawn_blacklist.dm
+++ b/zzzz_modular_occulus/code/modules/loot_spawn_blacklist.dm
@@ -135,3 +135,9 @@
 
 /obj/item/ammo_magazine/maxim						// pan magazine (.30)
 	spawn_blacklisted = TRUE
+
+/obj/item/weapon/reagent_containers/glass/beaker/bowl	// no sprite
+	spawn_blacklisted = TRUE
+
+/obj/item/device/onetankbomb	// no sprite
+	spawn_blacklisted = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This modular code adds two spriteless items to the blacklist:

`/obj/item/device/onetankbomb` (partial welder bomb assembly)
`/obj/item/weapon/reagent_containers/glass/beaker/bowl` (mixing bowl)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Less junk items in the spawn lists means more useful things can spawn.

## Changelog
```changelog
tweak: Partial welder bombs and mixing bowls no longer spawn in trash piles, as they have no sprite
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
