### PR TITLE
Extends GC hard delete warning time to 2 seconds

### DIFF
--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -230,9 +230,11 @@ SUBSYSTEM_DEF(garbage)
 		time = TICK_DELTA_TO_MS(tick)/100
 	if (time > highest_del_time)
 		highest_del_time = time
-	if (time > 10)
-		log_game("Error: [type]([refID]) took longer than 1 second to delete (took [time/10] seconds to delete)")
-		message_admins("Error: [type]([refID]) took longer than 1 second to delete (took [time/10] seconds to delete).")
+	//OCCULUS EDIT START - Setting the 1 second hardcap to 2 seconds to see if it makes things hang less
+	if (time > 20)
+		log_game("Error: [type]([refID]) took longer than 2 seconds to delete (took [time/10] seconds to delete)")
+		message_admins("Error: [type]([refID]) took longer than 2 seconds to delete (took [time/10] seconds to delete).")
+	//OCCULUS EDIT END
 		postpone(time)
 
 /datum/controller/subsystem/garbage/Recover()


### PR DESCRIPTION
## About The Pull Request

Currently, the server seems to be having trouble GC'ing a lot of things, taking over 1.3 seconds to delete roaches and such. When this happens, the subsystem intentionally hangs for the exact same about of time that it took to delete for reasons that go over my head. This causes the server to stutter noticeably. I think.

I am unable to test this as my local hardware does not have trouble GC'ing anything. Either way, it compiles and runs just fine.

## Why It's Good For The Game

Anything to make the server more playable is preferable.

## Changelog
```changelog Toriate
server: GC should now only error when something takes longer than 2 seconds to delete
```