### PR TITLE
Major nerf to shields

### DIFF
--- a/code/__DEFINES/shields.dm
+++ b/code/__DEFINES/shields.dm
@@ -2,7 +2,7 @@
 #define SHIELD_DAMTYPE_EM 2			// Electromagnetic damage - Ion weaponry, stun beams, ...
 #define SHIELD_DAMTYPE_HEAT 3		// Heat damage - Lasers, fire
 
-#define ENERGY_PER_HP (50 KILOWATTS)// Base amount energy that will be deducted from the generator's internal reserve per 1 HP of damage taken
+#define ENERGY_PER_HP (100 KILOWATTS)// Base amount energy that will be deducted from the generator's internal reserve per 1 HP of damage taken. Occulus Edit
 #define ENERGY_UPKEEP_PER_TILE 35	// Base upkeep per tile protected. Multiplied by various enabled shield modes. Without them the field does literally nothing.
 
 

--- a/code/game/gamemodes/events/meteors.dm
+++ b/code/game/gamemodes/events/meteors.dm
@@ -333,7 +333,7 @@
 	var/turf/hit_location //used for reporting hit locations. The meteor may be deleted and its location nulled by report time
 
 /obj/effect/meteor/proc/get_shield_damage()
-	return max(((max(hits, 2)) * (heavy + 1) * rand(100, 140)) / hitpwr , 0)
+	return max(((max(hits, 2)) * (heavy + 1) * rand(20, 28)) / hitpwr , 0)//Occulus edit
 
 /obj/effect/meteor/New()
 	..()

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -128,7 +128,7 @@
 /obj/machinery/power/shield_generator/RefreshParts()
 	max_energy = 0
 	for(var/obj/item/weapon/stock_parts/smes_coil/S in component_parts)
-		max_energy += (S.ChargeCapacity / CELLRATE)
+		max_energy += (S.ChargeCapacity / (CELLRATE * 5))//Occulus Edit
 	current_energy = between(0, current_energy, max_energy)
 
 	mitigation_max = MAX_MITIGATION_BASE
@@ -144,8 +144,8 @@
 /obj/machinery/power/shield_generator/proc/boost_field()
 	max_energy = 0
 	for(var/obj/item/weapon/stock_parts/smes_coil/S in component_parts)
-		max_energy += (S.ChargeCapacity / CELLRATE)
-	current_energy = max_energy
+		max_energy += (S.ChargeCapacity / (CELLRATE * 5))
+	current_energy = min(current_energy + (max_energy/3), max_energy)
 
 ///// OCCULUS EDIT END
 


### PR DESCRIPTION
## About The Pull Request

Shield capacity slashed by 1/5
Shield drain per impact increased by 200%
Numbers are subject to change after contact with live server.

## Why It's Good For The Game

This re-adds some teeth and tensions to meteor events, and potentially risks damage to the ship if the crew don't act to prevent it! SHOCK. HORROR.

If this is too much, we can modify the values slightly.

## Changelog
```changelog
balance: Shield capacity reduced to 20%
balance: Shield energy drain increased to 100KW from 50KW
balance: Meteor impact damage reduced to 20%
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
