### PR TITLE
Announce alt. titles when joining the round

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -427,7 +427,7 @@ SUBSYSTEM_DEF(job)
 	var/alt_title = null
 	if(H.mind)
 		H.mind.assigned_role = rank
-		alt_title = H.mind.role_alt_title
+		alt_title = H.mind.role_alt_title	// OCCULUS EDIT: Allow alt. title to be shown in the blurb
 
 		switch(rank)
 			if("Robot")

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -427,7 +427,7 @@ SUBSYSTEM_DEF(job)
 	var/alt_title = null
 	if(H.mind)
 		H.mind.assigned_role = rank
-	//	alt_title = H.mind.role_alt_title
+		alt_title = H.mind.role_alt_title
 
 		switch(rank)
 			if("Robot")

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -113,4 +113,7 @@ datum/announcement/proc/Log(message as text, message_title as text)
 		if(issilicon(character))
 			global_announcer.autosay("A new [rank] [join_message].", ANNOUNSER_NAME)
 		else
+			if (character.mind)
+				if (character.mind.role_alt_title)
+					rank = role_alt_title
 			global_announcer.autosay("[character.real_name], [rank], [join_message].", ANNOUNSER_NAME)

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -115,5 +115,5 @@ datum/announcement/proc/Log(message as text, message_title as text)
 		else
 			if (character.mind)
 				if (character.mind.role_alt_title)
-					rank = role_alt_title
+					rank = character.mind.role_alt_title
 			global_announcer.autosay("[character.real_name], [rank], [join_message].", ANNOUNSER_NAME)

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -113,7 +113,9 @@ datum/announcement/proc/Log(message as text, message_title as text)
 		if(issilicon(character))
 			global_announcer.autosay("A new [rank] [join_message].", ANNOUNSER_NAME)
 		else
+			// OCCULUS EDIT: Announce the alt. title
 			if (character.mind)
 				if (character.mind.role_alt_title)
 					rank = character.mind.role_alt_title
+			// OCCULIS EDIT END
 			global_announcer.autosay("[character.real_name], [rank], [join_message].", ANNOUNSER_NAME)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This non-modular code will announce that you have an alternate title when you join the round rather than your job's base title. There is additional code that changes the blurb you get when joining to also mention your alt. title.

![image](https://user-images.githubusercontent.com/77511162/111885948-17627300-89a1-11eb-96f5-a943caaac177.png)

(Thanks to DiscordWizard for helping me test!)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is a fun flavour thing for anyone who likes to use alternate titles, so the ship knows what you are when you join in.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
add: People using alt. titles will have their alt. titles announced when they join in place of their base job.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
