### PR TITLE
Multiple small tweaks to the map

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -18776,11 +18776,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
 	},
-/obj/item/weapon/computer_hardware/hard_drive/portable{
-	default_files = list(/datum/computer_file/program/trade);
-	icon_state = "guild";
-	name = "Asters Trade Program"
-	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/quartermaster/hangarsupply)
 "aTv" = (
@@ -19282,10 +19277,6 @@
 	})
 "aUz" = (
 /obj/structure/table/reinforced,
-/obj/item/ammo_magazine/lrifle/pk{
-	pixel_x = -6;
-	pixel_y = -4
-	},
 /obj/item/weapon/storage/box/trackimp,
 /obj/item/weapon/storage/box/chemimp{
 	pixel_x = 4;
@@ -20429,18 +20420,7 @@
 /area/eris/maintenance/section1deck4central)
 "aWV" = (
 /obj/structure/table/reinforced,
-/obj/item/stack/material/plastic{
-	amount = 120
-	},
-/obj/item/stack/material/steel{
-	amount = 120
-	},
-/obj/item/stack/material/glass{
-	amount = 120
-	},
-/obj/item/stack/material/plasteel{
-	amount = 10
-	},
+/obj/machinery/smartfridge/disks,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/security/warden)
 "aWW" = (
@@ -21703,10 +21683,21 @@
 "aZG" = (
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
-/obj/item/weapon/computer_hardware/hard_drive/portable/design/misc,
-/obj/item/weapon/computer_hardware/hard_drive/portable/design/security,
+/obj/item/stack/material/plastic{
+	amount = 120
+	},
+/obj/item/stack/material/steel{
+	amount = 120
+	},
+/obj/item/stack/material/glass{
+	amount = 120
+	},
+/obj/item/stack/material/plasteel{
+	amount = 10
+	},
 /obj/item/weapon/reagent_containers/glass/beaker,
-/obj/machinery/smartfridge/disks,
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/security,
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/misc,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/security/warden)
 "aZH" = (
@@ -30143,7 +30134,7 @@
 /turf/simulated/floor/plating,
 /area/eris/medical/virology)
 "bsi" = (
-/obj/item/modular_computer/console/preset/civilian/professional{
+/obj/item/modular_computer/console/preset/trade{
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
@@ -30499,7 +30490,14 @@
 /obj/machinery/button/remote/blast_door{
 	desc = "It controls the blast door to the main RND entrance.";
 	id = "RDDoorLockdown";
-	name = "RND Door Blast Door Control"
+	name = "RND Door Blast Door Control";
+	pixel_x = 6
+	},
+/obj/machinery/button/remote/blast_door{
+	desc = "It controls the RND Window Blast doors.";
+	id = "RDWindowsLockdown";
+	name = "RND Window Blast Doors Control";
+	pixel_x = -6
 	},
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/rnd/lab)
@@ -31110,15 +31108,11 @@
 	amount = 120
 	},
 /obj/spawner/material/resources/rare,
-/obj/machinery/button/remote/blast_door{
-	desc = "It controls the RND Window Blast doors.";
-	id = "RDWindowsLockdown";
-	name = "RND Window Blast Doors Control"
-	},
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/misc,
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/components,
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/medical,
 /obj/machinery/smartfridge/disks,
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/tools,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/rnd/lab)
 "buD" = (
@@ -36104,6 +36098,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/structure/bed/chair/custom/onestar/red,
 /turf/simulated/floor/plating,
 /area/eris/maintenance/substation/section4)
 "bGr" = (
@@ -53571,15 +53566,14 @@
 /turf/simulated/floor/carpet/bcarpet,
 /area/eris/neotheology/chapel)
 "cvi" = (
-/obj/structure/closet/secure_closet/reinforced/RD,
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/item/weapon/bluespace_harpoon,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/carpet/purcarpet,
 /area/eris/command/meo)
 "cvj" = (
@@ -55395,11 +55389,9 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/eris/crew_quarters/bar)
 "czB" = (
-/obj/structure/table/standard,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/weapon/packageWrap,
-/obj/item/device/destTagger,
+/obj/item/modular_computer/console/preset/trade{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/office)
 "czC" = (
@@ -55550,6 +55542,11 @@
 	name = "Maintenance Hatch"
 	},
 /obj/effect/window_lwall_spawn/smartspawn,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/eris/engineering/gravity_generator)
 "czV" = (
@@ -59311,14 +59308,6 @@
 "cIm" = (
 /turf/simulated/floor/tiled/steel,
 /area/eris/storage/primary)
-"cIn" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/violetcorener,
-/area/eris/command/bridge)
 "cIo" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/steel/panels,
@@ -60575,6 +60564,11 @@
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/eris/engineering/foyer)
@@ -62503,8 +62497,6 @@
 /area/eris/command/meeting_room)
 "cQj" = (
 /obj/structure/table/rack,
-/obj/item/clothing/shoes/magboots,
-/obj/item/clothing/mask/breath,
 /obj/item/weapon/rig/ce/equipped,
 /obj/machinery/alarm{
 	pixel_y = 26
@@ -62537,13 +62529,10 @@
 /area/eris/command/teleporter)
 "cQl" = (
 /obj/structure/table/reinforced,
-/obj/item/weapon/rcd_ammo,
-/obj/item/weapon/rcd_ammo,
-/obj/item/weapon/rcd_ammo,
-/obj/item/weapon/rcd_ammo,
-/obj/item/weapon/rcd_ammo,
-/obj/item/weapon/rcd_ammo,
-/obj/item/weapon/rcd,
+/obj/item/device/magnetic_lock/engineering,
+/obj/item/device/magnetic_lock/engineering,
+/obj/item/device/magnetic_lock/engineering,
+/obj/item/clothing/glasses/powered/meson,
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/command/exultant)
 "cQm" = (
@@ -64111,10 +64100,12 @@
 	},
 /area/shuttle/mining/station)
 "cUl" = (
-/turf/simulated/shuttle/wall/mining{
-	icon_state = "7,14"
-	},
-/area/shuttle/mining/station)
+/obj/item/device/magnetic_lock/security,
+/obj/item/device/magnetic_lock/security,
+/obj/item/device/magnetic_lock/security,
+/obj/item/device/magnetic_lock/security,
+/turf/simulated/floor/tiled/dark/cargo,
+/area/eris/security/armory)
 "cUm" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
