### PR TITLE
Aegis Antagonism

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2823,6 +2823,7 @@
 #include "zzzz_modular_occulus\code\datums\uplink\medical.dm"
 #include "zzzz_modular_occulus\code\game\occulus-lore-fixes.dm"
 #include "zzzz_modular_occulus\code\game\antagonist\outer\blitzshell\blitzshell.dm"
+#include "zzzz_modular_occulus\code\game\antagonist\station\traitor.dm"
 #include "zzzz_modular_occulus\code\game\gamemodes\changeling\modularchangeling.dm"
 #include "zzzz_modular_occulus\code\game\gamemodes\storytellers\storyevent.dm"
 #include "zzzz_modular_occulus\code\game\gamemodes\storytellers\storytellers.dm"

--- a/code/game/jobs/job/guild.dm
+++ b/code/game/jobs/job/guild.dm
@@ -73,6 +73,7 @@ Your second loyalty is to the Union. Ensure it retains good relations with priva
 	supervisors = "the Free Trade Union Merchant"
 	selection_color = "#c3b9a6"
 	wage = WAGE_LABOUR_DUMB
+	alt_titles = list("Union Salvage Technician")	// OCCULUS EDIT
 	department_account_access = TRUE
 	outfit_type = /decl/hierarchy/outfit/job/cargo/cargo_tech
 
@@ -110,7 +111,7 @@ Your main duties are to keep the local Union branch operational and profitable. 
 		Your second loyalty is to the merchant, he ensures you're well paid and respected, in a universe where workers are often treated as interchangeable parts."
 
 /obj/landmark/join/start/cargo_tech
-	name = "Union Cargo Technician"	//SYZYGY EDIT - Fixes landmarks
+	name = "Union Cargo Technician"	//OCCULUS EDIT - Fixes landmarks
 	icon_state = "player-beige"
 	join_tag = /datum/job/cargo_tech
 
@@ -125,7 +126,7 @@ Your main duties are to keep the local Union branch operational and profitable. 
 	supervisors = "the Free Trade Union Merchant"
 	selection_color = "#c3b9a6"
 	wage = WAGE_LABOUR_HAZARD //The miners union is stubborn
-	alt_titles = list("Union Salvage Technician")	// OCCULUS EDIT
+	alt_titles = list("Union Prospector")	// OCCULUS EDIT
 	outfit_type = /decl/hierarchy/outfit/job/cargo/mining
 
 	description = "You are an asteroid miner, working in resource Procurement for the local branch of the Free Trade Union.<br>\

--- a/zzzz_modular_occulus/code/game/antagonist/station/traitor.dm
+++ b/zzzz_modular_occulus/code/game/antagonist/station/traitor.dm
@@ -1,0 +1,8 @@
+/datum/antagonist/traitor
+	protected_jobs = list("Aegis Gunnery Sergeant","Aegis Inspector", JOBS_COMMAND)
+
+/datum/antagonist/marshal
+	protected_jobs = list("Aegis Gunnery Sergeant","Aegis Inspector", JOBS_COMMAND)
+
+/datum/antagonist/carrion
+	protected_jobs = list("Aegis Gunnery Sergeant","Aegis Inspector", JOBS_COMMAND)

--- a/zzzz_modular_occulus/code/game/jobs/job/church.dm
+++ b/zzzz_modular_occulus/code/game/jobs/job/church.dm
@@ -16,6 +16,7 @@
 	)
 	also_known_languages = list(LANGUAGE_CYRILLIC = 0)
 /datum/job/hydro
+	wage = WAGE_LABOUR
 	also_known_languages = list(LANGUAGE_JIVE = 0)
 	stat_modifiers = list(
 		STAT_BIO = 25,
@@ -23,6 +24,7 @@
 		STAT_ROB = 10
 	)
 /datum/job/janitor
+	wage = WAGE_LABOUR_HAZARD
 	stat_modifiers = list(
 		STAT_BIO = 10,
 		STAT_ROB = 15,


### PR DESCRIPTION
## About The Pull Request

As per Emojicracy, enables antagonist for Aegis Operative and Aegis Medspec

Also tweaks a few small things in other jobs

## Why It's Good For The Game

This widens the field for potential antagonist players, while still keeping certain important jobs blacklisted.

## Changelog
```changelog
balance: Aegis Operatives can now be antagonists!
balance: Aegis Medical Specialists can now be antagonists!
balance: Reduced Argolyte pay from 900 to 600
balance: Reduced Custodian pay from 900 to 750
tweak: Moved Union Salvage Technician to Union Technician
add: Miners now have a Union Prospector alt-title
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
