### PR TITLE
Re-enables client FPS settings

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -479,12 +479,11 @@
 	set category = "OOC"
 	if(prefs)
 		prefs.ShowChoices(usr)
-/*
-/client/proc/apply_fps(var/client_fps)
-	if(world.byond_version >= 511 && byond_version >= 511 && client_fps >= CLIENT_MIN_FPS && client_fps <= CLIENT_MAX_FPS)
-		vars["fps"] = prefs.clientfps
 
-*/
+// OCCULUS EDIT - Enabling Client FPS
+/client/proc/apply_fps(var/client_fps)
+	if(world.byond_version >= 511 && byond_version >= 511 && client_fps >= 0 && client_fps <= 1000)
+		vars["fps"] = prefs.clientfps
 
 // Byond seemingly calls stat, each tick.
 // Calling things each tick can get expensive real quick.

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -1,5 +1,5 @@
 /datum/preferences
-	//var/clientfps = 0
+	var/clientfps = 0
 		//game-preferences
 	var/ooccolor = "#010000"			//Whatever this is set to acts as 'reset' color and is thus unusable as an actual custom color
 	var/UI_style = "ErisStyle"
@@ -17,21 +17,21 @@
 	S["UI_style_color"]	>> pref.UI_style_color
 	S["UI_style_alpha"]	>> pref.UI_style_alpha
 	S["ooccolor"]		>> pref.ooccolor
-	//S["clientfps"]		>> pref.clientfps
+	S["clientfps"]		>> pref.clientfps
 
 /datum/category_item/player_setup_item/player_global/ui/save_preferences(var/savefile/S)
 	S["UI_style"]		<< pref.UI_style
 	S["UI_style_color"]	<< pref.UI_style_color
 	S["UI_style_alpha"]	<< pref.UI_style_alpha
 	S["ooccolor"]		<< pref.ooccolor
-	//S["clientfps"]		<< pref.clientfps
+	S["clientfps"]		<< pref.clientfps
 
 /datum/category_item/player_setup_item/player_global/ui/sanitize_preferences()
 	pref.UI_style		= sanitize_inlist(pref.UI_style, all_ui_styles, initial(pref.UI_style))
 	pref.UI_style_color	= sanitize_hexcolor(pref.UI_style_color, initial(pref.UI_style_color))
 	pref.UI_style_alpha	= sanitize_integer(pref.UI_style_alpha, 0, 255, initial(pref.UI_style_alpha))
 	pref.ooccolor		= sanitize_hexcolor(pref.ooccolor, initial(pref.ooccolor))
-	//pref.clientfps	    = sanitize_integer(pref.clientfps, CLIENT_MIN_FPS, CLIENT_MAX_FPS, initial(pref.clientfps))
+	pref.clientfps	    = sanitize_integer(pref.clientfps, 0, 1000, initial(pref.clientfps))	// OCCULUS EDIT - Enabling Client FPS
 
 /datum/category_item/player_setup_item/player_global/ui/content(var/mob/user)
 	. += "<b>UI Settings</b><br>"
@@ -45,7 +45,7 @@
 			. += "<a href='?src=\ref[src];select_ooc_color=1'><b>Using Default</b></a><br>"
 		else
 			. += "<a href='?src=\ref[src];select_ooc_color=1'><b>[pref.ooccolor]</b></a> <table style='display:inline;' bgcolor='[pref.ooccolor]'><tr><td>__</td></tr></table> <a href='?src=\ref[src];reset=ooc'>reset</a><br>"
-	//. += "<b>Client FPS:</b> <a href='?src=\ref[src];select_fps=1'><b>[pref.clientfps]</b></a><br>"
+	. += "<b>Client FPS:</b> <a href='?src=\ref[src];select_fps=1'><b>[pref.clientfps]</b></a><br>" // OCCULUS EDIT - Enabling Client FPS
 
 
 /datum/category_item/player_setup_item/player_global/ui/OnTopic(var/href,var/list/href_list, var/mob/user)
@@ -76,7 +76,7 @@
 			pref.ooccolor = new_ooccolor
 			return TOPIC_REFRESH
 
-	/*
+	// OCCULUS EDIT - Enabling Client FPS
 	else if(href_list["select_fps"])
 		var/version_message
 		if (user.client && user.client.byond_version < 511)
@@ -85,13 +85,13 @@
 			version_message += "\nThis server does not currently support client side fps. You can set now for when it does."
 		var/new_fps = input(user, "Choose your desired fps.[version_message]\n(0 = synced with server tick rate (currently:[world.fps]))", "Global Preference") as num|null
 		if (isnum(new_fps) && CanUseTopic(user))
-			pref.clientfps = CLAMP(new_fps, CLIENT_MIN_FPS, CLIENT_MAX_FPS)
+			pref.clientfps = CLAMP(new_fps, 0, 1000)
 
 			var/mob/target_mob = preference_mob()
 			if(target_mob && target_mob.client)
 				target_mob.client.apply_fps(pref.clientfps)
 			return TOPIC_REFRESH
-	*/
+
 	else if(href_list["reset"])
 		switch(href_list["reset"])
 			if("ui")


### PR DESCRIPTION
## About The Pull Request

Eris had commented it out when they ported it. Now it's been uncommented. It has been tested and confirmed to be working. No runtimes.

<img width="147" alt="iYRXa6i0hO" src="https://user-images.githubusercontent.com/31995558/120997817-1a0f8000-c7ba-11eb-9ccd-cf3f21a28775.png">
<img width="74" alt="k2oRGA6GYe" src="https://user-images.githubusercontent.com/31995558/120997821-1bd94380-c7ba-11eb-995b-4c3ab0097163.png">


## Why It's Good For The Game

Client FPS is kind of a big thing for making the game feel much smoother than it truly is. It may be putting lipstick on a pig, but it's far better than nothing.

## Changelog
```changelog Toriate
add: Client FPS settings
```