### PR TITLE
fixed two up pipes that should be trunks

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -104998,11 +104998,11 @@
 /obj/machinery/disposal/deliveryChute{
 	dir = 1
 	},
-/obj/structure/disposalpipe/up,
 /obj/structure/railing{
 	dir = 4
 	},
 /obj/structure/railing,
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/storage)
 "leS" = (
@@ -107128,11 +107128,11 @@
 /obj/machinery/disposal/deliveryChute{
 	dir = 1
 	},
-/obj/structure/disposalpipe/up,
 /obj/structure/railing{
 	dir = 8
 	},
 /obj/structure/railing,
+/obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/storage)
 "sZg" = (


### PR DESCRIPTION
## About The Pull Request

Tiny map error fixed 

## Why It's Good For The Game

whoop

## Changelog
```changelog
fix: Fixed two up disposals that should be trunks
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