@@ -64242,32 +64233,33 @@
 	},
 /area/shuttle/mining/station)
 "cUF" = (
-/obj/structure/bed/chair,
 /obj/machinery/camera/network/mining{
 	dir = 4
 	},
+/obj/structure/bed/chair/shuttle,
 /turf/simulated/shuttle/floor/mining{
-	icon_state = "5,13"
+	icon_state = "3,9"
 	},
 /area/shuttle/mining/station)
 "cUG" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed/chair/shuttle,
 /turf/simulated/shuttle/floor/mining{
-	icon_state = "6,13"
+	icon_state = "4,9"
 	},
 /area/shuttle/mining/station)
 "cUH" = (
-/obj/machinery/door/airlock/mining{
-	name = "Hulk Internal Airlock";
-	req_access = list(48)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/bed/chair/shuttle,
 /turf/simulated/shuttle/floor/mining{
-	icon_state = "7,13"
+	icon_state = "7,9"
 	},
 /area/shuttle/mining/station)
 "cUI" = (
@@ -64499,29 +64491,28 @@
 /area/shuttle/mining/station)
 "cVl" = (
 /obj/structure/table/standard,
-/obj/item/device/lighting/toggleable/lamp,
+/obj/machinery/microwave,
 /turf/simulated/shuttle/floor/mining{
-	icon_state = "5,12"
+	icon_state = "4,8"
 	},
 /area/shuttle/mining/station)
 "cVm" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/donkpockets,
 /turf/simulated/shuttle/floor/mining{
-	icon_state = "6,12"
+	icon_state = "4,8"
 	},
 /area/shuttle/mining/station)
 "cVn" = (
-/turf/simulated/shuttle/wall/mining{
-	icon_state = "7,12"
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer,
+/turf/simulated/shuttle/floor/mining{
+	icon_state = "7,8"
 	},
 /area/shuttle/mining/station)
 "cVo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 8
-	},
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "8,12"
 	},
@@ -64725,22 +64716,28 @@
 	},
 /area/shuttle/mining/station)
 "cVO" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet,
+/obj/structure/bed/chair/shuttle{
+	dir = 1
+	},
 /turf/simulated/shuttle/floor/mining{
-	icon_state = "5,11"
+	icon_state = "3,6"
 	},
 /area/shuttle/mining/station)
 "cVP" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet,
+/obj/machinery/light,
+/obj/structure/bed/chair/shuttle{
+	dir = 1
+	},
 /turf/simulated/shuttle/floor/mining{
-	icon_state = "6,11"
+	icon_state = "6,7"
 	},
 /area/shuttle/mining/station)
 "cVQ" = (
-/turf/simulated/shuttle/wall/mining{
-	icon_state = "7,11"
+/obj/structure/bed/chair/shuttle{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/mining{
+	icon_state = "7,7"
 	},
 /area/shuttle/mining/station)
 "cVR" = (
@@ -65169,10 +65166,14 @@
 	},
 /area/shuttle/mining/station)
 "cWQ" = (
-/turf/simulated/shuttle/wall/mining{
-	icon_state = "7,10"
-	},
-/area/shuttle/mining/station)
+/obj/structure/table/rack,
+/obj/item/device/destTagger,
+/obj/item/weapon/packageWrap,
+/obj/item/device/destTagger,
+/obj/item/weapon/packageWrap,
+/obj/item/weapon/packageWrap,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/eris/quartermaster/office)
 "cWR" = (
 /obj/machinery/door/airlock/multi_tile/metal/mait{
 	name = "Hulk Internal Airlock";
@@ -66851,7 +66852,6 @@
 /area/shuttle/mining/station)
 "daI" = (
 /obj/structure/table/steel,
-/obj/machinery/microwave,
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "7,4"
 	},
@@ -66871,8 +66871,8 @@
 /area/shuttle/mining/station)
 "daL" = (
 /obj/structure/table/steel,
-/obj/item/weapon/storage/box/donkpockets,
 /obj/machinery/camera/network/mining,
+/obj/item/weapon/storage/firstaid/regular,
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "10,4"
 	},
@@ -66970,8 +66970,6 @@
 /area/shuttle/mining/station)
 "dba" = (
 /obj/structure/table/steel,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/small/beer,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -66980,13 +66978,13 @@
 	},
 /area/shuttle/mining/station)
 "dbb" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/shuttle,
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "8,3"
 	},
 /area/shuttle/mining/station)
 "dbc" = (
-/obj/structure/bed/chair,
+/obj/structure/bed/chair/shuttle,
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "9,3"
 	},
