### PR TITLE
fixes space suits not providing full hot, cold, and rad protection

### DIFF
--- a/zzzz_modular_occulus/code/modules/clothing/spacesuits/void/station.dm
+++ b/zzzz_modular_occulus/code/modules/clothing/spacesuits/void/station.dm
@@ -1,3 +1,27 @@
+// Radsuits - cramming this In here since it's a tiny fix
+/obj/item/clothing/head/radiation
+	body_parts_covered = HEAD|FACE|EYES
+	heat_protection =    HEAD|FACE|EYES
+	cold_protection =    HEAD|FACE|EYES
+
+/obj/item/clothing/suit/radiation
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|FEET|HANDS
+	heat_protection =    UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|FEET|HANDS
+	cold_protection =    UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|FEET|HANDS
+// Firesuits - Cramming this varedit here for now
+
+/obj/item/clothing/suit/fire
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|FEET|HANDS
+	heat_protection =    UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|FEET|HANDS
+	cold_protection =    UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|FEET|HANDS
+
+// Engie Armor
+
+/obj/item/clothing/suit/storage/vest/insulated
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|FEET|HANDS
+	heat_protection =    UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|FEET|HANDS
+	cold_protection =    UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|FEET|HANDS
+
 // Station voidsuits
 
 /obj/item/clothing/head/space/void

--- a/zzzz_modular_occulus/code/modules/clothing/spacesuits/void/station.dm
+++ b/zzzz_modular_occulus/code/modules/clothing/spacesuits/void/station.dm
@@ -1,4 +1,15 @@
 // Station voidsuits
+
+/obj/item/clothing/head/space/void
+	body_parts_covered = HEAD|FACE|EYES
+	heat_protection =    HEAD|FACE|EYES
+	cold_protection =    HEAD|FACE|EYES
+
+/obj/item/clothing/suit/space/void
+	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|FEET|HANDS
+	heat_protection =    UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|FEET|HANDS
+	cold_protection =    UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|FEET|HANDS
+
 //Engineering rig
 /obj/item/clothing/head/space/void/engineering
 	name = "EES voidsuit helmet"


### PR DESCRIPTION
## About The Pull Request

Fixes voidsuits to provide full temperature and radiation protection when it should be provided.

## Why It's Good For The Game

It was a known, major, broken part of the voidsiuts. Now fixed.

## Changelog
```changelog
fix: voidsuits now protect against heat, cold, and radiation properly.
fix: Radiation suits now protect against radiation
fix: Firesuits now again fix against fire
fix: Insulated armor covers the hands and feet, protecting against fire properly
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
