### PR TITLE
Shield adjustment

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -76,7 +76,8 @@
 		var/obj/item/projectile/P = damage_source
 		//plastic shields do not stop bullets or lasers, even in space. Will block beanbags, rubber bullets, and stunshots just fine though.
 		if((is_sharp(P) && damage > 10) || istype(P, /obj/item/projectile/beam))
-			return 0
+			return base_block_chance //occulus edit- This shield is not plastic, it's metal. TRAYSHIELDS SHOULD NOT BLOCK BETTER THEN ACTUAL RIOT SHIELDS.
+		//	return 0
 	return base_block_chance
 
 /obj/item/weapon/shield/riot/attackby(obj/item/weapon/W as obj, mob/user as mob)


### PR DESCRIPTION
Adjusts riotshields to not be garbage against lethals, and be better then tray shields. Come on Eris, Really?

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Litterally just returns base block chance, instead of making it so the riotshields don't block bullets.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As is, makeshift Tray shields have a 20% chance to block lethals. And they're made of trays. Actual purposebuilt riots shields, that are made of metal and steel (per material in code) should do better then not blocking it at all.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
balance: Makes riotshields able to block lethal bullets.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