@@ -67140,6 +67138,7 @@
 "dbw" = (
 /obj/structure/table/steel,
 /obj/item/weapon/tool/crowbar,
+/obj/item/weapon/tool/crowbar,
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "7,2"
 	},
@@ -67163,6 +67162,7 @@
 /area/eris/command/captain)
 "dbz" = (
 /obj/structure/table/steel,
+/obj/item/device/radio/color/brown,
 /obj/item/device/radio/color/brown,
 /turf/simulated/shuttle/floor/mining{
 	icon_state = "10,2"
@@ -68834,12 +68834,13 @@
 /turf/simulated/floor/tiled/white/violetcorener,
 /area/eris/rnd/research)
 "dfl" = (
-/obj/structure/bed/chair/comfy/black{
-	dir = 4
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/landmark/join/start/merchant,
-/turf/simulated/floor/carpet/bcarpet,
-/area/eris/command/meeting_room)
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/eris/engineering/starboardhallway)
 "dfm" = (
 /obj/structure/table/reinforced,
 /obj/item/device/megaphone,
@@ -68960,7 +68961,6 @@
 	name = "Destiny id lock";
 	req_access = list(20)
 	},
-/obj/item/weapon/card/id/captains_spare,
 /turf/simulated/floor/carpet/turcarpet,
 /area/eris/command/captain)
 "dfA" = (
@@ -70538,9 +70538,6 @@
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/toolbox/mechanical,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/item/device/magnetic_lock/engineering,
-/obj/item/device/magnetic_lock/engineering,
-/obj/item/device/magnetic_lock/engineering,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/eris/command/exultant)
 "diR" = (
@@ -77183,6 +77180,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/starboardhallway)
 "dxZ" = (
@@ -77332,7 +77334,8 @@
 /area/eris/maintenance/oldbridge)
 "dyu" = (
 /obj/item/weapon/autopsy_scanner,
-/obj/structure/closet/secure_closet/reinforced/CMOcculus,
+/obj/structure/closet/secure_closet/personal,
+/obj/item/weapon/soulmanip,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/command/mbo)
 "dyv" = (
@@ -77568,6 +77571,11 @@
 "dyW" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/eris/engineering/starboardhallway)
@@ -77865,7 +77873,6 @@
 /area/eris/medical/reception)
 "dzG" = (
 /obj/structure/table/standard,
-/obj/item/weapon/soulmanip,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/command/mbo)
 "dzH" = (
@@ -78402,6 +78409,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/eris/engineering/foyer)
 "dAU" = (
@@ -78410,6 +78422,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/eris/engineering/foyer)
@@ -78424,6 +78441,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/eris/engineering/foyer)
@@ -78573,6 +78595,11 @@
 "dBr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel/orangecorner,
 /area/eris/engineering/foyer)
@@ -82667,6 +82694,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/eris/maintenance/section4deck2starboard)
 "dKJ" = (
@@ -83272,6 +83304,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/engineering/gravity_generator)
 "dMd" = (
@@ -83390,6 +83427,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
@@ -83657,6 +83699,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/engineering/foyer)
 "dMS" = (
@@ -83785,6 +83832,11 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
 "dNj" = (
@@ -83800,6 +83852,11 @@
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
 "dNk" = (
@@ -83809,6 +83866,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
@@ -83821,6 +83883,11 @@
 	},
 /obj/structure/railing{
 	dir = 1
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
@@ -83985,7 +84052,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
+/turf/simulated/floor/tiled/dark,
 /area/eris/command/bridge)
 "dNI" = (
 /obj/machinery/meter,
@@ -84046,6 +84113,11 @@
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering";
 	req_access = list(10)
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/engineering/foyer)
@@ -84126,6 +84198,11 @@
 /area/eris/quartermaster/office)
 "dOe" = (
 /obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/open,
 /area/eris/hallway/main/section4)
 "dOf" = (
@@ -84141,6 +84218,11 @@
 /obj/machinery/door/airlock/glass_engineering{
 	name = "Engineering";
 	req_access = list(10)
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/engineering/starboardhallway)
@@ -84251,6 +84333,11 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
 "dOu" = (
@@ -84266,6 +84353,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing{
 	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
@@ -84285,6 +84377,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
@@ -84456,11 +84553,16 @@
 /area/eris/maintenance/section4deck2starboard)
 "dOT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/shield_generator)
 "dOU" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
@@ -84674,11 +84776,11 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/shield_generator)
 "dPx" = (
-/obj/structure/cable/green{
+/obj/machinery/power/shield_generator/hull/installed,
+/obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/shield_generator/hull/installed,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/shield_generator)
 "dPy" = (
@@ -84692,7 +84794,7 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/shield_generator)
 "dPA" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -84729,19 +84831,28 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/structure/table/standard,
+/obj/machinery/constructable_frame/machine_frame,
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/shield_generator)
 "dPG" = (
-/obj/structure/cable/green{
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/cable/green{
-	d1 = 2;
+/obj/structure/cable{
+	d1 = 1;
 	d2 = 4;
-	icon_state = "2-4"
+	icon_state = "1-4"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/shield_generator)
@@ -84756,17 +84867,20 @@
 	name = "East APC";
 	pixel_x = 28
 	},
-/obj/structure/cable/green{
+/obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/shield_generator)
 "dPI" = (
-/obj/structure/table/standard,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/shield_generator)
@@ -84835,6 +84949,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/gravity_generator)
@@ -84978,16 +85097,21 @@
 /turf/simulated/floor/plating,
 /area/eris/engineering/engine_room)
 "dQl" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/shield_generator)
@@ -87095,7 +87219,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
+/turf/simulated/floor/tiled/dark,
 /area/eris/command/bridge)
 "dVG" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -87678,7 +87802,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/gray_platform,
