### PR TITLE
Fixes duplicate core implants and miscellaneous runtimes

### DIFF
--- a/code/datums/setup_option/core_implants.dm
+++ b/code/datums/setup_option/core_implants.dm
@@ -10,14 +10,16 @@
 	allow_modifications = TRUE
 
 /datum/category_item/setup_option/core_implant/cruciform/apply(mob/living/carbon/human/character)
-	var/obj/item/weapon/implant/core_implant/cruciform/C = new implant_type
-	C.install(character)
-	C.activate()
-	C.install_default_modules_by_job(character.mind.assigned_job)
-	C.access.Add(character.mind.assigned_job.cruciform_access)
-	spawn(1)
-		var/datum/core_module/cruciform/cloning/R = C.get_module(CRUCIFORM_CLONING)
-		R.ckey = character.ckey
+	if(!character.get_core_implant(null, FALSE))
+		var/obj/item/weapon/implant/core_implant/cruciform/C = new implant_type
+		C.install(character)
+		C.activate()
+		if(character.mind.assigned_job)
+			C.install_default_modules_by_job(character.mind.assigned_job)
+			C.access.Add(character.mind.assigned_job.cruciform_access)
+		spawn(1)
+			var/datum/core_module/cruciform/cloning/R = C.get_module(CRUCIFORM_CLONING)
+			R.ckey = character.ckey
 
 /datum/category_item/setup_option/core_implant/soulcrypt
 	name = "Soulcrypt"	//Syzygy edit - lazarus doesn't exist
@@ -29,4 +31,5 @@
 	allow_modifications = TRUE
 
 /datum/category_item/setup_option/core_implant/soulcrypt/apply(mob/living/carbon/human/character)
-	character.create_soulcrypt()
+	if(!character.get_core_implant(null, FALSE))
+		character.create_soulcrypt()

--- a/code/modules/soulcrypt/base_implant.dm
+++ b/code/modules/soulcrypt/base_implant.dm
@@ -111,9 +111,10 @@ The module base code is held in module.dm
 
 		if(!hacked_snatcher)
 			for(var/mob/M in GLOB.player_list) //If they've respawned, we don't want to yoink them out of their current body.
-				if(M.ckey == host_mind.key)
-					if(M.stat != DEAD)
-						return
+				if(host_mind)	// Extra check since this is runtiming on mannequins.
+					if(M.ckey == host_mind.key)
+						if(M.stat != DEAD)
+							return
 
 		host_mind.transfer_to(wearer)
 		wearer.ckey = host_mind.key


### PR DESCRIPTION
## About The Pull Request

Now the related procs check if you have an existing core implant before trying to install a second one. Also added checks that should prevent pointless code from running on mannequins and runtiming.

## Why It's Good For The Game

bugfix

## Changelog
```changelog Toriate
fix: players should no longer spawn with duplicate core implants
```
