### PR TITLE
Implement emojicracy: Join silently as vagabond/in dormitories

### DIFF
--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -118,13 +118,14 @@ datum/announcement/proc/Log(message as text, message_title as text)
 			if (character.client)
 				if (character.client.prefs)
 					if (character.mind)
-							if (character.mind.role_alt_title)
-								rank = character.mind.role_alt_title
+						if (character.mind.role_alt_title)
+							rank = character.mind.role_alt_title
 					if (rank == "Vagabond" && character.client.get_preference_value(/datum/client_preference/spawn_silent_vagabond) == GLOB.PREF_YES)
 						message_admins("A vagabond, [character.real_name], has joined the round silently.")
 					else if (character.client.prefs.spawnpoint == "Dormitory" && character.client.get_preference_value(/datum/client_preference/spawn_silent_dormitory) == GLOB.PREF_YES)
 						message_admins("[character.real_name] has joined the round silently.")
 					else
+						message_admins("Did not join silently")
 						global_announcer.autosay("[character.real_name], [rank], [join_message].", ANNOUNSER_NAME)
 			else
 				global_announcer.autosay("[character.real_name], [rank], [join_message].", ANNOUNSER_NAME)	// This should not trigger -- but it's here as an emergency fallback

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -113,9 +113,19 @@ datum/announcement/proc/Log(message as text, message_title as text)
 		if(issilicon(character))
 			global_announcer.autosay("A new [rank] [join_message].", ANNOUNSER_NAME)
 		else
-			// OCCULUS EDIT: Announce the alt. title
-			if (character.mind)
-				if (character.mind.role_alt_title)
-					rank = character.mind.role_alt_title
-			// OCCULIS EDIT END
-			global_announcer.autosay("[character.real_name], [rank], [join_message].", ANNOUNSER_NAME)
+			// OCCULUS EDIT: Add preferences for silent joining of vagabonds and dormitory sleepers.
+			// Also announce alt. titles properly.
+			if (character.client)
+				if (character.client.prefs)
+					if (character.mind)
+							if (character.mind.role_alt_title)
+								rank = character.mind.role_alt_title
+					if (rank == "Vagabond" && character.client.get_preference_value(/datum/client_preference/spawn_silent_vagabond) == GLOB.PREF_YES)
+						message_admins("A vagabond, [character.real_name], has joined the round silently.")
+					else if (character.client.prefs.spawnpoint == "Dormitory" && character.client.get_preference_value(/datum/client_preference/spawn_silent_dormitory) == GLOB.PREF_YES)
+						message_admins("[character.real_name] has joined the round silently.")
+					else
+						global_announcer.autosay("[character.real_name], [rank], [join_message].", ANNOUNSER_NAME)
+			else
+				global_announcer.autosay("[character.real_name], [rank], [join_message].", ANNOUNSER_NAME)	// This should not trigger -- but it's here as an emergency fallback
+			// OCCULUS EDIT END

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -123,9 +123,8 @@ datum/announcement/proc/Log(message as text, message_title as text)
 					if (rank == "Vagabond" && character.client.get_preference_value(/datum/client_preference/spawn_silent_vagabond) == GLOB.PREF_YES)
 						message_admins("A vagabond, [character.real_name], has joined the round silently.")
 					else if (character.client.prefs.spawnpoint == "Dormitory" && character.client.get_preference_value(/datum/client_preference/spawn_silent_dormitory) == GLOB.PREF_YES)
-						message_admins("[character.real_name] has joined the round silently.")
+						message_admins("[character.real_name], [rank], has joined the round silently.")
 					else
-						message_admins("Did not join silently")
 						global_announcer.autosay("[character.real_name], [rank], [join_message].", ANNOUNSER_NAME)
 			else
 				global_announcer.autosay("[character.real_name], [rank], [join_message].", ANNOUNSER_NAME)	// This should not trigger -- but it's here as an emergency fallback

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -217,6 +217,20 @@ var/list/_client_preferences_by_type
 	description = "Enable gun crosshair"
 	key = "GUN_CURSOR"
 
+// OCCULUS EDIT START: For compatibility with downstreams, these preferences are not in a modular file
+
+/datum/client_preference/spawn_silent_vagabond
+	description = "Spawn silently as vagabond"
+	key = "SPAWN_SILENT_VAGABOND"
+	default_value = GLOB.PREF_YES
+
+/datum/client_preference/spawn_silent_dormitory
+	description = "Spawn silently in dormitory"
+	key = "SPAWN_SILENT_DORMITORY"
+	default_value = GLOB.PREF_NO
+
+// OCCULUS EDIT END
+
 /********************
 * General Staff Preferences *
 ********************/


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Implements emojicracy at https://discord.com/channels/777375833084919839/777989657064636463/822945785960202261

This non-modular code adds two new options in the Global tab in Character Setup:

1. Spawn silently as a vagabond (defaults to yes)
2. Spawn silently in dormitory (defaults to no)

If either are active, there will be no arrivals announcement in those situations. Admins will be informed of any silent joins.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Some players have expressed annoyance with being greeted by everyone as soon as they wake up in the dorms, and there have also been situations where vagabonds are unhappy with being cheerily welcomed by the crew and would rather slip into maintenance unnoticed. These preferences will make both of those possible.

## Changelog
```changelog
add: Two new preferences, 'spawn silently as vagabond' and 'spawn silently in dormitory'
admin: Admins will be informed of any silent spawns
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
