### PR TITLE
[wip] eris ports but i'm still here just to suffer

### DIFF
--- a/code/ZAS/Airflow.dm
+++ b/code/ZAS/Airflow.dm
@@ -16,7 +16,7 @@ mob/proc/airflow_stun()
 		return 0
 	if(!lying)
 		to_chat(src, SPAN_WARNING("The sudden rush of air knocks you over!"))
-	Weaken(5)
+	Weaken(3) // Nerfed from 5
 	last_airflow_stun = world.time
 
 mob/living/silicon/airflow_stun()

--- a/code/game/objects/structures/low_wall.dm
+++ b/code/game/objects/structures/low_wall.dm
@@ -107,6 +107,10 @@
 		return 1
 	if(locate(/obj/structure/low_wall) in get_turf(mover))
 		return 1
+	if(isliving(mover))
+		var/mob/living/L = mover
+		if(L.weakened)
+			return 1
 	return ..()
 
 

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -10,7 +10,7 @@
 	//This armor only applies to legs
 	style = STYLE_NEG_LOW
 	spawn_blacklisted = TRUE
-	var/magpulse = 0
+	var/magpulse = FALSE
 	var/mag_slow = 3
 	var/icon_base = "magboots"
 
@@ -23,14 +23,14 @@
 /obj/item/clothing/shoes/magboots/attack_self(mob/user)
 	if(magpulse)
 		item_flags &= ~NOSLIP
-		magpulse = 0
+		magpulse = FALSE
 		set_slowdown()
 		force = WEAPON_FORCE_WEAK
 		if(icon_base) icon_state = "[icon_base]0"
 		to_chat(user, "You disable the mag-pulse traction system.")
 	else
 		item_flags |= NOSLIP
-		magpulse = 1
+		magpulse = TRUE
 		set_slowdown()
 		force = WEAPON_FORCE_PAINFUL
 		if(icon_base) icon_state = "[icon_base]1"

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -97,6 +97,13 @@ var/list/custom_table_appearance = list(
 		T.update_icon()
 	. = ..()
 
+/obj/structure/table/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
+	if(isliving(mover))
+		var/mob/living/L = mover
+		if(L.weakened)
+			return 1
+	return ..()	
+
 /obj/structure/table/examine(mob/user)
 	. = ..()
 	if(health < maxhealth)


### PR DESCRIPTION
## About The Pull Request

https://github.com/discordia-space/CEV-Eris/pull/6072

## Why It's Good For The Game

## Changelog
```changelog
add: Added new things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
