### PR TITLE
Add shield check in attack_generic (for roaches, etc)

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -31,7 +31,7 @@
 
 /obj/item/weapon/shield
 	name = "shield"
-	var/base_block_chance = 50
+	var/base_block_chance = 30	// OCCULUS EDIT: Less block chance
 
 /obj/item/weapon/shield/handle_shield(mob/user, var/damage, atom/damage_source = null, mob/attacker = null, var/def_zone = null, var/attack_text = "the attack")
 	if(user.incapacitated())

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -308,13 +308,20 @@
 
 	user.do_attack_animation(src)
 
+	// OCCULUS EDIT: invoke check_shields to catch superior_animal & other attacks
+
 	var/dam_zone = pick(organs_by_name)
-	var/obj/item/organ/external/affecting = get_organ(ran_zone(dam_zone))
-	var/dam = damage_through_armor(damage, BRUTE, affecting, ARMOR_MELEE)
-	if(dam > 0)
-		affecting.add_autopsy_data("[attack_message] by \a [user]", dam)
-	updatehealth()
-	hit_impact(damage, get_step(user, src))
+
+	if (!check_shields(damage, 0, user, dam_zone, "the [user.name]")) // if it fails to block, continue
+		var/obj/item/organ/external/affecting = get_organ(ran_zone(dam_zone))
+		var/dam = damage_through_armor(damage, BRUTE, affecting, ARMOR_MELEE)
+		if(dam > 0)
+			affecting.add_autopsy_data("[attack_message] by \a [user]", dam)
+		updatehealth()
+		hit_impact(damage, get_step(user, src))
+
+	// OCCULUS EDIT END
+
 	return TRUE
 
 //Used to attack a joint through grabbing


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This non-modular code adds a check to `attack_generic` for `/mob/living/carbon/human` to block generic attacks (as used by superior mobs, like roaches, and simple mobs).

Per request, the block rate was also nudged down to 30 rather than 50.

![image](https://user-images.githubusercontent.com/77511162/117609106-628d3c80-b12d-11eb-970e-a26ee47e6d7b.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Now shields against roaches have a chance to be effective.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
tweak: Mobs that invoke attack_generic (ex: roaches biting a human) can now be blocked by shields
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