+/turf/simulated/floor/tiled/dark,
 /area/eris/command/bridge)
 "dWP" = (
 /obj/structure/multiz/stairs/active{
@@ -90115,7 +90239,6 @@
 /area/shuttle/research/station)
 "ecG" = (
 /obj/structure/table/standard,
-/obj/item/weapon/storage/box/donut,
 /turf/simulated/shuttle/floor/science{
 	icon_state = "7,18"
 	},
@@ -90458,10 +90581,10 @@
 	},
 /area/shuttle/research/station)
 "eds" = (
-/obj/structure/bed/chair{
+/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/bed/chair/shuttle{
 	dir = 1
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/shuttle/floor/science{
 	icon_state = "8,17"
 	},
@@ -91388,7 +91511,7 @@
 	},
 /area/shuttle/research/station)
 "efI" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/shuttle{
 	dir = 4
 	},
 /turf/simulated/shuttle/floor/science{
@@ -91444,7 +91567,7 @@
 	},
 /area/shuttle/research/station)
 "efO" = (
-/obj/structure/bed/chair{
+/obj/structure/bed/chair/shuttle{
 	dir = 8
 	},
 /turf/simulated/shuttle/floor/science{
@@ -92208,13 +92331,14 @@
 /area/shuttle/research/station)
 "ehC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/item/device/radio/beacon,
 /turf/simulated/shuttle/floor/science{
 	icon_state = "8,12"
 	},
 /area/shuttle/research/station)
 "ehD" = (
-/obj/item/device/radio/beacon,
 /obj/machinery/camera/network/research_outpost,
+/obj/structure/bed/chair/shuttle,
 /turf/simulated/shuttle/floor/science{
 	icon_state = "9,12"
 	},
@@ -92223,6 +92347,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/bed/chair/shuttle,
 /turf/simulated/shuttle/floor/science{
 	icon_state = "10,12"
 	},
@@ -92908,10 +93033,17 @@
 	},
 /area/shuttle/research/station)
 "ejk" = (
-/turf/simulated/shuttle/wall/science{
-	icon_state = "7,10"
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
-/area/shuttle/research/station)
+/obj/structure/cable{
+	d1 = 16;
+	d2 = 0;
+	icon_state = "16-0"
+	},
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/eris/engineering/gravity_generator)
 "ejl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/freezer{
@@ -92923,10 +93055,13 @@
 	},
 /area/shuttle/research/station)
 "ejm" = (
-/turf/simulated/shuttle/wall/science{
-	icon_state = "9,10"
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/area/shuttle/research/station)
+/turf/simulated/floor/tiled/dark/gray_perforated,
+/area/eris/engineering/gravity_generator)
 "ejn" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "10,10"
