### PR TITLE
Adds club account access to club workers

### DIFF
--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -57,6 +57,7 @@
 		STAT_TGH = 10,
 		STAT_VIG = 5,
 	)
+	department_account_access = TRUE
 	outfit_type = /decl/hierarchy/outfit/job/service/waiter
 	description = "As a Club Worker, you work for the Club Manager. Your job is to fulfill your duties in running the Club and making sure all the customers are satisfied.<br>\
 	<br>\


### PR DESCRIPTION
## About The Pull Request

This change adds the club account to the club worker's memory on spawn. This allows club workers to use the EFTPOS and ATM.

## Why It's Good For The Game

As it stands, club workers are unable to do anything with the cash that the club makes beside putting it in the back room or carrying it. 

This also means that club workers are unable to use the EFTPOS machine unless:

1) there is a club manager present
2) they use their own personal account

Club already suffers from low population, and doesn't get any better for managers. Adding this will just be QoL change for workers.

## Changelog
```changelog
add: Added club worker access for club account
```