### PR TITLE
Blob Rebalance

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2828,6 +2828,7 @@
 #include "zzzz_modular_occulus\code\game\antagonist\station\occultist.dm"
 #include "zzzz_modular_occulus\code\game\antagonist\station\traitor.dm"
 #include "zzzz_modular_occulus\code\game\gamemodes\changeling\modularchangeling.dm"
+#include "zzzz_modular_occulus\code\game\gamemodes\events\blob.dm"
 #include "zzzz_modular_occulus\code\game\gamemodes\occultist\modular_occultist.dm"
 #include "zzzz_modular_occulus\code\game\gamemodes\occultist\occultist_mind.dm"
 #include "zzzz_modular_occulus\code\game\gamemodes\occultist\occultist_powers.dm"

--- a/code/game/gamemodes/events/blob.dm
+++ b/code/game/gamemodes/events/blob.dm
@@ -157,7 +157,7 @@
 
 	//Heal ourselves
 	regen()
-
+	MeltFloor(src.loc)//Occulus Edit
 
 	if (world.time >= next_expansion)
 		//Update our neighbors. This may cause us to stop processing
@@ -434,6 +434,9 @@
 //Blobs will do horrible things to any mobs they share a tile with
 //Returns true if any mob was damaged, false if not
 /obj/effect/blob/proc/attack_mobs(var/turf/T)
+	if(!core) //Occulus edit. If the core is dead, stop attacking
+		return//Occulus edit: If the core is dead, stop attacking
+	var/result = FALSE//Occulus Edit
 	if (!T)
 		T = loc
 	for (var/mob/living/L in T)
@@ -441,28 +444,30 @@
 			continue
 		L.visible_message(SPAN_DANGER("The blob attacks \the [L]!"), SPAN_DANGER("The blob attacks you!"))
 		playsound(loc, 'sound/effects/attackblob.ogg', 50, 1)
-		L.take_organ_damage(burn = RAND_DECIMAL(0.4, 2.3))
+//		L.take_organ_damage(burn = RAND_DECIMAL(6,8))//Occulus Edit: No wonder this did basically no damage.
+		L.apply_damage(RAND_DECIMAL(6,8),BURN)//Occulus Edit: this respects armor now
 
 		//In addition to the flat damage above, we will also splash a small amount of acid on the target
 		//This allows them to wear acidproof gear to resist it
 		if (iscarbon(L))
-			var/datum/reagents/R = new /datum/reagents(4, null)
-			R.add_reagent("sacid", RAND_DECIMAL(0.8,4))
-			R.trans_to(L, R.total_volume)
+			var/datum/reagents/R = new /datum/reagents(30, null)//Bigger container Occulus Edit
+			R.add_reagent("sacid", 30)//Deals another 5 damage if you aren't in an acidproof suit, Ocuclus Edit
+			R.splash(L, R.total_volume)//Acid gets splashed on people you Eris dummies. Occulus Edit
 			qdel(R)
 
-		return TRUE
+		result = TRUE//Occulus edit
 
 	//If we get here, nobody was harmed
-	return FALSE
+	return result//Occulus edit
 
 
 //Stepping on a blob is bad for your health.
 //When walked over, the blob will wake up and attack whoever stepped on it
 //Since it's awake, it will keep attacking them every process call until they leave or die
