### PR TITLE
(Proof of concept) Minimum identification levels for reagents

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2909,6 +2909,7 @@
 #include "zzzz_modular_occulus\code\modules\projectiles\projectile\bullettypes.dm"
 #include "zzzz_modular_occulus\code\modules\projectiles\projectile\projectile.dm"
 #include "zzzz_modular_occulus\code\modules\radio\radios.dm"
+#include "zzzz_modular_occulus\code\modules\reagents\chemical_identification.dm"
 #include "zzzz_modular_occulus\code\modules\reagents\food-Drinks.dm"
 #include "zzzz_modular_occulus\code\modules\reagents\recipes.dm"
 #include "zzzz_modular_occulus\code\modules\reagents\reagent_containers\hypospray.dm"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -298,7 +298,7 @@ its easier to just keep the beam vertical.
 			if(reagents.reagent_list.len)
 				for(var/I in reagents.reagent_list)
 					var/datum/reagent/R = I
-					R.identify_reagent(user)
+					R.identify_reagent(user)	// OCCULUS EDIT: Use new reagent identification
 					//to_chat(user, "<span class='notice'>[R.volume] units of [R.name]</span>")
 
 				// TODO: reagent vision googles? code below:

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -298,7 +298,8 @@ its easier to just keep the beam vertical.
 			if(reagents.reagent_list.len)
 				for(var/I in reagents.reagent_list)
 					var/datum/reagent/R = I
