### PR TITLE
Fixes the multieye bug, makes rejuv work properly

### DIFF
--- a/code/datums/setup_option/core_implants.dm
+++ b/code/datums/setup_option/core_implants.dm
@@ -10,15 +10,14 @@
 	allow_modifications = TRUE
 
 /datum/category_item/setup_option/core_implant/cruciform/apply(mob/living/carbon/human/character)
-	if(character.mind.assigned_role != "Robot")	// OCCULUS EDIT - Check if they're a cyborg before doing it
-		var/obj/item/weapon/implant/core_implant/cruciform/C = new implant_type
-		C.install(character)
-		C.activate()
-		C.install_default_modules_by_job(character.mind.assigned_job)
-		C.access.Add(character.mind.assigned_job.cruciform_access)
-		spawn(1)
-			var/datum/core_module/cruciform/cloning/R = C.get_module(CRUCIFORM_CLONING)
-			R.ckey = character.ckey
+	var/obj/item/weapon/implant/core_implant/cruciform/C = new implant_type
+	C.install(character)
+	C.activate()
+	C.install_default_modules_by_job(character.mind.assigned_job)
+	C.access.Add(character.mind.assigned_job.cruciform_access)
+	spawn(1)
+		var/datum/core_module/cruciform/cloning/R = C.get_module(CRUCIFORM_CLONING)
+		R.ckey = character.ckey
 
 /datum/category_item/setup_option/core_implant/soulcrypt
 	name = "Soulcrypt"	//Syzygy edit - lazarus doesn't exist
@@ -30,5 +29,4 @@
 	allow_modifications = TRUE
 
 /datum/category_item/setup_option/core_implant/soulcrypt/apply(mob/living/carbon/human/character)
