### PR TITLE
Fixes a missing " in the Space Ruins Hangar Door button. 

### DIFF
--- a/maps/encounters/spaceruins/spaceruins.dmm
+++ b/maps/encounters/spaceruins/spaceruins.dmm
@@ -1335,11 +1335,11 @@
 /area/asteroid/rogue)
 "SC" = (
 /obj/machinery/light/floor,
-/obj/machinery/button/remote{
-	desc = "The button that controls the hangar doors in the area. Do not press unless you can breathe vacuum, or you have oxygen..";
-	id = "HangarShutterSpaceRuin";
-	name = "Hangar Doors";
-	pixel_x = 27
+/obj/machinery/button/remote/blast_door{
+	desc = "A sticky note is attached: Do not press unless you can breathe vacuum.";
+	id = "OneStarHangar";
+	name = "Hangar Blast Doors";
+	pixel_x = 32
 	},
 /turf/simulated/floor/tiled/derelict/red_white_edges,
 /area/asteroid/rogue)
@@ -1513,7 +1513,7 @@
 "Xc" = (
 /obj/machinery/button/remote/blast_door{
 	desc = "A sticky note is attached: Do not press unless you can breathe vacuum.";
-	id = "OneStarHangar;
+	id = "OneStarHangar";
 	name = "Hangar Blast Doors";
 	pixel_y = 27
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a missing " on the interior door button of the Space Ruins hangar. Line 1516 in Spaceruins.dmm changed from "OneStarHangar to "OneStarHangar".

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

It can compile now, please ridicule me. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
fix: A missing ".
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