-/obj/effect/blob/Crossed()
-	set_awake()
-	attack_mobs()
+/obj/effect/blob/Crossed(mob/AM)
+	if(isliving(AM))//Occulus Edit
+		set_awake()//Edits
+		attack_mobs()//Edits
 
 /*******************
 	BLOB DEFENSE
@@ -484,6 +489,9 @@
 			absorbed_damage = min(health * fire_resist, Proj.damage_types[i])
 			taken_damage= (Proj.damage_types[i]  / fire_resist)
 			Proj.damage_types[i] -= absorbed_damage
+	var/datum/effect/effect/system/smoke_spread/bad/smoke
+	smoke.set_up(3, 0, src.loc)
+	smoke.start()
 	take_damage(taken_damage)
 	if (Proj.get_total_damage() <= 0)
 		return 0
@@ -504,6 +512,8 @@
 				damage = (W.force / brute_resist)
 
 		take_damage(damage)
+		if(prob(5))
+			attack_mobs(user.loc)
 		return 1
 	return ..()
 

--- a/code/game/gamemodes/events/blob.dm
+++ b/code/game/gamemodes/events/blob.dm
@@ -489,9 +489,6 @@
 			absorbed_damage = min(health * fire_resist, Proj.damage_types[i])
 			taken_damage= (Proj.damage_types[i]  / fire_resist)
 			Proj.damage_types[i] -= absorbed_damage
-	var/datum/effect/effect/system/smoke_spread/bad/smoke
-	smoke.set_up(3, 0, src.loc)
-	smoke.start()
 	take_damage(taken_damage)
 	if (Proj.get_total_damage() <= 0)
 		return 0

--- a/code/modules/reagents/reagents/dispenser.dm
+++ b/code/modules/reagents/reagents/dispenser.dm
@@ -322,7 +322,7 @@
 				remove_self(volume)
 				return
 			else if(volume > meltdose)
-				H << "<span class='danger'>Your [H.head] melts away!</span>"
+				to_chat(H, "<span class='danger'>Your [H.head] melts away!</span>")
 				qdel(H.head)
 				H.update_inv_head(1)
 				H.update_hair(1)
@@ -336,7 +336,7 @@
 				remove_self(volume)
 				return
 			else if(volume > meltdose)
-				H << "<span class='danger'>Your [H.wear_mask] melts away!</span>"
+				to_chat(H, "<span class='danger'>Your [H.wear_mask] melts away!</span>")
 				qdel(H.wear_mask)
 				H.update_inv_wear_mask(1)
 				H.update_hair(1)
@@ -349,7 +349,7 @@
 				H << "<span class='danger'>Your [H.glasses] partially protect you from the acid!</span>"
 				volume /= 2
 			else if(volume > meltdose)
-				H << "<span class='danger'>Your [H.glasses] melt away!</span>"
+				to_chat(H, "<span class='danger'>Your [H.glasses] melt away!</span>")
 				qdel(H.glasses)
 				H.update_inv_glasses(1)
 				remove_self(meltdose / 2)

--- a/zzzz_modular_occulus/code/game/gamemodes/events/blob.dm
+++ b/zzzz_modular_occulus/code/game/gamemodes/events/blob.dm
@@ -1,0 +1,42 @@
+/obj/effect/blob/proc/MeltFloor(var/turf/T)
+	if(!core)
+		return
+	if(istype(T, /turf/simulated/floor))
+		if(prob(25))
+			var/turf/simulated/floor/D
+			D = T
+			D.take_damage(20, BLAST)
+			playsound(src.loc, pick('sound/items/Welder.ogg','sound/items/Welder.ogg'), 10, 1)
+	for(var/obj/item/A in T)
+		if(!A.unacidable)
+			if(prob(5))
+				visible_message(SPAN_DANGER("Acid melts [A]!"))
+				A.ex_act(1)
+	for(var/obj/machinery/B in T)
+		if(!B.unacidable)
+			if(prob(5))
+				B.ex_act(1)
+				visible_message(SPAN_DANGER("Acid melts [B]!"))
+	for(var/obj/structure/C in T)
+		if(!C.unacidable)
+			if(prob(5))
+				C.ex_act(1)
+				visible_message(SPAN_DANGER("Acid melts [C]!"))
+	if(istype(T, /turf/simulated/open))
+		expand(get_turf(locate(T.x, T.y, T.z-1)))
+		active = FALSE
+
+/obj/effect/blob/shield/MeltFloor(var/turf/T)
+	if(istype(T, /turf/simulated/floor))
+		if(prob(10))
+			var/turf/simulated/floor/D
+			D = T
+			D.take_damage(100, BLAST)
+			playsound(src.loc, pick('sound/items/Welder.ogg','sound/items/Welder.ogg'), 75, 1)
+	..()
+/obj/structure/multiz
+	unacidable = 1
+
+/obj/machinery/multistructure/bioreactor_part
+	unacidable = 1
+

--- a/zzzz_modular_occulus/code/game/gamemodes/storytellers/storytellers.dm
+++ b/zzzz_modular_occulus/code/game/gamemodes/storytellers/storytellers.dm
@@ -1,6 +1,6 @@
 /datum/storyteller
 	variance = 0.45 //Tripling potential varience. Since right now storytellers are kinda... easy to predict
-
+	repetition_multiplier = 0.85 //This needs to be below 1, otherwise every time an event occurs it becomes much more likely to reoccur.
 /*The Guide is the default storyteller
 It is set as storyteller base in __defines/gamemode.dm
 */
