### PR TITLE
Fixing undies, also cleans up character setup.

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -1477,6 +1477,7 @@
 #include "code\modules\client\preference_setup\loadout\lists\uniforms.dm"
 #include "code\modules\client\preference_setup\loadout\lists\utility.dm"
 #include "code\modules\client\preference_setup\matchmaking\matchmaking.dm"
+#include "code\modules\client\preference_setup\matchmaking\matchmaking_disabled.dm"
 #include "code\modules\client\preference_setup\matchmaking\relations.dm"
 #include "code\modules\client\preference_setup\matchmaking\relations_types.dm"
 #include "code\modules\client\preference_setup\occupation\occupation.dm"

--- a/code/modules/client/preference_setup/customization/01_ears.dm
+++ b/code/modules/client/preference_setup/customization/01_ears.dm
@@ -1,8 +1,8 @@
 // Global stuff that will put us on the map
-/datum/category_group/player_setup_category/vore
+/* /datum/category_group/player_setup_category/vore // OCCULUS REMOVE: Removes tab, it is merging with the default tab now. It has been thrown into brazil
 	name = "Species Customization"
 	sort_order = 7
-	category_item_type = /datum/category_item/player_setup_item/vore
+	category_item_type = /datum/category_item/player_setup_item/vore */
 
 // Define a place to save appearance in character setup
 /datum/preferences
@@ -28,12 +28,16 @@
 	var/dress_mob = TRUE
 	var/fuzzy = FALSE
 
-// Definition of the stuff for Ears
-/datum/category_item/player_setup_item/vore/ears
-	name = "Appearance"
-	sort_order = 1
+//
+// OCCULUS EDIT - MASS REPLACEMENT /datum/category_item/player_setup_item/vore/ears -----> /datum/category_item/player_setup_item/physical/ears
+//
 
-/datum/category_item/player_setup_item/vore/ears/load_character(var/savefile/S)
+// Definition of the stuff for Ears
+/datum/category_item/player_setup_item/physical/ears
+	name = "Appearance"
+	sort_order = 5
+
+/datum/category_item/player_setup_item/physical/ears/load_character(var/savefile/S)
 	S["ear_style"]		>> pref.ear_style
 	S["r_ears"]			>> pref.r_ears
 	S["g_ears"]			>> pref.g_ears
@@ -57,7 +61,7 @@
 	S["fuzzy"]>> pref.fuzzy
 
 
-/datum/category_item/player_setup_item/vore/ears/save_character(var/savefile/S)
+/datum/category_item/player_setup_item/physical/ears/save_character(var/savefile/S)
 	S["ear_style"]		<< pref.ear_style
 	S["r_ears"]			<< pref.r_ears
 	S["g_ears"]			<< pref.g_ears
@@ -81,7 +85,7 @@
 	S["fuzzy"]<< pref.fuzzy
 
 
-/datum/category_item/player_setup_item/vore/ears/sanitize_character()
+/datum/category_item/player_setup_item/physical/ears/sanitize_character()
 	pref.r_ears		= sanitize_integer(pref.r_ears, 0, 255, initial(pref.r_ears))
 	pref.g_ears		= sanitize_integer(pref.g_ears, 0, 255, initial(pref.g_ears))
 	pref.b_ears		= sanitize_integer(pref.b_ears, 0, 255, initial(pref.b_ears))
@@ -109,19 +113,11 @@
 
 	pref.fuzzy				= sanitize_integer(pref.fuzzy, 0, 1, initial(pref.fuzzy))
 
+// OCCULUS EDIT: Removed Preview and renamed title appropriately
+/datum/category_item/player_setup_item/physical/ears/content(var/mob/user)
+	. += "<div style='clear: both;'"
+	. += "<b>Extra Appearance:</b><br>"
 
-/datum/category_item/player_setup_item/vore/ears/content(var/mob/user)
-	. += "<h2>Appearance and Custom Species Settings</h2>"
-
-	if(!pref.preview_icon)
-		pref.update_preview_icon()
- 	user << browse_rsc(pref.preview_icon, "previewicon.png")
-
-	. += "<b>Preview</b><br>"
-	. += "<div class='statusDisplay'><center><img src=previewicon.png width=[pref.preview_icon.Width()] height=[pref.preview_icon.Height()]></center></div>"
-	. += "<br><a href='?src=\ref[src];toggle_clothing=1'>[pref.dress_mob ? "Hide equipment" : "Show equipment"]</a><br>"
-
-	. += "<br>"
 	. += "<b>Custom Species</b> "
 	. += "<a href='?src=\ref[src];custom_species=1'>[pref.custom_species ? pref.custom_species : "-Input Name-"]</a><br>"
 
@@ -177,7 +173,7 @@
 		if (T.do_colouration)
 			. += "<a href='?src=\ref[src];wing_color=1'>Change Color</a> <font face='fixedsys' size='3' color='#[num2hex(pref.r_wing, 2)][num2hex(pref.g_wing, 2)][num2hex(pref.b_wing, 2)]'><table style='display:inline;' bgcolor='#[num2hex(pref.r_wing, 2)][num2hex(pref.g_wing, 2)][num2hex(pref.b_wing, 2)]'><tr><td>__</td></tr></table> </font><br>"
 