@@ -93359,48 +93494,46 @@
 	},
 /area/shuttle/research/station)
 "ejV" = (
-/obj/structure/closet/excavation,
+/obj/structure/bed/chair/shuttle,
 /turf/simulated/shuttle/floor/science{
 	icon_state = "5,9"
 	},
 /area/shuttle/research/station)
 "ejW" = (
-/obj/machinery/camera/network/research_outpost,
+/obj/structure/bed/chair/shuttle,
 /turf/simulated/shuttle/floor/science{
-	icon_state = "6,9"
+	icon_state = "11,5"
 	},
 /area/shuttle/research/station)
 "ejX" = (
-/turf/simulated/shuttle/wall/science{
-	icon_state = "7,9"
+/turf/simulated/shuttle/floor/science{
+	icon_state = "11,5"
 	},
 /area/shuttle/research/station)
 "ejY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light/small{
-	dir = 8
-	},
 /turf/simulated/shuttle/floor/science{
-	icon_state = "8,9"
+	icon_state = "11,4"
 	},
 /area/shuttle/research/station)
 "ejZ" = (
-/turf/simulated/shuttle/wall/science{
-	icon_state = "9,9"
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/void/hazardsuit/moebius,
+/obj/item/weapon/storage/belt/archaeology,
+/obj/item/clothing/mask/breath,
+/turf/simulated/shuttle/floor/science{
+	icon_state = "11,5"
 	},
 /area/shuttle/research/station)
 "eka" = (
 /obj/machinery/camera/network/research_outpost,
+/obj/structure/bed/chair/shuttle,
 /turf/simulated/shuttle/floor/science{
-	icon_state = "10,9"
+	icon_state = "11,5"
 	},
 /area/shuttle/research/station)
 "ekb" = (
-/obj/structure/table/rack,
-/obj/item/weapon/storage/belt/archaeology,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/suit/space/void/hazardsuit,
-/obj/item/clothing/head/space/void/hazardhelmet,
+/obj/structure/closet/excavation,
 /turf/simulated/shuttle/floor/science{
 	icon_state = "11,9"
 	},
@@ -93520,11 +93653,13 @@
 	dir = 1
 	},
 /obj/structure/table/rack,
+/obj/item/clothing/suit/space/void/hazardsuit/moebius,
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
 "eko" = (
 /obj/machinery/light,
 /obj/structure/table/rack,
+/obj/item/clothing/suit/space/void/hazardsuit/moebius,
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
 "ekp" = (
@@ -93647,7 +93782,11 @@
 	},
 /area/shuttle/research/station)
 "ekC" = (
-/obj/structure/closet/excavation,
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/table/standard,
+/obj/item/weapon/storage/box/donut,
 /turf/simulated/shuttle/floor/science{
 	icon_state = "5,8"
 	},
@@ -93656,54 +93795,16 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/structure/table/standard,
 /turf/simulated/shuttle/floor/science{
-	icon_state = "6,8"
-	},
-/area/shuttle/research/station)
-"ekE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/freezer{
-	name = "Vasiliy Dokuchaev Internal Airlock";
-	req_access = list(5)
-	},
-/turf/simulated/shuttle/floor/science{
-	icon_state = "7,8"
-	},
-/area/shuttle/research/station)
-"ekF" = (
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/turf/simulated/shuttle/floor/science{
-	icon_state = "8,8"
-	},
-/area/shuttle/research/station)
-"ekG" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/freezer{
-	name = "Vasiliy Dokuchaev Internal Airlock";
-	req_access = list(5)
-	},
-/turf/simulated/shuttle/floor/science{
-	icon_state = "9,8"
-	},
-/area/shuttle/research/station)
-"ekH" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/simulated/shuttle/floor/science{
-	icon_state = "10,8"
+	icon_state = "11,4"
 	},
 /area/shuttle/research/station)
 "ekI" = (
-/obj/structure/table/rack,
-/obj/item/weapon/storage/belt/archaeology,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/suit/space/void/hazardsuit,
-/obj/item/clothing/head/space/void/hazardhelmet,
+/obj/machinery/light/small{
+	dir = 4;
+	pixel_y = 8
+	},
 /turf/simulated/shuttle/floor/science{
 	icon_state = "11,8"
 	},
@@ -93895,45 +93996,49 @@
 	},
 /area/shuttle/research/station)
 "elk" = (
-/obj/structure/closet/excavation,
+/obj/structure/bed/chair/shuttle{
+	dir = 1
+	},
 /turf/simulated/shuttle/floor/science{
 	icon_state = "5,7"
 	},
 /area/shuttle/research/station)
 "ell" = (
-/obj/machinery/light/small,
-/turf/simulated/shuttle/floor/science{
-	icon_state = "6,7"
+/obj/machinery/camera/network/research_outpost{
+	dir = 1
 	},
-/area/shuttle/research/station)
-"elm" = (
-/turf/simulated/shuttle/wall/science{
-	icon_state = "7,7"
+/obj/structure/bed/chair/shuttle{
+	dir = 1
+	},
+/turf/simulated/shuttle/floor/science{
+	icon_state = "11,3"
 	},
 /area/shuttle/research/station)
 "eln" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/shuttle/floor/science{
-	icon_state = "8,7"
+	icon_state = "8,17"
 	},
 /area/shuttle/research/station)
 "elo" = (
-/turf/simulated/shuttle/wall/science{
-	icon_state = "9,7"
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/void/hazardsuit/moebius,
+/obj/item/weapon/storage/belt/archaeology,
+/obj/item/clothing/mask/breath,
+/turf/simulated/shuttle/floor/science{
+	icon_state = "11,3"
 	},
 /area/shuttle/research/station)
 "elp" = (
-/obj/machinery/light/small,
+/obj/structure/bed/chair/shuttle{
+	dir = 1
+	},
 /turf/simulated/shuttle/floor/science{
-	icon_state = "10,7"
+	icon_state = "11,3"
 	},
 /area/shuttle/research/station)
 "elq" = (
-/obj/structure/table/rack,
-/obj/item/weapon/storage/belt/archaeology,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/suit/space/void/hazardsuit,
-/obj/item/clothing/head/space/void/hazardhelmet,
+/obj/structure/closet/excavation,
 /turf/simulated/shuttle/floor/science{
 	icon_state = "11,7"
 	},
@@ -94284,27 +94389,34 @@
 	},
 /area/shuttle/research/station)
 "emt" = (
-/turf/simulated/shuttle/wall/science{
-	icon_state = "7,6"
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/area/shuttle/research/station)
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/eris/engineering/starboardhallway)
 "emu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/research_outpost{
-	dir = 8
-	},
-/obj/machinery/light/small{
-	dir = 8
+/obj/machinery/door/airlock/freezer{
+	name = "Vasiliy Dokuchaev Internal Airlock";
+	req_access = list(5)
 	},
 /turf/simulated/shuttle/floor/science{
 	icon_state = "8,6"
 	},
 /area/shuttle/research/station)
 "emv" = (
-/turf/simulated/shuttle/wall/science{
-	icon_state = "9,6"
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/area/shuttle/research/station)
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/turf/simulated/floor/tiled/steel/orangecorner,
+/area/eris/engineering/starboardhallway)
 "emw" = (
 /turf/simulated/shuttle/wall/science{
 	icon_state = "10,6"
@@ -94645,7 +94757,7 @@
 	amount = 25
 	},
 /turf/simulated/shuttle/floor/science{
-	icon_state = "4,5"
+	icon_state = "5,9"
 	},
 /area/shuttle/research/station)
 "enr" = (
@@ -94658,35 +94770,30 @@
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/camera/network/research_outpost,
 /turf/simulated/shuttle/floor/science{
-	icon_state = "6,5"
-	},
-/area/shuttle/research/station)
-"ent" = (
-/turf/simulated/shuttle/wall/science{
-	icon_state = "7,5"
+	icon_state = "5,5"
 	},
 /area/shuttle/research/station)
 "enu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/shuttle/floor/science{
