### PR TITLE
reSUScitator reagent_type fix

### DIFF
--- a/zzzz_modular_occulus/code/modules/reagents/reagents/other.dm
+++ b/zzzz_modular_occulus/code/modules/reagents/reagents/other.dm
@@ -2,3 +2,7 @@
 	result = "rejuvetaning_agent"
 	required_reagents = list("cleaner" = 2, "pacid" = 1, "sulfur" = 1, "uncap nanites" = 1)
 	result_amount = 1
+
+
+/datum/reagent/resuscitator
+		reagent_type = "Stimulator" //For some reason this doesn't inherit a reagent type unless we do this...????


### PR DESCRIPTION
## About The Pull Request

resuscitator previously showed up as reagent type 'PLEASE FIX IMIDIATLY'. wasn't inhereting its proper reagent type from its parent object?? idk why

## Why It's Good For The Game

fix.

## Changelog
```changelog
fix: RESUSCITATOR NO LONGER SUS!!!
```