-/datum/category_item/player_setup_item/vore/ears/OnTopic(var/href,var/list/href_list, var/mob/user)
+/datum/category_item/player_setup_item/physical/ears/OnTopic(var/href,var/list/href_list, var/mob/user)
 	if(!CanUseTopic(user))
 		return TOPIC_NOACTION
 

--- a/code/modules/client/preference_setup/customization/01_ears.dm
+++ b/code/modules/client/preference_setup/customization/01_ears.dm
@@ -118,7 +118,7 @@
 	. += "<div style='clear: both;'"
 	. += "<b>Extra Appearance:</b><br>"
 
-	. += "<b>Custom Species</b> "
+	. += "<b>Custom Species Name</b> "
 	. += "<a href='?src=\ref[src];custom_species=1'>[pref.custom_species ? pref.custom_species : "-Input Name-"]</a><br>"
 
 

--- a/code/modules/client/preference_setup/matchmaking/matchmaking_disabled.dm
+++ b/code/modules/client/preference_setup/matchmaking/matchmaking_disabled.dm
@@ -1,0 +1,4 @@
+// OCCULUS ADD: Disables matchmaking from initialising, even though it's removed from the character setup. If playerdata fucks up in a way, it wont affect the player.
+
+/datum/matchmaker/do_matchmaking()
+    return

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -35,10 +35,13 @@ var/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 	sort_order = 5
 	category_item_type = /datum/category_item/player_setup_item/antagonism
 
+// OCCULUS REMOVE - Removes matchmaking from character setup screen
+/*
 /datum/category_group/player_setup_category/relations_preferences
 	name = "Matchmaking"
 	sort_order = 6
 	category_item_type = /datum/category_item/player_setup_item/relations
+*/
 
 /datum/category_group/player_setup_category/loadout_preferences
 	name = "Loadout"

--- a/code/modules/client/preference_setup/preview.dm
+++ b/code/modules/client/preference_setup/preview.dm
@@ -11,8 +11,12 @@ datum/preferences/proc/update_preview_icon(var/naked = FALSE)
 	mannequin.delete_inventory(TRUE)
 	preview_icon = icon('icons/effects/96x64.dmi', bgstate)
 
-	if(SSticker.current_state > GAME_STATE_STARTUP)
-		dress_preview_mob(mannequin, naked)
+	// OCCULUS TWEAK - Allows you to see the character before the server initialises.
+	if(!mannequin.dna) // Special handling for preview icons before SSAtoms has initailized.
+		mannequin.dna = new /datum/dna(null)
+
+//	if(SSticker.current_state > GAME_STATE_STARTUP)
+	dress_preview_mob(mannequin, naked)
 
 	mannequin.dir = EAST
 	preview_east = getFlatIcon(mannequin, EAST)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -346,7 +346,7 @@ var/global/list/damage_icon_parts = list()
 			var/obj/item/underwear/UW = entry
 			var/icon/I = new /icon(get_gender_icon(gender, "underwear"), UW.icon_state)
 			if(UW.color)
-				I.Blend(UW.color, ICON_ADD)
+				I.Blend(UW.color, ICON_MULTIPLY)
 			underwear.Blend(I, ICON_OVERLAY)
 		overlays_standing[UNDERWEAR_LAYER] = image(underwear)
 	if(update_icons)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -346,7 +346,7 @@ var/global/list/damage_icon_parts = list()
 			var/obj/item/underwear/UW = entry
 			var/icon/I = new /icon(get_gender_icon(gender, "underwear"), UW.icon_state)
 			if(UW.color)
-				I.Blend(UW.color, ICON_MULTIPLY)
+				I.Blend(UW.color, ICON_MULTIPLY) // OCCULUS EDIT - Fixes undies
 			underwear.Blend(I, ICON_OVERLAY)
 		overlays_standing[UNDERWEAR_LAYER] = image(underwear)
 	if(update_icons)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Who I am is totally not important. I am just a random person.
I come to provide some quick changes to your code. Things which contain the following:

- [x] Fixing undies 
- [x] Disable matchmaking
- [x] Merging the tail/ear/size and whatnot tab (originally virgocode's tab) into the general tab
- [x] Clearing out tabs which isn't used such as the matchmaking tab.
- [x] ~~Preview moved to right hand side of character setup window.~~

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
idk why does underwear even exist in this game, can't we just like, be nudists or something? 🤔

Matchmaking is being disabled cause apparently you don't use it, if it's removed from character setup but is still in, if someone corrupts the playerdata it can mess up and it's a security step. Just an extra file you can untick when needed, no biggie.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
fix: Fixed underwear color being additive instead of multiplied
tweak: Adjusted the character setup page. yes.
tweak: Disabled matchmaking
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
