### PR TITLE
Ports Signals from Upstream

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -53,6 +53,8 @@
 #define CONSIG_TURF_LEVELUPDATE "turf_levelupdate" //levelupdate()
 // /atom/movable signals
 #define COMSIG_MOVABLE_MOVED "movable_moved"					//from base of atom/movable/Moved(): (/atom, origin_loc, new_loc)
+#define COMSIG_MOVABLE_Z_CHANGED "movable_z_moved"				//from base of atom/movable/onTransitZ(): (oldz, newz)
+#define COMSIG_MOVABLE_PREMOVE "moveable_boutta_move"
 
 // /mob signals
 #define COMSIG_MOB_LIFE  "mob_life"                             //from mob/Life()
@@ -65,7 +67,10 @@
 #define COMSIG_CARBON_ELECTROCTE "carbon_electrocute act"       //mob/living/carbon/electrocute_act()
 
 // /mob/living/carbon/human signals
-#define COMSIG_HUMAN_SAY "human_say"                            //from mob/living/carbon/human/say(): (message)
+#define COMSIG_HUMAN_ACTIONINTENT_CHANGE "action_intent_change"
+#define COMSIG_HUMAN_WALKINTENT_CHANGE "walk_intent_change"
+#define COMSIG_EMPTY_POCKETS "human_empty_pockets"
+#define COMSIG_HUMAN_SAY "human_say"							//from mob/living/carbon/human/say(): (message)
 #define COMSIG_HUMAN_ROBOTIC_MODIFICATION "human_robotic_modification"
 #define COMSIG_STAT "current_stat"							   //current stat
 #define COMSIG_HUMAN_BREAKDOWN "human_breakdown"
@@ -87,19 +92,32 @@
 #define COMSIG_ATTACKBY "attack_by"										//from /mob/ClickOn():
 #define COMSIG_APPVAL "apply_values"									//from /atom/refresh_upgrades(): (/src) Called to upgrade specific values
 #define COMSIG_ADDVAL "add_values" 										//from /atom/refresh_upgrades(): (/src) Called to add specific things to the /src, called before COMSIG_APPVAL
-#define COMSIG_REMOVE "uninstall"										//from  /obj/item/weapon/tool/attackby(): Called to remove an upgrade
+#define COMSIG_REMOVE "uninstall"	
+#define COMSIG_ITEM_DROPPED	"item_dropped"					//from  /obj/item/weapon/tool/attackby(): Called to remove an upgrade
+#define COMSIG_ITEM_PICKED "item_picked"
+
 // /obj/item/clothing signals
+#define COMSIG_CLOTH_DROPPED "cloths_missing"
+#define COMSIG_CLOTH_EQUIPPED "cloths_recovered"
 
 // /obj/item/implant signals
 
 // /obj/item/pda signals
 
 // /obj/item/radio signals
+#define COMSIG_MESSAGE_SENT "radio_message_sent"
+#define COMSIG_MESSAGE_RECEIVED "radio_message_received"
 
 /*******Component Specific Signals*******/
 //Janitor
 
 // /datum/component/storage signals
+#define COMSIG_STORAGE_INSERTED "item_inserted"
+#define COMSIG_STORAGE_TAKEN "item_taken"
+#define COMSIG_STORAGE_OPENED "new_backpack_who_dis"
+
+// OVERMAP
+#define COMSIG_SHIP_STILL "ship_still" // /obj/effect/overmap/ship/Process() && is_still()
 
 /*******Non-Signal Component Related Defines*******/
 

--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -86,6 +86,11 @@
 #define COMSIG_OBJ_HIDE	"obj_hide"
 
 //machinery
+#define COMSIG_AREA_APC_OPERATING "area_operating"  //from apc process()
+#define COMSIG_AREA_APC_DELETED "area_apc_gone"
+#define COMSIG_AREA_APC_POWER_CHANGE "area_apc_power_change"
+#define COMSING_DESTRUCTIVE_ANALIZER "destructive_analizer"
+#define COMSIG_TURRENT "create_turrent"
 
 // /obj/item signals
 #define COMSIG_IATTACK "item_attack"									//from /mob/ClickOn(): (/atom, /src, /params) If any reply to this returns TRUE, overrides attackby and afterattack

