### PR TITLE
rebalanced serveral origins

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2789,6 +2789,7 @@
 #include "zzzz_modular_occulus\code\datums\objective\blitzshell.dm"
 #include "zzzz_modular_occulus\code\datums\perks\oddity.dm"
 #include "zzzz_modular_occulus\code\datums\setup_option\core_implants.dm"
+#include "zzzz_modular_occulus\code\datums\setup_option\backgrounds\origin.dm"
 #include "zzzz_modular_occulus\code\datums\uplink\devices and tools.dm"
 #include "zzzz_modular_occulus\code\datums\uplink\medical.dm"
 #include "zzzz_modular_occulus\code\game\occulus-lore-fixes.dm"

--- a/zzzz_modular_occulus/code/datums/setup_option/backgrounds/origin.dm
+++ b/zzzz_modular_occulus/code/datums/setup_option/backgrounds/origin.dm
@@ -1,0 +1,120 @@
+//As a general rule, all origin backrounds must have summ of +5 of stat values
+
+/datum/category_item/setup_option/background/origin/oberth
+	stat_modifiers = list(
+		STAT_ROB = 5,
+		STAT_TGH = 5,
+		STAT_BIO = 0,
+		STAT_MEC = 0,
+		STAT_VIG = 10,
+		STAT_COG = -10
+	)
+
+
+/datum/category_item/setup_option/background/origin/predstraza
+	stat_modifiers = list(
+		STAT_ROB = 10,
+		STAT_TGH = 10,
+		STAT_BIO = -5,
+		STAT_MEC = -3,
+		STAT_VIG = 7,
+		STAT_COG = -8
+	)
+
+/datum/category_item/setup_option/background/origin/crozet
+	stat_modifiers = list(
+		STAT_ROB = 6,
+		STAT_TGH = 6,
+		STAT_BIO = -3,
+		STAT_MEC = 2,
+		STAT_VIG = 6,
+		STAT_COG = -4
+	)
+
+/datum/category_item/setup_option/background/origin/shimatengoku
+	stat_modifiers = list(
+		STAT_ROB = -9,
+		STAT_TGH = -9,
+		STAT_BIO = 15,
+		STAT_MEC = 15,
+		STAT_VIG = -5,
+		STAT_COG = 16
+	)
+
+/datum/category_item/setup_option/background/origin/end_point
+	stat_modifiers = list(
+		STAT_ROB = -3,
+		STAT_TGH = -2,
+		STAT_BIO = 0,
+		STAT_MEC = 15,
+		STAT_VIG = 2,
+		STAT_COG = 8
+	)
+
+/datum/category_item/setup_option/background/origin/medic
+	name = "Medic"
+	desc = "Be it by choice or cosmic design, most of your life has been spent tending to living things: plants, animals, or people. You have a strong understanding of what makes us all tick, and you are much less bothered by blood than other people."
+
+	stat_modifiers = list(
+		STAT_ROB = -5,
+		STAT_TGH = -5,
+		STAT_BIO = 15,
+		STAT_MEC = 0,
+		STAT_VIG = 8,
+		STAT_COG = 4
+	)
+
+//Medic here
+
+/datum/category_item/setup_option/background/origin/new_rome
+	stat_modifiers = list(
+		STAT_ROB = 2,
+		STAT_TGH = 6,
+		STAT_BIO = 6,
+		STAT_MEC = 6,
+		STAT_VIG = -6,
+		STAT_COG = 2
+	)
+
+
+/datum/category_item/setup_option/background/origin/hmss_destined
+	stat_modifiers = list(
+		STAT_ROB = 7,
+		STAT_TGH = 6,
+		STAT_BIO = 0,
+		STAT_MEC = 8,
+		STAT_VIG = 2,
+		STAT_COG = -8
+	)
+
+
+/datum/category_item/setup_option/background/origin/first_expeditionary_fleet
+	stat_modifiers = list(
+		STAT_ROB = 5,
+		STAT_TGH = 0,
+		STAT_BIO = 5,
+		STAT_MEC = -5,
+		STAT_VIG = 7,
+		STAT_COG = 6
+	)
+
+/datum/category_item/setup_option/background/origin/nss_forecaster
+	stat_modifiers = list(
+		STAT_ROB = 4,
+		STAT_TGH = 4,
+		STAT_BIO = -10,
+		STAT_MEC = 4,
+		STAT_VIG = 10,
+		STAT_COG = 6
+	)
+
+/datum/category_item/setup_option/background/origin/sich_prime
+	desc = "Miscreant. You're used to having to do what it takes to survive. Pulling out bullets, picking pockets, and  picking locks... it's all the same to you with your nimble fingers."
+	stat_modifiers = list(
+		STAT_ROB = -2,
+		STAT_TGH = -3,
+		STAT_BIO = 6,
+		STAT_MEC = 6,
+		STAT_VIG = 6,
+		STAT_COG = 4
+	)


### PR DESCRIPTION
## About The Pull Request

This PR balances out and quashes down the range of free stats from origins.
It also adds a new origin: Medic

## Why It's Good For The Game

Several trap options existed in origins,and a few particular ones were extremely egregiously strong. Now most origins are equal (though have specialties)

Combat Origins:

Mercenary (Ranged weapon specialist)
Thug (Melee weapon specialist)
Colonist (Combat all-rounder with fewer technical skill penalties)

Academic Origins

Academic (Strong utility, very weak in combat)
Greasemonkey (MEC focused background)
Medic (BIO/VIG vocused background)

Generalist Origins

Assistant: All rounder that is poor with guns
Crewmember: Generalist that is poor with COG
Activist: Generalist that is poor with MEC
Nomad: Generalist that is poor with BIO, but solid with guns
Vagrant: A generalist that is weak physically, but good with skilled stuff

## Changelog
```changelog
balance: Mercenary origin to -10 COG, 5 ROB, 5 TGH, 10VIG
balance: Thug origin to -5 BIO, -8 COG, -3 MEC, 10ROB, 10TGH, 7 VIG
balance: Colonist origin to -3 BIO, -4 COG, 2 MEC, 6 ROB, 6 TGH, 6 VIG
balance: Academic to 15 BIO, 16 COG, 15 MEC, -9 ROB, -9TGH, -5 VIG
balance: Greasemonkey to 8COG, 15 MEC, -3 ROB, -3 TGH, 2 VIG
add: Medic Origin. 15 BIO, 4 COG, -5 ROB, -5 TGH, 8VIG
balance: Assistant to 6 BIO, 2 COG, 6 MEC, 2 ROB, 6 TGH, -6 VIG
balance: Crewman to 0 BIO, -8 COG, 8 MEC, 7 ROB, 6 TGH, -2 VIG
balance: Activist to 5 BIO, 6 COG, -5 MEC, 5ROB, 7VIG
balance: Nomad to -10 BIO, 6 COG, 4 MEC, 4 ROB, 4 TGH, 10 VIG
balance: Vagrant to 6 BIO, 4 COG, 6 MED, -2 ROB, -3 TGH, 6 VIG


```