-	icon_state = "8,5"
+	icon_state = "5,5"
 	},
 /area/shuttle/research/station)
 "env" = (
-/turf/simulated/shuttle/wall/science{
-	icon_state = "9,5"
+/turf/simulated/shuttle/floor/science{
+	icon_state = "5,5"
 	},
 /area/shuttle/research/station)
 "enw" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/shuttle/floor/science{
-	icon_state = "10,5"
+	icon_state = "5,5"
 	},
 /area/shuttle/research/station)
 "enx" = (
 /obj/machinery/suspension_gen,
 /turf/simulated/shuttle/floor/science{
-	icon_state = "11,5"
+	icon_state = "5,5"
 	},
 /area/shuttle/research/station)
 "eny" = (
@@ -94946,17 +95053,24 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor,
-/area/shuttle/research/station)
-"eod" = (
 /turf/simulated/shuttle/floor/science{
-	icon_state = "4,4"
+	icon_state = "5,9"
 	},
 /area/shuttle/research/station)
+"eod" = (
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/plating,
+/area/eris/engineering/gravity_generator)
 "eoe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/shuttle/floor/science{
-	icon_state = "5,4"
+	icon_state = "11,4"
 	},
 /area/shuttle/research/station)
 "eof" = (
@@ -94964,37 +95078,21 @@
 	dir = 8
 	},
 /turf/simulated/shuttle/floor/science{
-	icon_state = "6,4"
-	},
-/area/shuttle/research/station)
-"eog" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/door/airlock/freezer{
-	name = "Vasiliy Dokuchaev Internal Airlock";
-	req_access = list(5)
-	},
-/turf/simulated/shuttle/floor/science{
-	icon_state = "7,4"
+	icon_state = "11,4"
 	},
 /area/shuttle/research/station)
 "eoh" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /turf/simulated/shuttle/floor/science{
-	icon_state = "8,4"
+	icon_state = "11,4"
 	},
 /area/shuttle/research/station)
 "eoi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/freezer{
-	name = "Vasiliy Dokuchaev Internal Airlock";
-	req_access = list(5)
-	},
 /turf/simulated/shuttle/floor/science{
-	icon_state = "9,4"
+	icon_state = "11,4"
 	},
 /area/shuttle/research/station)
 "eoj" = (
@@ -95002,7 +95100,7 @@
 	dir = 8
 	},
 /turf/simulated/shuttle/floor/science{
-	icon_state = "10,4"
+	icon_state = "11,4"
 	},
 /area/shuttle/research/station)
 "eok" = (
@@ -95232,7 +95330,7 @@
 	dir = 8
 	},
 /turf/simulated/shuttle/floor/science{
-	icon_state = "3,3"
+	icon_state = "5,7"
 	},
 /area/shuttle/research/station)
 "eoP" = (
@@ -95242,7 +95340,7 @@
 	icon_state = "2-8"
 	},
 /turf/simulated/shuttle/floor/science{
-	icon_state = "4,3"
+	icon_state = "11,3"
 	},
 /area/shuttle/research/station)
 "eoQ" = (
@@ -95250,7 +95348,7 @@
 	dir = 5
 	},
 /turf/simulated/shuttle/floor/science{
-	icon_state = "5,3"
+	icon_state = "11,3"
 	},
 /area/shuttle/research/station)
 "eoR" = (
@@ -95262,29 +95360,18 @@
 	},
 /obj/machinery/telecomms/relay/preset/science,
 /turf/simulated/shuttle/floor/science{
-	icon_state = "6,3"
-	},
-/area/shuttle/research/station)
-"eoS" = (
-/turf/simulated/shuttle/wall/science{
-	icon_state = "7,3"
+	icon_state = "11,3"
 	},
 /area/shuttle/research/station)
 "eoT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/shuttle/floor/science{
-	icon_state = "8,3"
+	icon_state = "11,3"
 	},
 /area/shuttle/research/station)
 "eoU" = (
-/turf/simulated/shuttle/wall/science{
-	icon_state = "9,3"
-	},
-/area/shuttle/research/station)
-"eoV" = (
-/obj/machinery/floodlight,
 /turf/simulated/shuttle/floor/science{
-	icon_state = "10,3"
+	icon_state = "11,3"
 	},
 /area/shuttle/research/station)
 "eoW" = (
@@ -96960,13 +97047,13 @@
 	name = "Generator Room";
 	req_access = list(10)
 	},
-/obj/structure/cable/green{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/engineering/gravity_generator)
 "esI" = (
@@ -101158,11 +101245,6 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/gravity_generator)
 "eBD" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -101173,16 +101255,16 @@
 /area/eris/engineering/gravity_generator)
 "eBE" = (
 /obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/open,
 /area/eris/engineering/gravity_generator)