-					to_chat(user, "<span class='notice'>[R.volume] units of [R.name]</span>")
+					R.identify_reagent(user)
+					//to_chat(user, "<span class='notice'>[R.volume] units of [R.name]</span>")
 
 				// TODO: reagent vision googles? code below:
 				/*

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -40,7 +40,7 @@
 	var/sanity_gain = 0
 	var/list/taste_tag = list()
 	var/sanity_gain_ingest = 0
-	var/minimum_identification = STAT_LEVEL_GODLIKE	// OCCULUS EDIT: Minimum BIO level to identify the reagent without a scanner
+	var/minimum_identification = STAT_LEVEL_NONE	// OCCULUS EDIT: Minimum BIO level to identify the reagent without a scanner
 
 	var/chilling_point
 	var/chilling_message = "crackles and freezes!"

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -266,11 +266,8 @@
 
 	// Next, see if the user's BIO is greater than or equal to the reagent's minimum identification.
 
-	message_admins("min ID for [name] is [minimum_identification] and examiner's BIO is [user.stats.getStat(STAT_BIO)]")
-
 	if (user.stats.getStat(STAT_BIO) >= minimum_identification || is_silicon)
 		if (exact_amount)
-			message_admins("Best case scenario reached")
 			to_chat(user, "<span class='notice'>[volume] units of [name]</span>")
 		else
 			to_chat(user, "<span class='notice'>[desc_amount] of [name]</span>")

--- a/code/modules/reagents/reagents.dm
+++ b/code/modules/reagents/reagents.dm
@@ -40,7 +40,7 @@
 	var/sanity_gain = 0
 	var/list/taste_tag = list()
 	var/sanity_gain_ingest = 0
-	var/minimum_identification = 100	// OCCULUS EDIT: Minimum BIO level to identify the reagent without a scanner
+	var/minimum_identification = STAT_LEVEL_GODLIKE	// OCCULUS EDIT: Minimum BIO level to identify the reagent without a scanner
 
 	var/chilling_point
 	var/chilling_message = "crackles and freezes!"
@@ -239,7 +239,7 @@
 
 /datum/reagent/proc/identify_reagent(mob/user)
 
-	var/minimum_cog = 15
+	var/minimum_cog = STAT_LEVEL_BASIC
 	var/is_silicon = istype(user, /mob/living/silicon)	// Silicons can always identify it
 
 	// Can they see the amount? Low level COG check
@@ -254,15 +254,15 @@
 	if (!exact_amount)
 		switch(volume)
 			if (0 to 1)
-				desc_amount = "a tiny bit"
+				desc_amount = "A tiny bit"
 			if (1 to 5)
-				desc_amount = "a sip"
+				desc_amount = "A sip"
 			if (5 to 15)
-				desc_amount = "a few drinks"
+				desc_amount = "A few drinks"
 			if (15 to 30)
-				desc_amount = "a good amount"
+				desc_amount = "A good amount"
 			if (30 to INFINITY)
-				desc_amount = "a lot"
+				desc_amount = "A lot"
 
 	// Next, see if the user's BIO is greater than or equal to the reagent's minimum identification.
 

--- a/zzzz_modular_occulus/code/modules/reagents/chemical_identification.dm
+++ b/zzzz_modular_occulus/code/modules/reagents/chemical_identification.dm
@@ -1,29 +1,44 @@
-/datum/reagent/drink
+/datum/reagent/drink  // Regular drinks, like space cola
+	minimum_identification = STAT_LEVEL_NONE
 
-	// Regular drinks, like space cola
-
-	minimum_identification = 0
-
-/datum/reagent/toxin
-
-	// Cyanide, etc
-
+/datum/reagent/toxin  // Cyanide, etc
 	minimum_identification = STAT_LEVEL_PROF
 
-/datum/reagent/medicine
-
-	// Reagents combined into a medicine
-
+/datum/reagent/medicine  // Reagents combined into a medicine
 	minimum_identification = STAT_LEVEL_EXPERT
 
-/datum/reagent/ethanol
-
-	// Alcohol
-
+/datum/reagent/ethanol  // Alcohol
 	minimum_identification = STAT_LEVEL_BASIC
 
-/datum/reagent/water
+/datum/reagent/organic //Blood, antibodies
+	minimum_identification = STAT_LEVEL_BASIC
 
-	// Water
+/datum/reagent/metal // Metallic substances
+	minimum_identification = STAT_LEVEL_BASIC
 
-	minimum_identification = 0
+/datum/reagent/acid // Various ingredient acids
+	minimum_identification = STAT_LEVEL_PROF
+
+/datum/reagent/drug //LSD, Seratonium, Impedrazine
+	minimum_identification = STAT_LEVEL_EXPERT
+
+/datum/reagent/nanites //Nanites. Extremely hard to identify
+	minimum_identification = STAT_LEVEL_GODLIKE
+
+/datum/reagent/stim //Advanced stims
+	minimum_identification = STAT_LEVEL_EXPERT
+
+/datum/reagent/adminordrazine //o.o what is this?
+	minimum_identification = 200
+
+/datum/reagent/adrenaline //Basically a Stim
+	minimum_identification = STAT_LEVEL_EXPERT
+
+/datum/reagent/other/thermite //Chemist solution to bolted doors
+	minimum_identification = STAT_LEVEL_PROF
+
+/datum/reagent/other/glycerol //used in Explosives
+	minimum_identification = STAT_LEVEL_PROF
+
+/datum/reagent/other/nitroglycerin //am explosive
+	minimum_identification = STAT_LEVEL_PROF

--- a/zzzz_modular_occulus/code/modules/reagents/chemical_identification.dm
+++ b/zzzz_modular_occulus/code/modules/reagents/chemical_identification.dm
@@ -4,17 +4,23 @@
 
 	minimum_identification = 0
 
+/datum/reagent/toxin
+
+	// Cyanide, etc
+
+	minimum_identification = STAT_LEVEL_PROF
+
 /datum/reagent/medicine
 
 	// Reagents combined into a medicine
 
-	minimum_identification = 50
+	minimum_identification = STAT_LEVEL_EXPERT
 
 /datum/reagent/ethanol
 
 	// Alcohol
 
-	minimum_identification = 20
+	minimum_identification = STAT_LEVEL_BASIC
 
 /datum/reagent/water
 

--- a/zzzz_modular_occulus/code/modules/reagents/chemical_identification.dm
+++ b/zzzz_modular_occulus/code/modules/reagents/chemical_identification.dm
@@ -1,0 +1,23 @@
+/datum/reagent/drink
+
+	// Regular drinks, like space cola
+
+	minimum_identification = 0
+
+/datum/reagent/medicine
+
+	// Reagents combined into a medicine
+
+	minimum_identification = 50
+
+/datum/reagent/ethanol
+
+	// Alcohol
+
+	minimum_identification = 20
+
+/datum/reagent/water
+
+	// Water
+
+	minimum_identification = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

**This is a proof of concept. This is not a true pull -- the intent of this pull is to show that the idea is viable without significant code alterations, and I am unlikely to personally continue work on it.**

This non-modular adds the flag `minimum_identification` to `/datum/reagent`, and changes the examine call to call reagent's new proc, `identify_reagent` rather than a direct `to_chat` with the information.

The purpose of `minimum_identification` is to act as a minimum level for identifying the liquid without a scanner.

Straight reagents, like carbon or acetone, are set to a minimum level of STAT_LEVEL_GODLIKE (100)
Medicines are set to a level of STAT_LEVEL_EXPERT (40)
Alcohol is set to a level of STAT_LEVEL_BASIC (15)
Drinks are set to a level of 0.	(space cola, dr. gibb)
Water is set to 0 (because normally it would try to inherit 100 from `/datum/reagent`)

There is also a small check to see the 'exact amount' of a liquid based on COG. It's easy to pass at a 15 minimum, otherwise you'll just get a descriptor saying how much is in the glass.

Screenshot examples (debug messages are not in live code, and descriptor texts are capitalized in live code):

Acetone (min 100)
![image](https://user-images.githubusercontent.com/77511162/115603011-a36fff00-a2ad-11eb-9f9b-6fff62e27de9.png)

Water (min 0)
![image](https://user-images.githubusercontent.com/77511162/115603059-b1258480-a2ad-11eb-920b-acb8f002240c.png)

**COG below 15:**

Absinthe (min 20)
![image](https://user-images.githubusercontent.com/77511162/115603150-cd292600-a2ad-11eb-9698-d16b83d1c449.png)

Space cleaner (min 100, could probably be lowered)
![image](https://user-images.githubusercontent.com/77511162/115603231-e500aa00-a2ad-11eb-94ed-d5d00b3c627e.png)

Finally, silicons ignore the skill requirements. This does not touch reagent descriptions or names (as you can see the final picture has 'contains space cleaner'. The desc could also be obfuscated if it's an unknown reagent but that is not in the current code.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

More obfuscation for reagents -- now a vagabond can't look a vial and go 'oh! that's ossisine!'

## Changelog
```changelog
balance: Skill checks are required to identify reagents and how much of it there is
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
