### PR TITLE
New command stashes

### DIFF
--- a/code/modules/stashes/stash_types/captain.dm
+++ b/code/modules/stashes/stash_types/captain.dm
@@ -33,7 +33,7 @@
 	/obj/item/clothing/suit/storage/greatcoat = 15)
 	weight = 0.2
 
-
+/* Occulus edit
 /datum/stash/command/kismet
 	contents_list_external = list(/obj/item/remains/human = 1)
 	lore = "A hundred thousand credits of education fallen to a ten cent rubber bullet to the temple.<br>\
@@ -91,3 +91,4 @@ Remember this spot when the anesthetic wears off<br>\
  %D;<br>\
  <br>\
  don't go stumbling around for a week like last time. "
+ */

--- a/zzzz_modular_occulus/code/modules/stashes/stashes.dm
+++ b/zzzz_modular_occulus/code/modules/stashes/stashes.dm
@@ -10,17 +10,17 @@
 	/obj/item/weapon/implanter = 1)
 	lore = "The colony is safe, but C.T. says we should not go back. We are stuck on the Eridian Light.<br>\
  Our split of the payment is at %D.<br>\
- We do not know what sector the BSD will send us. <br>\
+ We do not know what sector the BSD will send us to. <br>\
  It took some convincing, but we got some extra holochips as part of the deal. <br>\
  Do not worry about having the right hardware for them. That is taken care of.<br>\
- Keep it from the cultists."
+ Keep it safe from the cultists."
 
 /datum/stash/junk/clowning
 	contents_list_extra = list(/obj/item/clothing/under/rank/clown = 1,
 	/obj/item/clothing/shoes/clown_shoes = 1,
 	/obj/item/weapon/bananapeel = 8,
 	/obj/item/clothing/mask/gas/clown_hat = 1)
-	lore = "Killed taht tee-totaling bastard good, we did.<br>\
+	lore = "Killed that tee-totaling bastard good, we did.<br>\
 	<br>\
 	Teach him to cut the rum ration. Like how rowdy we were now ya screaming pig?<br>\
 	<br>\