@@ -22,7 +22,12 @@ It is set as storyteller base in __defines/gamemode.dm
 	welcome = "A strict regimen is paramount, if one is to master the brutal arithmetic of combat."
 	description = "A PvE focused storyteller that pulls no punches, but doesn't try and overwhelm you. Defend the gates. Identical to guide, but generates no antagonists or round-ending events."
 	gain_mult_roleset = 0
-	tag_weight_mults = list(TAG_ROUNDENDING = 0)
+	points = list(
+		EVENT_LEVEL_MUNDANE = 0, //Mundane
+		EVENT_LEVEL_MODERATE = 0, //Moderate
+		EVENT_LEVEL_MAJOR = 0, //Major
+		EVENT_LEVEL_ROLESET = 0 //Roleset - Spawns antagonists at 30minutes and 150 minutes roughly
+	)
 /*The Mentor is designed to teach new players the ropes of the Northern Light.
 It generates points about half as a fast as guide
 */
@@ -40,7 +45,7 @@ It generates points about half as a fast as guide
 	EVENT_LEVEL_MUNDANE = 10, //Mundane
 	EVENT_LEVEL_MODERATE = 20, //Moderate
 	EVENT_LEVEL_MAJOR = 40, //Major
-	EVENT_LEVEL_ROLESET = 0 //Roleset
+	EVENT_LEVEL_ROLESET = 45 //Roleset
 	)
 /*The Healer is designed for RP-heavy rounds.
 It generates no antagonists and disables the most destructive major events.
@@ -57,6 +62,7 @@ It generates no antagonists and disables the most destructive major events.
 	gain_mult_roleset = 0 //Healer does not generate antagonists.
 
 	tag_weight_mults = list(TAG_COMBAT = 0.75, TAG_NEGATIVE = 0.5, TAG_POSITIVE = 2, TAG_ROUNDENDING = 0)
+	repetition_multiplier = 0.85 //This needs to be below 1, otherwise every time an event occurs it becomes much more likely to reoccur.
 
 	points = list(
 	EVENT_LEVEL_MUNDANE = 25, //Mundane
@@ -79,8 +85,6 @@ It generates half again as many events as default, as well as more antagonists.
 	gain_mult_roleset = 1.2
 
 	tag_weight_mults = list(TAG_COMBAT = 0.6, TAG_DESTRUCTIVE = 0.6)
-
-	repetition_multiplier = 1 //Fine, since we want antags to spawn and not much else to happen that isn't combat or destructive.
 
 	//Generates few events after spawning antagonists.
 	points = list(


### PR DESCRIPTION
## About The Pull Request

Blob has been significantly buffed to make it a more threatening Major event.

![image](https://user-images.githubusercontent.com/1775680/121628349-04fb5100-ca47-11eb-87a1-9cbd6c6c9b29.png)


Blobs now deal notably more damage and spray significant quantities of acid onto people who they attack
Blobs now melt most objects, including the floor. Strong blobs are capable of punching holes through Z-levels!
Blobs now flow down Z-levels.
Blobs now occasionally counterattack people that hit them (5% of the time)
Blobs no longer consider ghosts value creatures for crossing them.
Blobs now can hit multiple creatures in a tile.

In addition to this, the following tweaks and fixes are included.

Acid melting your gear no longer tries to send text to a nonexistent HTTP server.
multiz objects and the bioreactor no longer can be melted by acid.
The base repeat value for events is now 0.85. Previously rolling an event made it increasingly more likely to roll that event again, and again, and again. This has been fixed.
Sentinel now can roll rounending events such as blob and hivemind.



## Why It's Good For The Game

Significantly more variety and danger is inbound to the CEV Northern Light.

## Changelog
```changelog
add: Blobs can now melt floors
add: Blobs will melt objects that share a tile with them, if that object is not immune to acid
add: Blobs can now travel down Z-levels
add: Blobs will counterattack occasionally when hit in melee
balance: Blob damage upped to 6-8 burn from 2-4 (respects armor)
fix: Blobs now properly spray you with sulphuric cid. This will destroy your gear and can significantly injure or disfigure you.
fix: Blobs will not trigger crossed() from ghosts
fix: Blobs will now hit every creature in their tile
fix: acid melting lines now display properly 
fix: Storytellers will no longer infinitely recursively increase event weight when you roll an event.
tweak: multiz objects are now immune to acid
tweak: bioreactor parts are now immune to acid
tweak: Sentinel now can roll round-ending events
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
