### PR TITLE
fixes lag on returning to lobby

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -82,13 +82,14 @@ SUBSYSTEM_DEF(ticker)
 			if(first_start_trying)
 				pregame_timeleft = initial(pregame_timeleft)
 				to_chat(world, "<B><FONT color='blue'>Welcome to the pre-game lobby!</FONT></B>")
+				send_assets()
 			else
 				pregame_timeleft = 40
 
 			if(!start_immediately)
 				to_chat(world, "Please, setup your character and select ready. Game will start in [pregame_timeleft] seconds.")
 			current_state = GAME_STATE_PREGAME
-			send_assets()
+
 
 		if(GAME_STATE_PREGAME)
 			if(start_immediately)
@@ -450,11 +451,11 @@ SUBSYSTEM_DEF(ticker)
 
 /datum/controller/subsystem/ticker/proc/declare_completion()
 	to_chat(world, "<br><br><br><H1>A round has ended!</H1>")
-	
+
 	for(var/client/C)
 		if(!C.credits)
 			C.RollCredits()
-	
+
 	for(var/mob/Player in GLOB.player_list)
 		if(Player.mind && !isnewplayer(Player))
 			if(Player.stat != DEAD)


### PR DESCRIPTION
## About The Pull Request

This fixes the lag when the server fails to start, by pushing the initial asset distribution into the first loop only.

## Why It's Good For The Game

Big bug fix.

## Changelog
```changelog
fix: The server should no longer lag terrible for everyone when the game fails to start because of no players.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
