### PR TITLE
Moves 'gun assembly' from the bottom of the misc menu into the gun tab.

### DIFF
--- a/code/datums/craft/recipes/guns.dm
+++ b/code/datums/craft/recipes/guns.dm
@@ -85,3 +85,12 @@
 		list(/obj/item/weapon/stock_parts/micro_laser , 4),
 		list(QUALITY_SCREW_DRIVING, 10)
 	)
+
+ /datum/craft_recipe/gun/guns_craft_frame //occulus edit: originally in misc.dm as /datum/craft_recipe/gun/guns_craft_frame - bear
+	name = "Gun assembly"
+	result = /obj/item/craft_frame/guns
+	steps = list(
+		list(CRAFT_MATERIAL, 5, MATERIAL_PLASTEEL, "time" = 30),
+		list(QUALITY_WELDING, 10, 10)
+	)
+	related_stats = list(STAT_MEC)

--- a/code/datums/craft/recipes/misc.dm
+++ b/code/datums/craft/recipes/misc.dm
@@ -292,11 +292,11 @@
 	name = "Makeshift prosthetic right arm"
 	result = /obj/item/organ/external/robotic/makeshift/r_arm*/
 
-/datum/craft_recipe/guns_craft_frame
+/* /datum/craft_recipe/guns_craft_frame Occulus Edit: This is now under gun.dm as /datum/craft_recipe/gun/guns_craft_frame
 	name = "Gun assembly"
 	result = /obj/item/craft_frame/guns
 	steps = list(
 		list(CRAFT_MATERIAL, 5, MATERIAL_PLASTEEL, "time" = 30),
 		list(QUALITY_WELDING, 10, 10)
 	)
-	related_stats = list(STAT_MEC)
+	related_stats = list(STAT_MEC) */


### PR DESCRIPTION
## About The Pull Request

As above.

## Why It's Good For The Game

Better to have it be in the proper place?  All the changes are really clearly marked, too, so it shouldn't override anything. Ideally.

## Changelog
```changelog
tweak: gun assembly crafting now shows up under gun crafting.
```