### PR TITLE
Handtele now works on all valid zlevels

### DIFF
--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -45,7 +45,8 @@
 		to_chat(user, SPAN_WARNING("[src] battery is dead or missing."))
 		return
 	var/turf/current_location = get_turf(user)//What turf is the user on?
-	if(!current_location||current_location.z==2||current_location.z>=7)//If turf was not found or they're on z level 2 or >7 which does not currently exist.
+	// OCCULUS EDIT - Z level 2 absolutely does exist, and zs above 7 do as well
+	if(!current_location)//If turf was not found or they're on z level 2 or >7 which does not currently exist.
 		to_chat(user, SPAN_NOTICE("\The [src] is malfunctioning!"))
 		return
 	var/list/L = list()


### PR DESCRIPTION
## About The Pull Request

Exactly what it says on the tin. Handtele was preventing teleports from Zlevel 2 because """""it does not exist""""". That restriction has been removed.

## Why It's Good For The Game

less jank

## Changelog
```changelog Toriate
fix: handtele should now work on all valid zlevels instead of malfunctioning on deck 4
```
