### PR TITLE
Defaults hypospray to not use reagent scan

### DIFF
--- a/zzzz_modular_occulus/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/zzzz_modular_occulus/code/modules/reagents/reagent_containers/hypospray.dm
@@ -49,7 +49,7 @@
 	var/inject_self = SELF_INJECT
 	var/quickload = FALSE
 	var/penetrates = FALSE
-	var/mode = 0
+	var/mode = 1
 	var/window_width = 400
 	var/window_height = 200
 	var/scan_title
@@ -120,10 +120,10 @@
 
 	mode = !mode
 	switch (mode)
-		if(0)
+		if(1)
 			to_chat(usr, "You open up the [src]'s data tab")
 			update_icon()
-		if(1)
+		if(0)
 			to_chat(usr, "You close the [src]'s data tab")
 			update_icon()
 

--- a/zzzz_modular_occulus/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/zzzz_modular_occulus/code/modules/reagents/reagent_containers/hypospray.dm
@@ -120,10 +120,10 @@
 
 	mode = !mode
 	switch (mode)
-		if(1)
+		if(0)
 			to_chat(usr, "You open up the [src]'s data tab")
 			update_icon()
-		if(0)
+		if(1)
 			to_chat(usr, "You close the [src]'s data tab")
 			update_icon()
 


### PR DESCRIPTION
Defaults the hypospray to not use the reagent scanner. Still able to flip it on with a right click toggle at any time.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The sudden popup is jarring if you just want to inject reagents.
The reagent scan is semi situational, so having it start as toggled off makes more sense.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Better gameplay flow predominantly.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
tweak: made hypos just start with the scan off.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