-	if(character.mind.assigned_role != "Robot")	// OCCULUS EDIT - Check if they're a cyborg before doing it
-		character.create_soulcrypt()
+	character.create_soulcrypt()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1190,24 +1190,28 @@ var/list/rank_prefix = list(\
 		for(var/obj/item/organ/internal/carrion/C in internal_organs)
 			C.removed_mob()
 			organs_to_readd += C
-/*	OCCULUS EDIT - Remove now redundant core implant spawning bits, these are now handled in core_implants.dm with the apply proc
-	var/obj/item/weapon/implant/core_implant/CI = get_core_implant()
-	var/checkprefcruciform = FALSE	// To reset the cruciform to original form
+
+/////////////////////////////////////////////////////////////////////////////////////////
+// OCCULUS EDIT START - Spaghetti to make rejuv less crap, and also fix the weird eye bug
+	var/obj/item/weapon/implant/core_implant/CI = get_core_implant(null, FALSE)
+	var/checkprefcruciform = FALSE	// To reset the cruciform to original form //wtf does this even mean???
 	if(CI)
 		checkprefcruciform = TRUE
-		qdel(CI)
-*/
+		qdel(CI)	//so this qdel isn't working for whatever reason!
+
+// OCCULUS EDIT START - Spaghetti to make rejuv less crap, and also fix the weird eye bug
 	for(var/obj/item/organ/organ in (organs|internal_organs))//Occulus Edit - Moving this out so the cloner stops breaking
 		qdel(organ)//Occulus Edit
+	if(organs.len)
+		organs.Cut()
+	if(internal_organs.len)
+		internal_organs.Cut()
+	if(organs_by_name.len)
+		organs_by_name.Cut()
+	if(internal_organs_by_efficiency.len)
+		internal_organs_by_efficiency.Cut()
 
 	if(from_preference)
-
-		if(organs.len)
-			organs.Cut()
-		if(internal_organs.len)
-			internal_organs.Cut()
-		if(organs_by_name.len)
-			organs_by_name.Cut()
 		var/datum/preferences/Pref
 		if(istype(from_preference, /datum/preferences))
 			Pref = from_preference
@@ -1236,15 +1240,12 @@ var/list/rank_prefix = list(\
 			else
 				var/organ_type = species.has_process[tag]
 				new organ_type(src)
-/*	OCCULUS EDIT - Remove now redundant core implant spawning bits, these are now handled in core_implants.dm with the apply proc
+
+//	OCCULUS EDIT START - Spaghetti to fix spaghetti
 		var/datum/category_item/setup_option/core_implant/I = Pref.get_option("Core implant")
-		if(I.implant_type && (!mind || mind.assigned_role != "Robot"))
-			var/obj/item/weapon/implant/core_implant/C = new I.implant_type
-			C.install(src)
-			C.activate()
-			if(mind)
-				C.install_default_modules_by_job(mind.assigned_job)
-				C.access.Add(mind.assigned_job.cruciform_access)	*/
+		if(I)
+			I.apply(src)
+//	OCCULUS EDIT END
 	else
 		var/organ_type
 
@@ -1261,16 +1262,14 @@ var/list/rank_prefix = list(\
 			if(I && I.type == organ_type)
 				continue
 			new organ_type(src)
-/*	OCCULUS EDIT - Remove now redundant core implant spawning bits, these are now handled in core_implants.dm with the apply proc
+
+//	OCCULUS EDIT START - Spaghetti to fix spaghetti
 		if(checkprefcruciform)
 			var/datum/category_item/setup_option/core_implant/I = client.prefs.get_option("Core implant")
-			if(I.implant_type)
-				var/obj/item/weapon/implant/core_implant/C = new I.implant_type
-				C.install(src)
-				C.activate()
-				C.install_default_modules_by_job(mind.assigned_job)
-				C.access.Add(mind.assigned_job.cruciform_access)
-*/
+			if(I)
+				I.apply(src)
+//	OCCULUS EDIT END
+
 	for(var/obj/item/organ/internal/carrion/C in organs_to_readd)
 		C.replaced(get_organ(C.parent_organ_base))
 
@@ -1279,13 +1278,15 @@ var/list/rank_prefix = list(\
 
 	update_body()
 
-/mob/living/carbon/human/proc/post_prefinit()
+/mob/living/carbon/human/proc/post_prefinit()	//OCCULUS EDIT - This proc is completely redundant.
+	return
+	/*
 	var/obj/item/weapon/implant/core_implant/C = locate() in src
 	if(C)
 		C.install(src)
 		C.activate()
 		C.install_default_modules_by_job(mind.assigned_job)
-		C.access |= mind.assigned_job.cruciform_access
+		C.access |= mind.assigned_job.cruciform_access*/
 
 /mob/living/carbon/human/proc/bloody_doodle()
 	set category = "IC"

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1198,6 +1198,19 @@
 /mob/living/carbon/human/rejuvenate()
 	sanity.setLevel(sanity.max_level)
 	restore_blood()
+//OCCULUS EDIT - Resets bodymarkings when we rejuv
+	for(var/N in organs_by_name)
+		var/obj/item/organ/external/O = organs_by_name[N]
+		O.markings.Cut()
+
+	for(var/M in client.prefs.body_markings)
+		var/datum/sprite_accessory/marking/mark_datum = body_marking_styles_list[M]
+		var/mark_color = "[body_markings[M]]"
+
+		for(var/BP in mark_datum.body_parts)
+			var/obj/item/organ/external/O = organs_by_name[BP]
+			if(O)
+				O.markings[M] = list("color" = mark_color, "datum" = mark_datum)
 	..()
 
 /mob/living/carbon/human/handle_vision()


### PR DESCRIPTION
## About The Pull Request
After half a year, I have finally figured out how to make people stop spawning with 3 sets of eyes, one of which becomes a null reference a minute and a half after spawning, thus causing mysterious bouts of blindness.

I have also made rejuv not eject core implants (the upstream fix was not quite compatible with the way we did things), but it may occasionally still vomit out a duplicate implant for reasons unknown. Rejuv also does not wipe body markings anymore.

## Why It's Good For The Game

bugfixes good
bugs bad

## Changelog
```changelog Toriate
fix: players should no longer spawn with 3 sets of buggy eyes
fix: rejuv should work without ruining characters now
```