--- a/code/_onclick/hud/screen_objects/base_screen_objects.dm
+++ b/code/_onclick/hud/screen_objects/base_screen_objects.dm
@@ -995,6 +995,7 @@ obj/screen/fire/DEADelize()
 /obj/screen/mov_intent/Click()
 	var/move_intent_type = next_list_item(usr.move_intent.type, usr.move_intents)
 	var/decl/move_intent/newintent = decls_repository.get_decl(move_intent_type)
+	SEND_SIGNAL(parentmob, COMSIG_HUMAN_WALKINTENT_CHANGE, parentmob, newintent)
 	if (newintent.can_enter(parentmob, TRUE))
 		parentmob.move_intent = newintent
 		update_icon()
@@ -1101,20 +1102,15 @@ obj/screen/fire/DEADelize()
 /obj/screen/intent/Click(location, control, params)
 	var/_x = text2num(params2list(params)["icon-x"])
 	var/_y = text2num(params2list(params)["icon-y"])
-
 	if(_x<=16 && _y<=16)
 		parentmob.a_intent_change(I_HURT)
-
-	else if(_x<=16 && _y>=17)
+	if(_x<=16 && _y>=17)
 		parentmob.a_intent_change(I_HELP)
-
-	else if(_x>=17 && _y<=16)
+	if(_x>=17 && _y<=16)
 		parentmob.a_intent_change(I_GRAB)
-
-	else if(_x>=17 && _y>=17)
+	if(_x>=17 && _y>=17)
 		parentmob.a_intent_change(I_DISARM)
-	else
-		return ..()
+	SEND_SIGNAL(parentmob, COMSIG_HUMAN_ACTIONINTENT_CHANGE, parentmob)
 
 /obj/screen/intent/on_update_icon()
 	src.cut_overlays()

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -205,6 +205,7 @@
 /area/proc/power_change()
 	for(var/obj/machinery/M in src)	// for each machine in the area
 		M.power_change()			// reverify power status (to update icons etc.)
+	SEND_SIGNAL(src, COMSIG_AREA_APC_POWER_CHANGE)
 	if (fire || eject || party)
 		updateicon()
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -336,6 +336,7 @@
 	// To prevent issues, diagonal movements are broken up into two cardinal movements.
 
 	// Is this a diagonal movement?
+	SEND_SIGNAL(src, COMSIG_MOVABLE_PREMOVE, src)
 	if (Dir & (Dir - 1))
 		if (Dir & NORTH)
 			if (Dir & EAST)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1098,15 +1098,15 @@ FIRE ALARM
 	if(stat & (NOPOWER|BROKEN))
 		return
 
-	if(src.timing)
-		if(src.time > 0)
-			src.time = src.time - ((world.timeofday - last_process)/10)
+	if(timing)
+		if(time > 0)
+			time -= (world.timeofday - last_process)/10
 		else
-			src.alarm()
-			src.time = 0
-			src.timing = 0
+			alarm()
+			time = 0
+			timing = 0
 			STOP_PROCESSING(SSmachines, src)
-		src.updateDialog()
+		updateDialog()
 	last_process = world.timeofday
 
 	if(locate(/obj/fire) in loc)
@@ -1333,4 +1333,3 @@ Just a object used in constructing fire alarms
 		var/tp = text2num(href_list["tp"])
 		time += tp
 		time = min(max(round(time), 0), 120)
-

--- a/code/game/machinery/telecomms/broadcaster.dm
+++ b/code/game/machinery/telecomms/broadcaster.dm
@@ -280,7 +280,7 @@ var/message_delay = 0 // To make sure restarting the recentmessages list is kept
 	var/list/heard_gibberish= list() // completely screwed over message (ie "F%! (O*# *#!<>&**%!")
 
 	for (var/mob/R in receive)
