### PR TITLE
Heavily rebalanced several voidsuit armor values. Mostly lower

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2857,6 +2857,7 @@
 #include "zzzz_modular_occulus\code\modules\clothing\head\hood.dm"
 #include "zzzz_modular_occulus\code\modules\clothing\masks\masks.dm"
 #include "zzzz_modular_occulus\code\modules\clothing\spacesuits\rig\modules\ninja.dm"
+#include "zzzz_modular_occulus\code\modules\clothing\spacesuits\void\station.dm"
 #include "zzzz_modular_occulus\code\modules\clothing\suit\hooded.dm"
 #include "zzzz_modular_occulus\code\modules\clothing\suit\suits.dm"
 #include "zzzz_modular_occulus\code\modules\clothing\under\under.dm"

--- a/zzzz_modular_occulus/code/modules/clothing/spacesuits/void/station.dm
+++ b/zzzz_modular_occulus/code/modules/clothing/spacesuits/void/station.dm
@@ -1,0 +1,160 @@
+// Station voidsuits
+//Engineering rig
+/obj/item/clothing/head/space/void/engineering
+	name = "EES voidsuit helmet"
+	armor = list(
+		melee = 35,
+		bullet = 20,
+		energy = 20,
+		bomb = 25,
+		bio = 100,
+		rad = 100
+	)
+
+/obj/item/clothing/suit/space/void/engineering
+	name = "EES voidsuit"
+	armor = list(
+		melee = 35,
+		bullet = 20,
+		energy = 20,
+		bomb = 25,
+		bio = 100,
+		rad = 100
+	)
+
+//Mining rig
+/obj/item/clothing/head/space/void/mining
+	name = "FTU voidsuit helmet"
+	armor = list(
+		melee = 50,
+		bullet = 25,
+		energy = 25,
+		bomb = 25,
+		bio = 100,
+		rad = 75
+	)
+
+/obj/item/clothing/suit/space/void/mining
+	name = "FTU voidsuit"
+	slowdown = 0.40
+	armor = list(
+		melee = 50,
+		bullet = 25,
+		energy = 25,
+		bomb = 25,
+		bio = 100,
+		rad = 75
+	)
+
+//Medical Rig
+/obj/item/clothing/head/space/void/medical
+	name = "NT medical voidsuit helmet"
+	armor = list(
+		melee = 30,
+		bullet = 10,
+		energy = 10,
+		bomb = 25,
+		bio = 100,
+		rad = 75
+	)
+
+/obj/item/clothing/suit/space/void/medical
+	icon_state = "rig-medical"
+	name = "NT medical voidsuit"
+	slowdown = 0.15
+	armor = list(
+		melee = 30,
+		bullet = 10,
+		energy = 10,
+		bomb = 25,
+		bio = 100,
+		rad = 75
+	)
+
+	//Security
+/obj/item/clothing/head/space/void/security
+	name = "CAS combat voidsuit helmet"
+	armor = list(
+		melee = 35,
+		bullet = 45,
+		energy = 30,
+		bomb = 25,
+		bio = 100,
+		rad = 75
+	)
+
+/obj/item/clothing/suit/space/void/security
+	name = "CAS combat voidsuit"
+	armor = list(
+		melee = 35,
+		bullet = 45,
+		energy = 30,
+		bomb = 25,
+		bio = 100,
+		rad = 75
+	)
+
+//Science
+/obj/item/clothing/head/space/void/science
+	name = "NT combat Helmet"
+	armor = list(
+		melee = 35,
+		bullet = 30,
+		energy = 45,
+		bomb = 100,
+		bio = 100,
+		rad = 75
+	)
+
+/obj/item/clothing/suit/space/void/science
+	name = "NT combat voidsuit"
+	armor = list(
+		melee = 35,
+		bullet = 30,
+		energy = 45,
+		bomb = 100,
+		bio = 100,
+		rad = 75
+	)
+
+/obj/item/clothing/head/space/void/agrolyte
+	armor = list(
+		melee = 30,
+		bullet = 10,
+		energy = 10,
+		bomb = 25,
+		bio = 100,
+		rad = 50
+	)
+
+/obj/item/clothing/suit/space/void/agrolyte
+	armor = list(
+		melee = 30,
+		bullet = 10,
+		energy = 10,
+		bomb = 25,
+		bio = 100,
+		rad = 50
+	)
+	slowdown = 0.15
+
+/obj/item/clothing/head/space/void/custodian
+	armor = list(
+		melee = 35,
+		bullet = 20,
+		energy = 20,
+		bomb = 25,
+		bio = 200,
+		rad = 90
+	)
+
+/obj/item/clothing/suit/space/void/custodian
+	armor = list(
+		melee = 35,
+		bullet = 20,
+		energy = 20,
+		bomb = 25,
+		bio = 200,
+		rad = 90
+	)
+


### PR DESCRIPTION
## About The Pull Request

Rebalances voidsuit armors across the board.

## Why It's Good For The Game

Many voidsuit armor values were extremely high for what they are. This patch reigns them down to significantly lower levels.
Combat-styled voidsuits are now generally stronger than non-combat voidsuits.
Melee is an exception to this, as most suits provide fairly robust anti-melee resistance.
Renamed all station-bound hardsuits to represent the faction that uses them.

## Changelog
```changelog
balance: Engineering suit changed to 35 melee, 20 bullet, 20 laser resist
tweak: Engineering voidsuit now known as EES voidsuit
balance: Mining voidsuit changed to 50 melee, 25 bullet, 25 energy.
balance: mining voidsuit increased to 0.4 slowdown from 0.35
tweak: Mining voidsuit renamed to FTU voidsuit
balance: medical voidsuit changed to 30 melee, 10 bullet, 10 energy resist
tweak: medical voidsuit renamed to NT medical voidsuit
balance: aegis voidsuit changed to 35 melee, 45 bullet, 30 energy resist
tweak: aegis voidsuit renamed to CAS combat voidsuit
balance: Moebius voidsuit changed to 35 melee, 30 bullet, 45 energy, 100 bomb
tweak: moebius voidsuit renamed NT combat voidsuit.
balance: argolyte voidsuit changed to 30 melee, 10 bullet, 10 energy, 0.15 slowdown
balance: custodian voidsuit changed to 35 melee, 20 bullet, 20 energy
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