@@ -101191,28 +101273,28 @@
 	pixel_y = 32
 	},
 /obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/open,
 /area/eris/engineering/gravity_generator)
 "eBG" = (
 /obj/structure/catwalk,
-/obj/structure/cable/green{
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/open,
 /area/eris/engineering/gravity_generator)
 "eBH" = (
@@ -101477,11 +101559,6 @@
 /area/eris/engineering/propulsion/left)
 "eCo" = (
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -101495,11 +101572,6 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/gravity_generator)
 "eCp" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -101509,11 +101581,6 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/gravity_generator)
 "eCq" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -101528,10 +101595,11 @@
 /area/eris/engineering/gravity_generator)
 "eCs" = (
 /obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing{
 	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 32;
+	icon_state = "32-1"
 	},
 /turf/simulated/open,
 /area/eris/engineering/gravity_generator)
@@ -102438,11 +102506,11 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "eEE" = (
-/obj/structure/closet/secure_closet/reinforced/engineering_chief,
 /obj/spawner/pack/tech_loot/low_chance,
 /obj/spawner/pack/tech_loot/low_chance,
 /obj/effect/floor_decal/rust,
-/obj/item/weapon/hatton,
+/obj/structure/closet/secure_closet/personal/engineering_personal,
+/obj/spawner/pack/tech_loot/onestar,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/hallway/side/atmosphericshallway)
 "eEF" = (
@@ -102453,18 +102521,19 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/hallway/side/atmosphericshallway)
 "eEG" = (
-/obj/structure/closet/secure_closet/reinforced/engineering_chief,
-/obj/item/weapon/hatton,
-/obj/item/weapon/hatton_magazine,
-/obj/item/weapon/hatton_magazine,
-/obj/item/weapon/hatton_magazine,
+/obj/structure/closet/secure_closet/personal,
+/obj/item/weapon/rcd,
+/obj/item/weapon/rcd_ammo,
+/obj/item/weapon/rcd_ammo,
+/obj/item/weapon/rcd_ammo,
+/obj/item/weapon/rcd_ammo,
+/obj/item/weapon/rcd_ammo,
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/command/exultant)
 "eEH" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/clipboard,
 /obj/item/clothing/glasses/welding/superior,
-/obj/item/clothing/glasses/powered/meson,
 /obj/item/weapon/storage/fancy/cigarettes,
 /obj/item/weapon/book/manual/wiki/engineering_supermatter,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -102536,6 +102605,7 @@
 	},
 /obj/structure/closet/secure_closet/personal/engineering_personal,
 /obj/spawner/tool/advanced/low_chance,
+/obj/item/device/magnetic_lock/engineering,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/breakroom)
 "eEP" = (
@@ -102545,6 +102615,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/spawner/tool/advanced/low_chance,
+/obj/item/device/magnetic_lock/engineering,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/breakroom)
 "eEQ" = (
@@ -102565,6 +102636,7 @@
 /obj/structure/closet/secure_closet/personal/engineering_personal,
 /obj/structure/disposalpipe/segment,
 /obj/spawner/tool/advanced/low_chance,
+/obj/item/device/magnetic_lock/engineering,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/breakroom)
 "eET" = (
@@ -103533,6 +103605,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/shield_generator)
 "eQd" = (
@@ -104075,14 +104152,6 @@
 /obj/machinery/microwave,
 /turf/simulated/floor/wood,
 /area/eris/maintenance/section4deck4central)