-
+		SEND_SIGNAL(radio, COMSIG_MESSAGE_RECEIVED, R)
 	  /* --- Loop through the receivers and categorize them --- */
 		if(isnewplayer(R)) // we don't want new players to hear messages. rare but generates runtimes.
 			continue

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -193,6 +193,7 @@
 /obj/item/proc/pickup(mob/target)
 	throwing = 0
 	var/atom/old_loc = loc
+	SEND_SIGNAL(src, COMSIG_ITEM_PICKED, src, target)
 	if(target.put_in_active_hand(src) && old_loc )
 		if((target != old_loc) && (target != old_loc.get_holding_mob()))
 			do_pickup_animation(target,old_loc)
@@ -230,11 +231,13 @@
 	return TRUE
 
 // called when this item is removed from a storage item, which is passed on as S. The loc variable is already set to the new destination before this is called.
-/obj/item/proc/on_exit_storage(obj/item/weapon/storage/S as obj)
+/obj/item/proc/on_exit_storage(obj/item/weapon/storage/the_storage)
+	SEND_SIGNAL(the_storage, COMSIG_STORAGE_TAKEN, src, the_storage)
 	return
 
 // called when this item is added into a storage item, which is passed on as S. The loc variable is already set to the storage item.
-/obj/item/proc/on_enter_storage(obj/item/weapon/storage/S as obj)
+/obj/item/proc/on_enter_storage(obj/item/weapon/storage/the_storage)
+	SEND_SIGNAL(the_storage, COMSIG_STORAGE_INSERTED, src, the_storage)
 	return
 
 // called when "found" in pockets and storage items. Returns 1 if the search should end.

--- a/code/game/objects/items/_inventory.dm
+++ b/code/game/objects/items/_inventory.dm
@@ -52,8 +52,6 @@
 			user.drop_from_inventory(equipped)
 			equipped.forceMove(src)
 
-
-
 /obj/item/proc/equipped(var/mob/user, var/slot)
 	equip_slot = slot
 	if(user.pulling == src)
@@ -66,8 +64,8 @@
 		user.r_hand.update_twohanding()
 	if(wielded)
 		unwield(user)
-
-
+	SEND_SIGNAL(user, COMSIG_CLOTH_EQUIPPED, src) // Theres instances in which its usefull to keep track of it both on the user and individually
+	SEND_SIGNAL(src, COMSIG_CLOTH_EQUIPPED)
 
 /obj/item/proc/dropped(mob/user)
 	if(zoom) //binoculars, scope, etc

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -9,7 +9,7 @@
 	canhear_range = 2
 	flags = CONDUCT | NOBLOODY
 	var/number = 0
-	var/last_tick //used to delay the powercheck
+	var/area/linked_area
 
 /obj/item/device/radio/intercom/custom
 	name = "station intercom (Custom)"
@@ -39,7 +39,7 @@
 
 /obj/item/device/radio/intercom/New()
 	..()
-	START_PROCESSING(SSobj, src)
+	loop_area_check()
 
 /obj/item/device/radio/intercom/department/medbay/New()
 	..()
@@ -63,10 +63,6 @@
 /obj/item/device/radio/intercom/syndicate/New()
 	..()
 	internal_channels[num2text(SYND_FREQ)] = list(access_syndicate)
-
-/obj/item/device/radio/intercom/Destroy()
-	STOP_PROCESSING(SSobj, src)
-	. = ..()
 
 /obj/item/device/radio/intercom/attack_ai(mob/user as mob)
 	src.add_fingerprint(user)
@@ -93,23 +89,26 @@
 
 	return canhear_range
 
-/obj/item/device/radio/intercom/Process()
-	if(((world.timeofday - last_tick) > 30) || ((world.timeofday - last_tick) < 0))
-		last_tick = world.timeofday
+/obj/item/device/radio/intercom/proc/change_status()
+	on = linked_area.powered(EQUIP)
+	icon_state = on ? "intercom" : "intercom-p"
 
