### PR TITLE
Jamini pdafixes

### DIFF
--- a/zzzz_modular_occulus/code/game/jobs/job/civilian.dm
+++ b/zzzz_modular_occulus/code/game/jobs/job/civilian.dm
@@ -39,3 +39,6 @@
 	id_type = /obj/item/weapon/card/id/white
 	pda_type = /obj/item/modular_computer/pda/club_worker
 	backpack_contents = list(/obj/item/weapon/bananapeel = 1, /obj/item/weapon/storage/fancy/crayons = 1, /obj/item/toy/waterflower = 1, /obj/item/weapon/stamp/clown = 1, /obj/item/weapon/handcuffs/fake = 1)
+
+/obj/item/modular_computer/pda/club_worker
+	scanner_type = /obj/item/weapon/computer_hardware/scanner/reagent

--- a/zzzz_modular_occulus/code/game/jobs/job/guild.dm
+++ b/zzzz_modular_occulus/code/game/jobs/job/guild.dm
@@ -15,3 +15,7 @@
 		STAT_TGH = 10,
 		STAT_VIG = 10
 	)
+
+
+/decl/hierarchy/outfit/job/cargo/mining
+	pda_type = /obj/item/modular_computer/pda/cargo


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Modular change giving miners the cargo pda (with an export scanner) and adding a reagent scanner to club worker pdas

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Just some sanity checking on pda types

## Changelog
```changelog
tweak: Mining pda is now a cargo pda
tweak: Club pda now has a reagent scanner by default
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
