### PR TITLE
Fixes duplicate core implants without rebreaking everything

### DIFF
--- a/code/datums/setup_option/core_implants.dm
+++ b/code/datums/setup_option/core_implants.dm
@@ -10,16 +10,15 @@
 	allow_modifications = TRUE
 
 /datum/category_item/setup_option/core_implant/cruciform/apply(mob/living/carbon/human/character)
-	if(!character.get_core_implant(null, FALSE))
-		var/obj/item/weapon/implant/core_implant/cruciform/C = new implant_type
-		C.install(character)
-		C.activate()
-		if(character.mind.assigned_job)
-			C.install_default_modules_by_job(character.mind.assigned_job)
-			C.access.Add(character.mind.assigned_job.cruciform_access)
-		spawn(1)
-			var/datum/core_module/cruciform/cloning/R = C.get_module(CRUCIFORM_CLONING)
-			R.ckey = character.ckey
+	var/obj/item/weapon/implant/core_implant/cruciform/C = new implant_type
+	C.install(character)
+	C.activate()
+	if(character.mind.assigned_job)
+		C.install_default_modules_by_job(character.mind.assigned_job)
+		C.access.Add(character.mind.assigned_job.cruciform_access)
+	spawn(1)
+		var/datum/core_module/cruciform/cloning/R = C.get_module(CRUCIFORM_CLONING)
+		R.ckey = character.ckey
 
 /datum/category_item/setup_option/core_implant/soulcrypt
 	name = "Soulcrypt"	//Syzygy edit - lazarus doesn't exist
@@ -31,5 +30,4 @@
 	allow_modifications = TRUE
 
 /datum/category_item/setup_option/core_implant/soulcrypt/apply(mob/living/carbon/human/character)
-	if(!character.get_core_implant(null, FALSE))
-		character.create_soulcrypt()
+	character.create_soulcrypt()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -877,6 +877,12 @@ var/list/rank_prefix = list(\
 	// This will ignore any prosthetics in the prefs currently.
 	rebuild_organs()
 
+// OCCULUS EDIT START - Reinstall our core implant if we had one, because rebuild_organs() has that bit of code gutted from it
+	var/datum/category_item/setup_option/core_implant/I = client.prefs.get_option("Core implant")
+	if(I)
+		I.apply(src)
+// OCCULUS EDIT END
+
 	if(!client || !key) //Don't boot out anyone already in the mob.
 		for(var/obj/item/organ/internal/brain/H in world)
 			if(H.brainmob)
@@ -1194,10 +1200,10 @@ var/list/rank_prefix = list(\
 /////////////////////////////////////////////////////////////////////////////////////////
 // OCCULUS EDIT START - Spaghetti to make rejuv less crap, and also fix the weird eye bug
 	var/obj/item/weapon/implant/core_implant/CI = get_core_implant(null, FALSE)
-	var/checkprefcruciform = FALSE	// To reset the cruciform to original form //wtf does this even mean???
+	//var/checkprefcruciform = FALSE	// To reset the cruciform to original form //wtf does this even mean???
 	if(CI)
-		checkprefcruciform = TRUE
-		qdel(CI)	//so this qdel isn't working for whatever reason!
+		//checkprefcruciform = TRUE
+		qdel(CI)
 
 // OCCULUS EDIT START - Spaghetti to make rejuv less crap, and also fix the weird eye bug
 	for(var/obj/item/organ/organ in (organs|internal_organs))//Occulus Edit - Moving this out so the cloner stops breaking
@@ -1240,12 +1246,13 @@ var/list/rank_prefix = list(\
 			else
 				var/organ_type = species.has_process[tag]
 				new organ_type(src)
-
+/* haha this spaghetti just made things 100x worse
 //	OCCULUS EDIT START - Spaghetti to fix spaghetti
 		var/datum/category_item/setup_option/core_implant/I = Pref.get_option("Core implant")
 		if(I)
 			I.apply(src)
 //	OCCULUS EDIT END
+*/
 	else
 		var/organ_type
 
@@ -1262,14 +1269,14 @@ var/list/rank_prefix = list(\
 			if(I && I.type == organ_type)
 				continue
 			new organ_type(src)
-
+/* guess this isn't working out after all
 //	OCCULUS EDIT START - Spaghetti to fix spaghetti
 		if(checkprefcruciform)
 			var/datum/category_item/setup_option/core_implant/I = client.prefs.get_option("Core implant")
 			if(I)
 				I.apply(src)
 //	OCCULUS EDIT END
-
+*/
 	for(var/obj/item/organ/internal/carrion/C in organs_to_readd)
 		C.replaced(get_organ(C.parent_organ_base))
 


### PR DESCRIPTION
## About The Pull Request

Now all redundant procs have been moved into where they ought to be, and useless checks have been removed. This fix has been tested and confirmed to work.

## Why It's Good For The Game
so you guys can stop hounding my ass about this

## Changelog
```changelog
fix: players no longer spawn with duplicate core implants.
```