-		if(!src.loc)
-			on = FALSE
-		else
-			var/area/A = get_area(src)
-			if(!A)
-				on = FALSE
-			else
-				on = A.powered(EQUIP) // set "on" to the power status
+/obj/item/device/radio/intercom/proc/loop_area_check()
+	var/area/target_area = get_area(src)
+	if(!target_area?.apc)
+		addtimer(CALLBACK(src, .proc/loop_area_check), 30 SECONDS) // We don't proces if there is no APC , no point in doing so is there ?
+		return FALSE
+	linked_area = target_area
+	RegisterSignal(target_area, COMSIG_AREA_APC_DELETED, .proc/on_apc_removal)
+	RegisterSignal(target_area, COMSIG_AREA_APC_POWER_CHANGE, .proc/change_status)
 
-		if(!on)
-			icon_state = "intercom-p"
-		else
-			icon_state = "intercom"
+/obj/item/device/radio/intercom/proc/on_apc_removal()
+	UnregisterSignal(linked_area , COMSIG_AREA_APC_DELETED)
+	UnregisterSignal(linked_area, COMSIG_AREA_APC_POWER_CHANGE)
+	linked_area = null
+	on = FALSE
+	icon_state = "intercom-p"
+	addtimer(CALLBACK(src, .proc/loop_area_check), 30 SECONDS)
 
 /obj/item/device/radio/intercom/broadcasting
 	broadcasting = 1

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -365,6 +365,7 @@ var/global/list/default_medbay_channels = list(
 		displayname = M.GetVoice()
 		jobname = "Unknown"
 		voicemask = 1
+	SEND_SIGNAL(src, COMSIG_MESSAGE_SENT)
 
 
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -241,6 +241,8 @@
 		generateHUD(data).show(user.client)
 		is_seeing |= user
 		user.s_active = src
+	SEND_SIGNAL(src, COMSIG_STORAGE_OPENED, user)
+	SEND_SIGNAL(user, COMSIG_STORAGE_OPENED, src)
 
 /obj/item/weapon/storage/proc/hide_from(mob/user)
 	is_seeing -= user

--- a/code/modules/lighting/lighting_atom.dm
+++ b/code/modules/lighting/lighting_atom.dm
@@ -129,4 +129,5 @@
 
 /obj/item/dropped()
 	. = ..()
+	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED, src)
 	update_light()

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -128,6 +128,8 @@
 /mob/proc/unEquip(obj/item/I, var/atom/Target = null, force = 0) //Force overrides NODROP for things like wizarditis and admin undress.
 	if(!canUnEquip(I))
 		return
+	SEND_SIGNAL(src, COMSIG_CLOTH_DROPPED, I)
+	SEND_SIGNAL(I, COMSIG_CLOTH_DROPPED, src)
 	return drop_from_inventory(I,Target)
 
 //Attemps to remove an object on a mob.

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -129,7 +129,8 @@
 	if(!canUnEquip(I))
 		return
 	SEND_SIGNAL(src, COMSIG_CLOTH_DROPPED, I)
-	SEND_SIGNAL(I, COMSIG_CLOTH_DROPPED, src)
+	if(I)
+		SEND_SIGNAL(I, COMSIG_CLOTH_DROPPED, src)
 	return drop_from_inventory(I,Target)
 
 //Attemps to remove an object on a mob.

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -188,6 +188,7 @@
 /obj/machinery/power/apc/Destroy()
 	update()
 	area.apc = null
+	SEND_SIGNAL(area, COMSIG_AREA_APC_DELETED)
 	area.power_light = 0
 	area.power_equip = 0
 	area.power_environ = 0


### PR DESCRIPTION
## About The Pull Request

#6185, #6202 and #6097 have been ported from upstream. These PRs mostly feature component signals which a allow various bits of code to interact with each other seamlessly, without spaghetti code and without excessive use of process(). So far not much actually makes use of it aside from intercoms. Once we get the shield PRs, (handheld) shields will make use of it as well.

Compiles, no related runtimes were discovered as a test server was ran.

## Why It's Good For The Game

Less spaghetti, less process(), better code, better performance.

## Changelog
```changelog CEV-Eris Contributors
code: Introduced component signals for many bits of code
refactor: Intercoms do not process() anymore, instead making use of comsigs.
```
