### PR TITLE
Merge Club Worker and Actor

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -7,7 +7,7 @@
 #define JOBS_MEDICAL "Chief Medical Officer","Medical Doctor","Psychiatrist","Pharmacist","Paramedic","Surgeon","Nurse","Medical Intern"
 #define JOBS_SCIENCE "Chief Science Officer","Scientist","Roboticist","Xenobiologist","Xenoflorist","Research Intern","Anomalist"
 #define JOBS_CARGO "Free Trade Union Merchant","Union Cargo Technician","Union Miner"
-#define JOBS_CIVILIAN "Club Manager","Club Worker","Actor",ASSISTANT_TITLE,"Intern","Assistant"
+#define JOBS_CIVILIAN "Club Manager","Club Worker",ASSISTANT_TITLE,"Intern","Assistant"
 #define JOBS_CHURCH "Chaplain","Mekhane Acolyte","Mekhane Custodian","Mekhane Agrolyte"
 #define JOBS_NONHUMAN "AI","Robot","pAI"
 

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -74,6 +74,7 @@
 	icon_state = "player-grey"
 	join_tag = /datum/job/clubworker
 
+/*	OCCULUS EDIT: Actor has been merged with Club Worker.
 /datum/job/actor
 	title = "Actor"
 	flag = ACTOR
@@ -94,11 +95,12 @@
 	)
 
 	loyalties = LOYALTY_CIVILIAN
+*/
 
 /obj/landmark/join/start/actor
 	name = "Actor"
 	icon_state = "player-grey"
-	join_tag = /datum/job/actor
+	// join_tag = /datum/job/actor // OCCULUS EDIT: Comment out the datum so the spawn can stay on the map if it's ever separated again
 /*
 /datum/job/hydro
 	title = "Botanist"

--- a/zzzz_modular_occulus/code/game/jobs/job/civilian.dm
+++ b/zzzz_modular_occulus/code/game/jobs/job/civilian.dm
@@ -1,6 +1,6 @@
 /datum/job/clubworker
 	wage = WAGE_LABOUR_DUMB //Club workers make less than professional wages and are expected to make up the difference in tips.
-	access = list(access_bar, access_kitchen, access_maint_tunnels)
+	access = list(access_bar, access_kitchen, access_maint_tunnels, access_theatre)
 	also_known_languages = list(LANGUAGE_JIVE = 0)
 	stat_modifiers = list(
 		STAT_BIO = 15,
@@ -8,6 +8,7 @@
 		STAT_TGH = 10,
 		STAT_VIG = 5
 	)
+	alt_titles = list("Chef", "Cook", "Bartender", "Bouncer", "Clown", "Mime", "Musician", "Entertainer")
 
 /datum/job/clubmanager
 	department_account_access = TRUE
@@ -23,12 +24,14 @@
 	custodians, and botanists get paid
 	*/
 
+/* OCCULUS EDIT: Actor has been merged with Club Worker.
 /datum/job/actor
 	outfit_type = /decl/hierarchy/outfit/job/service/actor/actor
 	stat_modifiers = list(
 		STAT_TGH = 30,
 		STAT_VIG = 10
 	)
+*/
 
 /decl/hierarchy/outfit/job/service/actor/actor
 	name = OUTFIT_JOB_NAME("Actor")
@@ -36,4 +39,3 @@
 	id_type = /obj/item/weapon/card/id/white
 	pda_type = /obj/item/modular_computer/pda/club_worker
 	backpack_contents = list(/obj/item/weapon/bananapeel = 1, /obj/item/weapon/storage/fancy/crayons = 1, /obj/item/toy/waterflower = 1, /obj/item/weapon/stamp/clown = 1, /obj/item/weapon/handcuffs/fake = 1)
-

--- a/zzzz_modular_occulus/code/game/jobs/job/civilian.dm
+++ b/zzzz_modular_occulus/code/game/jobs/job/civilian.dm
@@ -8,7 +8,7 @@
 		STAT_TGH = 10,
 		STAT_VIG = 5
 	)
-	alt_titles = list("Chef", "Cook", "Bartender", "Bouncer", "Clown", "Mime", "Musician", "Entertainer")
+	alt_titles = list("Actor", "Bartender", "Bouncer", "Chef", "Clown", "Cook", "Entertainer", "Mime", "Musician")
 
 /datum/job/clubmanager
 	department_account_access = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Per emojicracy at https://discord.com/channels/777375833084919839/777989657064636463/810077211306229782

This mostly non-modular code merges the roles of Club Worker and Actor. Specifically, the theatre access of the Actor has been given to Club Workers, and Club Workers have been given a variety of alternate titles. All of the actor titles have been inherited from Actor, as well as adding some new titles.

Club Worker titles available:

Club Worker
Chef
Cook
Bartender
Bouncer
Clown
Mime
Musician
Entertainer
Actor

![image](https://user-images.githubusercontent.com/77511162/111884744-eb8fbf00-8999-11eb-9a88-f8955f5bc01c.png)
_Actor not pictured here, but was implemented after screenshot was taken -- list has also been alphabetized since then_

![image](https://user-images.githubusercontent.com/77511162/111884759-0104e900-899a-11eb-8d29-32aa12be29fe.png)
_A musician with kitchen access._

Players who currently have Actor set as their job should be aware that if they do not have a secondary job set, you must set a new job or you will not be able to join an ongoing round.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Per the emojicracy, Club players have reported that which they would like to be actors, they don't do so because of the actor's limited access. Now they can have the best of both words -- Club workers have a variety of titles to choose from and don't have to sacrifice access for flavour.

## Changelog
```changelog
tweak: Actor has been merged with Club Worker -- the Club Worker has gained theatre access and a variety of alternate titles.
add: The Club Worker now has several alternate titles: Chef, Cook, Bartender, Bouncer, Clown, Mime, Musician, Entertainer, Actor
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
