### PR TITLE
Text "Volume" now respects selected font size.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -284,7 +284,8 @@ its easier to just keep the beam vertical.
 	if(isobserver(user))
 		to_chat(user, "\icon[src] This is [full_name] [suffix]")
 	else
-		user.visible_message("<font size=1>[user.name] looks at [src].</font>", "\icon[src] This is [full_name] [suffix]")
+		//Occulus Edit. Now scales properly.
+		user.visible_message("<span style='font-size:0.8em'>[user.name] looks at [src].</span>", "\icon[src] This is [full_name] [suffix]")
 
 	to_chat(user, show_stat_verbs()) //rewrite to show_stat_verbs(user)?
 

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -10,7 +10,8 @@
 		speaker_name = H.rank_prefix_name(H.GetVoice())
 
 	if(speech_volume)
-		message = "<FONT size='[speech_volume]'>[message]</FONT>"
+		//Occulus Edit - Speech now scales correctly.
+		message = "<span style='font-size:[speech_volume]em'>[message]</span>"
 	if(italics)
 		message = "<i>[message]</i>"
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -118,7 +118,8 @@ var/list/channel_to_radio_key = new
 
 // returns message
 /mob/living/proc/getSpeechVolume(var/message)
-	var/volume = chem_effects[CE_SPEECH_VOLUME] ? round(chem_effects[CE_SPEECH_VOLUME]) : 2	// 2 is default text size in byond chat
+	//Occulus Edit - Make volume scale correctly.
+	var/volume = chem_effects[CE_SPEECH_VOLUME] ? round(chem_effects[CE_SPEECH_VOLUME]) : 1	// 2 is default text size in byond chat
 	var/ending = copytext(message, length(message))
 	if(ending == "!")
 		volume ++

--- a/code/modules/organs/pain.dm
+++ b/code/modules/organs/pain.dm
@@ -27,25 +27,25 @@ mob/living/carbon/proc/pain(var/partname, var/amount, var/force, var/burning = 0
 		src:drop_item()
 	var/msg
 	if(burning)
-		switch(amount)
+		switch(amount) //Occulus Edits - Messages now scale with chat size.
 			if(1 to 10)
-				msg = "\red <b>Your [partname] burns.</b>"
+				msg = "\red <b><span style=`font-size:1em'>Your [partname] burns.</span></b>"
 			if(11 to 90)
 				flash_weak_pain()
-				msg = "\red <b><font size=2>Your [partname] burns badly!</font></b>"
+				msg = "\red <b><span style='font-size:1.5em'>Your [partname] burns badly!</span></b>"
 			if(91 to 10000)
 				flash_pain()
-				msg = "\red <b><font size=3>OH GOD! Your [partname] is on fire!</font></b>"
+				msg = "\red <span style='font-size:2em'>OH GOD! Your [partname] is on fire!</span></b>"
 	else
-		switch(amount)
+		switch(amount) //Occulus Edits - Messages now scale with chat size.
 			if(1 to 10)
-				msg = "<b>Your [partname] hurts.</b>"
+				msg = "<b><span style='font-size:1em'>Your [partname] hurts.</span></b>"
 			if(11 to 90)
 				flash_weak_pain()
-				msg = "<b><font size=2>Your [partname] hurts badly.</font></b>"
+				msg = "<b><span style='font-size:1.5em'>Your [partname] hurts badly.</span></b>"
 			if(91 to 10000)
 				flash_pain()
-				msg = "<b><font size=3>OH GOD! Your [partname] is hurting terribly!</font></b>"
+				msg = "<b><span style='font-size:2em'>OH GOD! Your [partname] is hurting terribly!</span></b>"
 	if(msg && (msg != last_pain_message || prob(10)))
 		last_pain_message = msg
 		to_chat(src, msg)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
fixes #364 
Volume scaling for says, witnessed examines, and pain messages will now respect the users selected font size.
The messages originally used html font size selectors instead of css span selectors. This PR changes them to use css selectors and em units for font size.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Improve accessibility for the visually impaired.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
fix: fixed font size scaling for certain chat messages.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
