### PR TITLE
Buffing hivemind and blob spawn chance.

### DIFF
--- a/zzzz_modular_occulus/code/game/gamemodes/storytellers/storyevent.dm
+++ b/zzzz_modular_occulus/code/game/gamemodes/storytellers/storyevent.dm
@@ -2,11 +2,11 @@
 
 /datum/storyevent/hivemind
 	tags = list(TAG_COMMUNAL, TAG_DESTRUCTIVE, TAG_NEGATIVE, TAG_SCARY, TAG_ROUNDENDING)
-	req_crew = 12	//Makes it so that at least 9 players must be playing in order to spawn
+	req_crew = 9	//Makes it so that at least 6 players must be playing in order to spawn
 	max_crew_diff_lower = 3
 
 /datum/storyevent/blob
-	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_NEGATIVE, TAG_ROUNDENDING)
+	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_NEGATIVE)
 	req_crew = 9
 	max_crew_diff_lower = 3
 

--- a/zzzz_modular_occulus/code/game/gamemodes/storytellers/storyevent.dm
+++ b/zzzz_modular_occulus/code/game/gamemodes/storytellers/storyevent.dm
@@ -6,7 +6,7 @@
 	max_crew_diff_lower = 3
 
 /datum/storyevent/blob
-	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_NEGATIVE)
+	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_NEGATIVE, TAG_ROUNDENDING)
 	req_crew = 9
 	max_crew_diff_lower = 3
 


### PR DESCRIPTION
## About The Pull Request

Hivemind player requirement reduced to 6. 9 for full weighting.


## Why It's Good For The Game

We have people who have never seen either on Occulus

## Changelog
```changelog
balance: hivemind player requirement reduced from 9 to 6. hivemind ideal playercount reduced from 12 to 9
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