@@ -59,7 +59,7 @@
 	lore = "Adrian. This should help keep that new bitch of a CE over at EES off your ass. <br>\
 	I do not know of a single engineer who can resist these things. It is like catnip to them...<br>\
 	...no offense intended.<br>\
-	Anyway the goods are at %D."
+	Anyway, the goods are at %D."
 
 /datum/stash/junk/music
 	contents_list_extra = list(/obj/item/device/synthesized_instrument/guitar = 1,
@@ -93,7 +93,7 @@
 	Is the tale of Jayme Dawson and his crew <br>\
 	Yes, the tale of Dawson's Christian and her crew.<br>\
 	<br>\
-	%D"
+	I remember this song from my old crew. Hope this helps me remember them. %D"
 
 
 /datum/stash/valueable/pirate/song2
@@ -118,7 +118,7 @@
 	Never fearing guns or numbers, like a tiger to its meat <br>\
 	The stranger then attacked the pirate fleet. <br>\
 	<br>\
-	%D"
+	Where's this song from? I'll look into it when this stuff is safe. %D"
 
 
 /datum/stash/valueable/pirate/song3
@@ -150,28 +150,214 @@
 	Is the tale of Jayme Dawson and his crew <br>\
 	Yes, the tale of Dawson's Christian and her crew. <br>\
 	<br>\
-	%D"
+	Why do I remember this ship? Did it ever exist? I'll hide this stuff while I look for an answer. %D"
 
-/datum/stash/command
+/datum/stash/command/capstash //Regular captain stash minus the headset
+	lore = "Who's the king now? Huh? God, for all the armor and security and high-and-mightiness, fucker went down to a single bullet.<br>\
+			Turns out they're not so invincible after all. I'm know I'm not, and his shit won't help me with it. <br>\
+			I'll stick it here, %D, come back to it later when Aegis isn't so far up my ass they can see out my mouth."
 	contents_list_random = list(/obj/item/clothing/head/space/capspace = 70,
-	/obj/item/clothing/suit/space/void/captain = 70,
-	/obj/item/weapon/tank/jetpack/oxygen = 55,
-	/obj/item/weapon/tool/chainofcommand = 65,
-	/obj/item/weapon/reagent_containers/food/drinks/flask = 50,
-	/obj/item/weapon/gun/energy/captain = 65,
-	/obj/item/weapon/card/id/captains_spare = 10,
-	/obj/item/clothing/under/captainformal = 65,
-	/obj/item/clothing/head/caphat/formal = 65,
-	/obj/item/device/radio/headset/heads/captain = 40,
-	/obj/item/weapon/bedsheet/captain = 30,
-	/obj/item/weapon/storage/backpack/satchel/captain = 40,
-	/obj/item/clothing/mask/smokable/cigarette/cigar/havana = 15,
-	/obj/item/modular_computer/tablet/lease/preset/command = 25,
-	/obj/item/weapon/stamp/captain = 35,
-	/obj/item/weapon/disk/nuclear = 15,
-	/obj/item/weapon/hand_tele = 25,
-	/obj/item/weapon/reagent_containers/hypospray = 15,
-	/obj/item/weapon/hatton = 15,
-	/obj/item/weapon/rcd = 15,
-	/obj/item/weapon/melee/telebaton = 15,
-	/obj/item/clothing/suit/storage/greatcoat = 15)
+		/obj/item/clothing/suit/space/void/captain = 70,
+		/obj/item/weapon/tank/jetpack/oxygen = 55,
+		/obj/item/weapon/tool/chainofcommand = 65,
+		/obj/item/weapon/reagent_containers/food/drinks/flask = 50,
+		/obj/item/weapon/gun/energy/captain = 65,
+		/obj/item/weapon/card/id/captains_spare = 10,
+		/obj/item/clothing/under/captainformal = 65,
+		/obj/item/clothing/head/caphat/formal = 65,
+		/obj/item/weapon/bedsheet/captain = 30,
+		/obj/item/weapon/storage/backpack/satchel/captain = 40,
+		/obj/item/clothing/mask/smokable/cigarette/cigar/havana = 15,
+		/obj/item/modular_computer/tablet/lease/preset/command = 25,
+		/obj/item/weapon/stamp/captain = 35,
+		/obj/item/weapon/disk/nuclear = 15,
+		/obj/item/weapon/melee/telebaton = 15,
+		/obj/item/clothing/suit/storage/greatcoat = 15)
+
+/datum/stash/command/CMOstash //This is the CMO stash.
+	lore = "Not so smart now are ya? So much for knowing everything about chemistry, got him with a water and potassium bomb. <br>\
+			Once the fire dies down and I can get Aegis off my back I'll come back for his stuff. Gotta get some acid for the body. <br>\
+			Stashed it at %D."
+	contents_list_external = list(/obj/effect/decal/cleanable/ash =1)
+	contents_list_base = list(/obj/item/clothing/under/rank/moebius_biolab_officer = 1,
+		/obj/item/clothing/suit/storage/toggle/labcoat/cmo = 1)
+	contents_list_random = list(/obj/item/clothing/suit/bio_suit/cmo = 70,
+		/obj/item/clothing/head/bio_hood/cmo = 70,
+		/obj/item/weapon/tank/emergency_oxygen = 30,
+		/obj/item/device/flash = 65,
+		/obj/item/weapon/gun/projectile/dartgun = 65,
+		/obj/item/ammo_magazine/chemdart = 65,
+		/obj/item/ammo_magazine/chemdart = 65,
+		/obj/item/weapon/card/id/cmo = 10,
+		/obj/item/clothing/head/surgery/green = 65,
+		/obj/item/clothing/gloves/latex/nitrile = 55,
+		/obj/item/weapon/bedsheet/medical = 30,
+		/obj/item/weapon/storage/backpack/satchel/medical = 40,
+		/obj/item/hypospray/mkii/CMO = 30,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/drugs = 30,
+		/obj/item/weapon/reagent_containers/glass/beaker/hypocartridge/large/CMO = 30,
+		/obj/item/modular_computer/tablet/lease/preset/medical = 25,
+		/obj/item/weapon/stamp/cmo = 35)
+
+/datum/stash/command/CEstash //This is the CE stash
+	contents_list_external = list(/obj/item/remains/human = 1)
+	lore = "Pushed the fucker into the engine and ran. He didn't get his suit on in time, but I don't think I did either. <br>\
+			I'll come back for his stuff once I can get medical to fix me up. Leg's not working right, hope I can make it in time. <br>\
+			<br>\
+			%D, so I don't forget."
+	contents_list_base = list(/obj/item/clothing/under/rank/exultant = 1,
+		/obj/item/clothing/head/hardhat/white = 1)
+	contents_list_random = list(/obj/item/weapon/rig/ce = 70,
+		/obj/item/stack/material/plasteel/random = 55,
+		/obj/item/weapon/tool/wrench/big_wrench = 65,
+		/obj/item/stack/material/steel/random = 65,
+		/obj/item/weapon/card/id/ce = 10,
+		/obj/item/weapon/bedsheet/ce = 30,
+		/obj/item/weapon/storage/backpack/satchel/industrial = 40,
+		/obj/item/weapon/hatton = 15,
+		/obj/item/weapon/rcd = 15,
+		/obj/item/blueprints = 65,
+		/obj/item/stack/material/glass/random = 65,
+		/obj/item/weapon/stamp/ce = 35,
+		/obj/spawner/tool_upgrade = 70,
+		/obj/spawner/tool_upgrade = 25,
+		/obj/spawner/tool_upgrade = 25,
+		/obj/spawner/tool_upgrade = 25)
+
+/datum/stash/command/HOSstash //Stuff from the HOS
+	lore = "Yo Jensen, hope you can hold your end of this stupid plan. Just like we talked about, got 'em at %D. <br>\
+			I'll know if you get the other one, don't risk the plan. <br>\
+			<br>\
+			God I hope this shit works."
+	contents_list_base = list(/obj/item/clothing/under/rank/ih_commander = 1,
+		/obj/item/clothing/head/beret/sec/navy/hos = 1)
+	contents_list_random = list(/obj/item/weapon/gun/projectile/avasarala = 70,
+		/obj/item/clothing/head/HoS = 70,
+		/obj/item/clothing/gloves/stungloves = 55,
+		/obj/item/clothing/gloves/security/tactical = 30,
+		/obj/item/weapon/rig/combat = 65,
+		/obj/item/clothing/suit/storage/greatcoat/ironhammer = 50,
+		/obj/item/weapon/card/id/hos = 10,
+		/obj/item/weapon/bedsheet/hos = 30,
+		/obj/item/weapon/storage/box/handcuffs = 60,
+		/obj/item/weapon/storage/backpack/satchel/security = 40,
+		/obj/item/weapon/storage/belt/tactical/ironhammer = 15,
+		/obj/item/clothing/accessory/holster/waist = 25,
+		/obj/item/weapon/stamp/hos = 35,
+		/obj/item/weapon/gun/projectile/revolver/sky_driver = 15,
+		/obj/item/ammo_magazine/magnum = 80,
+		/obj/item/ammo_magazine/magnum = 80,
+		/obj/item/ammo_magazine/magnum = 80,
+		/obj/item/weapon/reagent_containers/food/snacks/hotdog = 10,
+		/obj/item/weapon/melee/telebaton = 15)
+
+/datum/stash/command/RDstash //RD's stuff
+	lore = "I told you, I told you! Call me mad one more time and I'll show you a mad scientist! <br>\
+			<br>\
+			Maybe you were right, but that doesn't matter anymore. Well, not to you anyway. <br>\
+			Now just to toss this whatever it is into space. I'll come back to %D. Gotta pick up the uniform."
+	contents_list_external = list(/obj/effect/decal/cleanable/greenglow = 1)
+	contents_list_base = list(/obj/item/clothing/under/rank/expedition_overseer = 1,
+		/obj/item/clothing/gloves/color/brown = 1)
+	contents_list_random = list(/obj/item/clothing/suit/space/void/science= 70,
+		/obj/item/clothing/head/space/void/science = 70,
+		/obj/item/weapon/tank/jetpack/oxygen = 55,
+		/obj/item/device/flash = 65,
+		/obj/item/stack/material/uranium/random = 50,
+		/obj/item/stack/material/plasteel/random = 65,
+		/obj/item/weapon/card/id/rd = 10,
+		/obj/item/clothing/shoes/leather = 70,
+		/obj/item/clothing/head/collectable/rabbitears = 10,
+		/obj/item/clothing/head/collectable/slime = 65,
+		/obj/item/weapon/bedsheet/rd = 30,
+		/obj/item/weapon/storage/backpack/satchel/purple/scientist = 40,
+		/obj/item/weapon/hand_tele = 15,
+		/obj/item/device/chameleon = 25,
+		/obj/item/weapon/stamp/rd = 35,
+		/obj/item/stack/material/diamond/random = 15,
+		/obj/item/stack/material/platinum/random = 15)
+
+/datum/stash/command/Merchstash //Merchant's stuff
+	lore = "Always charged too much. Maybe I'll give your stuff, for FREE, just to spite you. You deserved it. <br>\
+			<br>\
+			For this to happen the universe's gotta hate you. Wonder what else you did to people. At least I got some answers. <br>\
+			<br>\
+			Someone's coming, gotta hide it. Here, %D, come back later."
+	contents_list_base = list(/obj/item/clothing/under/rank/cargotech = 1,
+		/obj/item/clothing/glasses/powered/meson = 1)
+	contents_list_random = list(/obj/item/clothing/suit/space/void/mining= 70,
+		/obj/item/clothing/head/space/void/mining = 70,
+		/obj/item/weapon/tank/jetpack/oxygen = 55,
+		/obj/item/weapon/reagent_containers/food/drinks/flask = 50,
+		/obj/item/weapon/gun/projectile/shotgun/pump = 65,
+		/obj/item/ammo_casing/shotgun/beanbag/prespawned = 80,
+		/obj/item/ammo_casing/shotgun/beanbag/prespawned = 80,
+		/obj/item/weapon/bedsheet/brown = 30,
+		/obj/item/weapon/storage/backpack/satchel/leather = 40,
+		/obj/item/device/scanner/price = 25,
+		/obj/item/weapon/stamp/qm = 35,
+		/obj/spawner/credits/c100 = 90,
+		/obj/spawner/credits/c500 = 90,
+		/obj/spawner/credits/c1000 = 75,
+		/obj/spawner/credits/c5000 = 35,
+		/obj/spawner/credits/c10000 = 15,
+		/obj/item/clothing/head/soft = 15)
+
+/datum/stash/command/FOstash //First office/HOP stuff.
+	lore = "all i wanted was access <br>\
+			thats all i asked for <br>\
+			and i told you thered be consequences <br>\
+			and there were <br>\
+			<br>\
+			gotta hide it gotta hide it someone might find me <br>\
+			here ill put it here here here here <br>\
+			%D <br>\
+			and come back to it later when theyve had consequences too."
+	contents_list_external = list(/obj/item/remains/human = 1)
+	contents_list_base = list(/obj/item/clothing/under/rank/first_officer = 1,
+		/obj/item/clothing/head/caphat/hop = 1)
+	contents_list_random = list(/obj/item/clothing/suit/armor/vest = 70,
+		/obj/item/clothing/glasses/sunglasses = 55,
+		/obj/item/weapon/reagent_containers/food/drinks/flask = 50,
+		/obj/item/weapon/gun/projectile/avasarala = 65,
+		/obj/item/ammo_magazine/magnum = 80,
+		/obj/item/ammo_magazine/magnum = 80,
+		/obj/item/weapon/cartridge/ce = 35,
+		/obj/item/weapon/cartridge/hop = 35,
+		/obj/item/weapon/cartridge/hos = 35,
+		/obj/item/weapon/cartridge/rd = 35,
+		/obj/item/weapon/cartridge/cmo = 35,
+		/obj/item/device/pda/heads = 50,
+		/obj/item/device/pda/heads = 50,
+		/obj/item/device/pda/heads = 50,
+		/obj/item/weapon/card/id/hop = 10,
+		/obj/item/weapon/storage/box/ids = 65,
+		/obj/item/weapon/bedsheet/hop = 30,
+		/obj/item/weapon/storage/backpack/satchel/leather/withwallet = 40,
+		/obj/item/modular_computer/tablet/lease/preset/command = 25,
+		/obj/item/weapon/stamp/hop = 35)
+
+/datum/stash/command/Chaplainstash //Mekhane chaplain stuff
+	lore = "Ave. May your soul find the peace in the afterlife you did not allow it in this, o sorrowful leader. <br>\
+			I must admit I always admired your conviction, even if such misguided anger was your undoing. <br>\
+			<br>\
+			The flock requires my attention. I will return your effects to your descendants, or entomb them among the stars.\
+			I require some time to ruminate on this. <br>\
+			<br>\
+			%D, to quell any fear of losing this spot among the other things that require my immediate attention."
+	contents_list_base = list(/obj/item/clothing/under/rank/preacher = 1,
+		/obj/item/clothing/head/preacher = 1)
+	contents_list_random = list(/obj/item/clothing/suit/storage/neotheology_jacket = 70,
+		/obj/item/weapon/book/ritual/cruciform = 55,
+		/obj/item/weapon/tool/knife/dagger/nt = 65,
+		/obj/item/weapon/reagent_containers/food/drinks/bottle/ntcahors = 50,
+		/obj/item/weapon/gun/energy/nt_svalinn = 65,
+		/obj/item/weapon/card/id/chaplain = 10,
+		/obj/item/clothing/under/rank/church/sport = 65,
+		/obj/item/weapon/storage/belt/tactical/neotheology = 30,
+		/obj/item/weapon/storage/backpack/satchel/neotheology = 40,
+		/obj/item/weapon/storage/fancy/candle_box = 15,
+		/obj/item/weapon/implant/core_implant/cruciform = 25,
+		/obj/item/weapon/deck/tarot = 35,
+		/obj/item/weapon/tool/sword/nt/longsword = 15,
+		/obj/item/clothing/suit/storage/neotheosports = 15)


### PR DESCRIPTION
New stashes for command instead of just the captain one. Also, removed the headset from all command stashes.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR changes the command stashes from just spawning the captain and its variants to picking a head stash at random from each of the command positions minus ensign. Each stash has clothing and items associated with the head position. For example, the CE has toolmods and the station blueprints (among other things), the RD has materials and the bluespace harpoon (also among other things), and the merchant has money.  Each stash also has associated lore to put in the directions. 

Additionally, no command stash will spawn with the associated headset. I've removed the captain headset from the captain stash and not included the associated headsets in each of the command stashes. 

The only edit in a core file was commenting out some of the lore for captain stashes upon request by Jamini. I can revert that change if requested but I'd talk to him first. 

I've also changed some of the wording on our lore tabs to make it flow better and fixed a few typos in the stash lore as well. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Just having captain stashes gets boring, now there's more variety. Headsets were removed upon request. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Notes:
1. When compiling there was a DMM error related to a retail scanner. That shouldn't be a problem, but I can do some digging if it ends up being one. 

## Changelog
```changelog
add: Added new stashes for each of the command roles, with associated lore and drops! Go looking! 
del: Removed the headsets from command stashes. 
tweak: Fixed some typos in other stash lores. 
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
