### PR TITLE
Rubberizes Rubber Bullets

### DIFF
--- a/zzzz_modular_occulus/code/modules/projectiles/projectile/bullettypes.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/projectile/bullettypes.dm
@@ -20,3 +20,14 @@
 	silenced = 1 //embedding messages are still produced so it's kind of weird when enabled.
 	no_attack_log = 1
 	muzzle_type = null
+
+//Rubberizing rubber rounds
+
+/obj/item/projectile/bullet/srifle/rubber
+	penetrating = 0
+
+/obj/item/projectile/bullet/clrifle/rubber
+	penetrating = 0
+
+/obj/item/projectile/bullet/lrifle/rubber
+	penetrating = 0


### PR DESCRIPTION
## About The Pull Request

Removes rubber bullet's ability to overpen targets on .20, .25 caseless and .30 (The only rubber rounds that overpens). They're rubbers, not HV/Lethal rounds

I've tested and this seems to fix the overpenning while being modular and without fucking gun damage values

## Why It's Good For The Game

I hate accidentally shooting friends because i'm using rubbers that aren't rubbery enough

## Changelog
```changelog
balance: Gives caseless 25, .20 and .30 rubber rounds a "Penetrating = 0" variable
```