-"gLU" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/dark/gray_perforated,
-/area/eris/command/bridge)
 "gMa" = (
 /obj/structure/bed/chair/sofa/teal/corner{
 	dir = 4
@@ -105749,10 +105818,6 @@
 /obj/spawner/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck4central)
-"mjm" = (
-/obj/structure/bed/chair/custom/onestar/red,
-/turf/simulated/wall/r_wall,
-/area/eris/maintenance/substation/section4)
 "mjD" = (
 /obj/machinery/holomap{
 	dir = 4;
@@ -106326,7 +106391,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/orangecorner,
+/turf/simulated/floor/tiled/dark,
 /area/eris/command/bridge)
 "nGz" = (
 /obj/structure/sink{
@@ -107123,7 +107188,7 @@
 /area/eris/crew_quarters/sleep/cryo)
 "qnY" = (
 /obj/structure/table/steel,
-/obj/item/weapon/storage/firstaid,
+/obj/item/weapon/storage/firstaid/regular,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "qok" = (
@@ -130545,7 +130610,7 @@ eoq
 adP
 aeq
 aeU
-abS
+cUl
 aaR
 aaa
 aaa
@@ -169404,7 +169469,7 @@ anJ
 yhx
 yhx
 anJ
-aae
+anJ
 aaa
 aaa
 bsY
@@ -170625,7 +170690,7 @@ bCU
 bEA
 bFH
 bFN
-mjm
+bFN
 aVZ
 bFN
 bFN
@@ -208795,7 +208860,7 @@ dRW
 dRW
 dOO
 dOO
-bVU
+anJ
 aaa
 aCM
 cDX
@@ -208997,7 +209062,7 @@ eto
 dOO
 dOO
 dOO
-bVU
+anJ
 aaa
 aCM
 aCM
@@ -211009,7 +211074,7 @@ dYc
 dyl
 ewk
 cwD
-dOd
+cWQ
 dOd
 dOd
 dHp
@@ -214067,11 +214132,11 @@ cRY
 cSE
 cTg
 cTG
-cUl
+dal
 cUH
 cVn
 cVQ
-cWQ
+dal
 cXE
 cYu
 cZc
@@ -249123,7 +249188,7 @@ ddN
 deh
 det
 deP
-dfl
+det
 dwG
 ddu
 cQi
@@ -250017,7 +250082,7 @@ bCs
 byY
 dKk
 dyT
-dpZ
+dKJ
 dyT
 dKk
 byY
@@ -251633,7 +251698,7 @@ abF
 dKa
 dxT
 dxX
-dxX
+emt
 dxX
 dDk
 dDH
@@ -251833,9 +251898,9 @@ aaa
 aaa
 abF
 dKa
-dxX
+dfl
 dyW
-dBs
+emv
 dCW
 dDl
 dDH
@@ -253651,11 +253716,11 @@ btI
 abF
 dLg
 dki
-dpa
-dpa
-dpa
-dpa
-dPk
+ejk
+ejm
+ejm
+ejm
+eod
 dPU
 dQu
 dLg
@@ -288908,7 +288973,7 @@ aad
 dUv
 dUv
 tIW
-cIn
+nEP
 dWi
 rgB
 dcW
@@ -289110,7 +289175,7 @@ dUv
 dUv
 cEQ
 cIC
-gLU
+nEP
 gGX
 oxr
 daA
@@ -289312,7 +289377,7 @@ dUv
 xjo
 dex
 cZG
-gLU
+nEP
 gGX
 dBh
 daA
@@ -289514,7 +289579,7 @@ dUv
 hVk
 cHf
 cZG
-gLU
+nEP
 dDL
 rsu
 daA
@@ -290322,7 +290387,7 @@ dUv
 ihp
 cHH
 dvw
-gLU
+nEP
 dVg
 sPB
 daA
@@ -290524,7 +290589,7 @@ dUv
 www
 deT
 dvw
-gLU
+nEP
 gGX
 dBB
 daA
@@ -290726,7 +290791,7 @@ dUv
 dUv
 dfp
 dvx
-gLU
+nEP
 rNT
 iVC
 daA
@@ -293849,7 +293914,7 @@ ddZ
 dKs
 dKs
 dLg
-eBE
+eBH
 eCr
 eCr
 eCr
@@ -298660,7 +298725,7 @@ ekB
 elj
 emq
 enq
-eod
+eok
 eoP
 epn
 epN
@@ -299260,14 +299325,14 @@ efK
 egA
 ehB
 eiC
-ejk
+egz
 ejX
-ekE
-elm
-emt
-ent
-eog
-eoS
+eoi
+eoU
+egz
+env
+eoi
+eoU
 epq
 epQ
 eql
@@ -299464,7 +299529,7 @@ ehC
 eiD
 ejl
 ejY
-ekF
+eoh
 eln
 emu
 enu
@@ -299664,11 +299729,11 @@ efM
 egC
 ehD
 eiE
-ejm
+egz
 ejZ
-ekG
+eoi
 elo
-emv
+egz
 env
 eoi
 eoU
@@ -299868,12 +299933,12 @@ ehE
 eiF
 ejn
 eka
-ekH
+eoj
 elp
 emw
 enw
 eoj
-eoV
+eoW
 ept
 epT
 eqo


### PR DESCRIPTION
## About The Pull Request

Multiple small tweaks to the map

- The Shield gen is now on the main powerline instead of the engineering subnet
- Added a machine frame in a location for adding a SMES to the shield generator for bored engineers
- Added seats and a break room the the hulk
- Made the Doku far less ugly and cramped
- Removed the two spare CE lockers
- Removed one of two CMO lockers
- Removed one of two CSO lockers
- Removed duplicate captain spare
- Removed duplicate FTU Merchant Spawn
- Fixed a bad shield tile in the lower club
- Tweaked the appearance of the bridge
- Moved the disk compartmentalizer in Aegisto a better location
- Moved a button in RnD out from under the disk compartmentalizer
- Removed the trade program disk from the lower floor of cargo
- Added a preset trade console to the lower floor of cargo
- Added a trade console to the cargo lobby
- Moved the rogue wall chair.

![image](https://user-images.githubusercontent.com/1775680/118586550-f8961800-b768-11eb-99a6-e6034eb7515a.png)
![image](https://user-images.githubusercontent.com/1775680/118586568-ffbd2600-b768-11eb-9448-879f46e9887d.png)
![image](https://user-images.githubusercontent.com/1775680/118586584-06e43400-b769-11eb-9c99-a349e662c898.png)


## Why It's Good For The Game

Map tweaks

## Changelog
```changelog
tweak: The Shield gen is now on the main powerline instead of the engineering subnet
tweak: Added a machine frame in a location for adding a SMES to the shield generator for bored engineers
add: Added seats and a break room the the hulk
tweak: Made the Doku far less ugly and cramped
del: Removed the two spare CE lockers
del: Removed one of two CMO lockers
del: Removed one of two CSO lockers
del: Removed duplicate captain spare
del: Removed duplicate FTU Merchant Spawn
fix: Fixed a bad shield tile in the lower club
tweak: Tweaked the appearance of the bridge
tweak: Moved the disk compartmentalizer in Aegisto a better location
tweak: Moved a button in RnD out from under the disk compartmentalizer
del: Removed the trade program disk from the lower floor of cargo
add: Added a preset trade console to the lower floor of cargo
add: Added a trade console to the cargo lobby
del: Moved the rogue wall chair.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
