### PR TITLE
postmortum restorative patch

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2934,6 +2934,7 @@
 #include "zzzz_modular_occulus\code\modules\sprite_accessories\_accessory_hair.dm"
 #include "zzzz_modular_occulus\code\modules\sprite_accessories\_accessory_tesh.dm"
 #include "zzzz_modular_occulus\code\modules\stashes\stashes.dm"
+#include "zzzz_modular_occulus\code\modules\surgery\organic_damage.dm"
 #include "zzzz_modular_occulus\maps\submaps\deepmaint_rooms\core\core_rooms.dm"
 #include "zzzz_modular_occulus\maps\submaps\deepmaint_rooms\normal\normal_rooms.dm"
 // END_INCLUDE

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1028,7 +1028,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			conditions_list.Add(list(condition))
 
 	else if(BP_IS_ORGANIC(src))
-		if(brute_dam > 15)
+		if(brute_dam > 15)//Occulus Edit Start
 			condition = list(
 				"name" = "Blunt trauma",
 				"fix_name" = "Mend",
@@ -1041,7 +1041,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 				"fix_name" = "Mend",
 				"step" = /datum/surgery_step/fix_burn
 			)
-			conditions_list.Add(list(condition))
+			conditions_list.Add(list(condition))//Occulus Edit End
 		if(status & ORGAN_BLEEDING)
 			condition = list(
 				"name" = "Bleeding",

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1028,6 +1028,20 @@ Note that amputating the affected organ does in fact remove the infection from t
 			conditions_list.Add(list(condition))
 
 	else if(BP_IS_ORGANIC(src))
+		if(brute_dam > 15)
+			condition = list(
+				"name" = "Blunt trauma",
+				"fix_name" = "Mend",
+				"step" = /datum/surgery_step/fix_brute
+			)
+			conditions_list.Add(list(condition))
+		if(burn_dam > 15)
+			condition = list(
+				"name" = "Charred flesh",
+				"fix_name" = "Mend",
+				"step" = /datum/surgery_step/fix_burn
+			)
+			conditions_list.Add(list(condition))
 		if(status & ORGAN_BLEEDING)
 			condition = list(
 				"name" = "Bleeding",

--- a/zzzz_modular_occulus/code/modules/reagents/reagents/medicine.dm
+++ b/zzzz_modular_occulus/code/modules/reagents/reagents/medicine.dm
@@ -9,9 +9,31 @@
 
 /datum/reagent/medicine/paracetamol
 	metabolism = REM * 0.25
-	
+
 /datum/reagent/medicine/tramadol
 	metabolism = REM * 0.25
 
 /datum/reagent/medicine/oxycodone
 	metabolism = REM * 0.25
+
+/datum/reagent/medicine/reconstructive_nanites
+	name = "Reconstructive nanites"
+	id = "res nanites"
+	description = "Microscopic machines that aggressively rebuild organic cells regardless of the metabolism of the body."
+	taste_description = "metal"
+	reagent_state = SOLID
+	overdose = REAGENTS_OVERDOSE
+	scannable = 1
+	affects_dead = 1
+	metabolism = REM * 2
+	price_tag = 50
+
+/datum/chemical_reaction/reconstructive_nanites
+	result = "res nanites"
+	required_reagents = list("rezadone" = 1, "clonexadone" = 1, "nanites" = 1, "meralyne" = 1, "dermaline" = 1)
+	result_amount = 1
+
+/datum/reagent/medicine/reconstructive_nanites/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	M.adjustOxyLoss(-0.3 * effect_multiplier)
+	M.heal_organ_damage(0.3 * effect_multiplier, 0.3 * effect_multiplier)
+	M.adjustToxLoss(-0.3 * effect_multiplier)

--- a/zzzz_modular_occulus/code/modules/surgery/organic_damage.dm
+++ b/zzzz_modular_occulus/code/modules/surgery/organic_damage.dm
@@ -1,0 +1,63 @@
+/datum/surgery_step/fix_brute
+	allowed_tools = list(
+		/obj/item/stack/medical/advanced/bruise_pack = 100,
+		/obj/item/stack/medical/bruise_pack = 20,
+	)
+
+	duration = 80
+
+/datum/surgery_step/fix_brute/can_use(mob/living/user, obj/item/organ/external/organ, obj/item/stack/tool)
+	return BP_IS_ORGANIC(organ) && organ.is_open() && organ.brute_dam >= 15
+
+/datum/surgery_step/fix_brute/begin_step(mob/living/user, obj/item/organ/external/organ, obj/item/stack/tool)
+	user.visible_message(
+		SPAN_NOTICE("[user] begins to mend [organ.get_surgery_name()]."),
+		SPAN_NOTICE("You begin to mend [organ.get_surgery_name()].")
+	)
+
+/datum/surgery_step/fix_brute/end_step(mob/living/user, obj/item/organ/external/organ, obj/item/stack/tool)
+	user.visible_message(
+		SPAN_NOTICE("[user] finishes mending [organ.get_surgery_name()]."),
+		SPAN_NOTICE("You finish mending [organ.get_surgery_name()].")
+	)
+	if(tool.use(1))
+		organ.heal_damage(rand(10, 15), 0, 1, 1)
+
+/datum/surgery_step/fix_brute/fail_step(mob/living/user, obj/item/organ/external/organ, obj/item/stack/tool)
+	user.visible_message(
+		SPAN_WARNING("[user]'s hand slips, further damaging [organ.get_surgery_name()]!"),
+		SPAN_WARNING("Your hand slips, further damaging [organ.get_surgery_name()]!")
+	)
+	organ.take_damage(rand(5,10), 0)
+
+/datum/surgery_step/fix_burn
+	allowed_tools = list(
+	/obj/item/stack/medical/advanced/ointment = 100,
+	/obj/item/stack/medical/ointment = 20,
+	)
+
+	duration = 80
+
+/datum/surgery_step/fix_burn/can_use(mob/living/user, obj/item/organ/external/organ, obj/item/stack/tool)
+	return BP_IS_ORGANIC(organ) && organ.is_open() && organ.burn_dam >= 15
+
+/datum/surgery_step/fix_burn/begin_step(mob/living/user, obj/item/organ/external/organ, obj/item/stack/tool)
+	user.visible_message(
+		SPAN_NOTICE("[user] begins to treat [organ.get_surgery_name()]."),
+		SPAN_NOTICE("You begin to treat [organ.get_surgery_name()].")
+	)
+
+/datum/surgery_step/fix_burn/end_step(mob/living/user, obj/item/organ/external/organ, obj/item/stack/tool)
+	user.visible_message(
+		SPAN_NOTICE("[user] finishes treating [organ.get_surgery_name()]."),
+		SPAN_NOTICE("You finish treating [organ.get_surgery_name()].")
+	)
+	if(tool.use(1))
+		organ.heal_damage(0, rand(10, 15), 1, 1)
+
+/datum/surgery_step/fix_burn/fail_step(mob/living/user, obj/item/organ/external/organ, obj/item/stack/tool)
+	user.visible_message(
+		SPAN_WARNING("[user] hand slips, further injuring [organ.get_surgery_name()]!"),
+		SPAN_WARNING("Your hand slips, further injuring [organ.get_surgery_name()]!")
+	)
+	organ.take_damage(rand(5,10))

--- a/zzzz_modular_occulus/code/modules/surgery/organic_damage.dm
+++ b/zzzz_modular_occulus/code/modules/surgery/organic_damage.dm
@@ -30,6 +30,12 @@
 	)
 	organ.take_damage(rand(5,10), 0)
 
+/datum/surgery_step/fix_brute/require_tool_message(mob/living/user)
+	to_chat(user, SPAN_WARNING("You need an advanced trauma kit, or at least some bandages, to complete this step."))
+
+/datum/surgery_step/fix_burn/require_tool_message(mob/living/user)
+	to_chat(user, SPAN_WARNING("You need an advanced burn kit, or at least some ointment, to complete this step."))
+
 /datum/surgery_step/fix_burn
 	allowed_tools = list(
 	/obj/item/stack/medical/advanced/ointment = 100,


### PR DESCRIPTION
## About The Pull Request

Adds in surgeries and chems that can lower brute and burn damage on patients just outside of defibable range

![image](https://user-images.githubusercontent.com/1775680/113516360-d4c79b80-9547-11eb-8404-0d6d17cf7ee6.png)


## Why It's Good For The Game

This makes the -100 damage cap a bit less arbitrary.
These options are not for someone with excessive damage. Past a certain point you should be resleeving or regenerating someone.

## Changelog
```changelog
add:  burn treatment surgery option
add: trauma treatment surgery option
add: reconstructive nanites
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
