### PR TITLE
Add roboticist alt. titles

### DIFF
--- a/zzzz_modular_occulus/code/game/jobs/job/science.dm
+++ b/zzzz_modular_occulus/code/game/jobs/job/science.dm
@@ -9,7 +9,6 @@
 		access_genetics, access_maint_tunnels
 	)
 
-
 /datum/job/roboticist
 	stat_modifiers = list(
 		STAT_MEC = 25,
@@ -19,6 +18,7 @@
 	access = list(
 		access_robotics, access_tox, access_tox_storage, access_morgue, access_moebius, access_research_equipment, access_maint_tunnels
 	)
+	alt_titles = list("Cyberneticist", "Exosuit Technician", "Machinist")
 
 /datum/job/rd
 	access = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

This modular code introduces three alternate titles for roboticist:

Cyberneticist
Exosuit Technician
Machinist

These titles have no functionality beyond flavour.

![image](https://user-images.githubusercontent.com/77511162/111885210-c781ad00-899c-11eb-9ba6-cdb852b1eab8.png)
![image](https://user-images.githubusercontent.com/77511162/111885218-d0727e80-899c-11eb-8c85-2e2621db2d86.png)

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

I've interacted with other roboticists who have a particular specialty, so now it can be represented in-game!

## Changelog
```changelog
add: Roboticists have three new alt. titles: Cyberneticist, Exosuit Technician, Machinist
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
