### PR TITLE
Fixes mines

### DIFF
--- a/zzzz_modular_occulus/code/game/objects/items/weapons/mine.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/mine.dm
@@ -1,7 +1,7 @@
 /obj/item/weapon/mine/
 	name = "landmine"
-	explosion_d_size = -1
-	explosion_h_size = -1
+	explosion_d_size = 0
+	explosion_h_size = 0
 	explosion_l_size = 2
 	explosion_f_size = 15
 	num_fragments = 8


### PR DESCRIPTION
## About The Pull Request

This PR should fix the negative explosion size on maint landmines. Mines will now properly detonate

## Why It's Good For The Game

More dangerous maints and all

## Changelog
```changelog
fix: Landmines should now properly explode on people
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
