### PR TITLE
Fixes Stunglove electrocution

### DIFF
--- a/zzzz_modular_occulus/code/modules/clothing/gloves/stungloves.dm
+++ b/zzzz_modular_occulus/code/modules/clothing/gloves/stungloves.dm
@@ -8,7 +8,7 @@
 	action_button_name = "Toggle Stun Glove"
 	price_tag = 100
 	rarity_value = 30
-	//siemens_coefficient = 1 Jamini Edit: Original stungloves didn't protect you from shocks as a balance concern. Additionally adding wiring to conduct electricity would probably make your glove armor less effective
+	siemens_coefficient = 1.3 // Siemens Coef 0 is shock proof. 1 is full shock damage. If anything it should be set to 1.3, for extra shock, Not commented out, as that makes you take less shock via normal glove coef
 	stunforce = 0
 	agonyforce = 15 //Maint gremlins not as good as Aegis. Glove stuns at over 100 Halloss. Req 7 consequetive hits to knock unconscious at 15 agony.
 	suitable_cell = /obj/item/weapon/cell/medium


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makeshift Stunglove users will now bear the brunt of having batteries and wires attached their zappy gloves when touching electrified things
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Prior stungloves were acting like normal gloves, and reducing shock due to inheriting the Siemens Coef of .5 of normal gloves.
This was originally set to 1 for makeshift gloves, but was commented out by Jamini.
Note: Insulation from shock is 0 siemens coeficient, not 1.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
fix: Makes makeshift shock gloves properly take full electric shock+ a bit extra, because glovewires/batteries
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
