### PR TITLE
Fixes antag spam

### DIFF
--- a/code/game/gamemodes/roleset/simple.dm
+++ b/code/game/gamemodes/roleset/simple.dm
@@ -34,7 +34,7 @@
 	name = "inquisitor"
 	role_id = ROLE_INQUISITOR
 	weight = 0.15
-	event_pools = list(EVENT_LEVEL_ROLESET = -30) //This is an antitag, it has a negative cost to allow more antags to exist
+//	event_pools = list(EVENT_LEVEL_ROLESET = -30) //This is an antitag, it has a negative cost to allow more antags to exist
 
 
 //Weighting is based on the total number of active antags and disciples.
@@ -92,7 +92,7 @@
 	role_id = ROLE_MARSHAL
 	weight = 0.2
 	req_crew = 10
-	event_pools = list(EVENT_LEVEL_ROLESET = -30) //This is an antitag, it has a negative cost to allow more antags to exist
+//	event_pools = list(EVENT_LEVEL_ROLESET = -30) //This is an antitag, it has a negative cost to allow more antags to exist
 
 /datum/storyevent/roleset/marshal/can_trigger(var/severity, var/report)
 	var/a_count = 0


### PR DESCRIPTION
## About The Pull Request

Removed special weighting for marshel and inquisitor, which was causing roleset to fire twice if it was successfully spawned and three times if it failed to spawn

This is because the storyvent/cancel() proc only takes into account the unmodified cost of an event. So partial and full failures to spawn inquisitors would first add 30 points to roleset (instead of subtracting 120. Bringing us to 150), and then adding another 60/120 if the inquis/marshal roleset failed or partially failed. Meaning we would get up to 3 rolesets for the time/price of one.

## Why It's Good For The Game

Found the cause of all the antags

## Changelog
```changelog
fix: Marshal and Inquisitor no longer forcibly spawn excessive amounts of other antagonists.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
