### PR TITLE
Fixes the SC updater eating IDs, fixes holochip init

### DIFF
--- a/code/modules/soulcrypt/access_update_tool.dm
+++ b/code/modules/soulcrypt/access_update_tool.dm
@@ -13,6 +13,10 @@
 
 
 /obj/item/weapon/access_update_tool/attackby(obj/item/I, mob/user as mob)
+	if(card)	//haha it was deleting pre-existing IDs if you try to insert one while there was one in it
+		to_chat(user, SPAN_WARNING("There's already an ID in the card port!"))
+		return
+
 	if(istype(I, /obj/item/weapon/card/id))
 		to_chat(user, SPAN_NOTICE("You slot the [I] into [src]'s ID card port."))
 		user.drop_item()

--- a/code/modules/soulcrypt/holochip.dm
+++ b/code/modules/soulcrypt/holochip.dm
@@ -26,6 +26,7 @@
 
 /obj/item/weapon/holochip/Initialize()
 	update_icon()
+	..()	//This is needed so that INITIALIZE_HINT_NORMAL is returned and it doesn't mess up initialization. Or so I hope.
 
 /obj/item/weapon/holochip/afterattack(atom/A, mob/user)
 	if(used)


### PR DESCRIPTION
## About The Pull Request
The Soulcrypt Access Updater would delete an inserted ID if you tried to insert a new ID in without taking out the old one. It will now prevent that and notify the user that there is already a card within.

Holochips have also had their init proc callback to the parent, which should fix the atom initialization oddities we've been experiencing. Keyword is should. It did not fix it on my test server.

## Why It's Good For The Game

Less bugs!

## Changelog
```changelog
fix: SC Access Updater should no longer delete inserted IDs when you insert another one in
```
