### PR TITLE
Update poll_types.dm

### DIFF
--- a/code/controllers/subsystems/voting/poll_types.dm
+++ b/code/controllers/subsystems/voting/poll_types.dm
@@ -158,7 +158,7 @@
 	name = "Evacuate Ship"
 	question = "Do you want to call evacuation and restart the round?"
 	time = 120
-	minimum_win_percentage = 0.6
+//	minimum_win_percentage = 0.6 Occulus Edit, we are moving this to a simple majority
 	cooldown = 20 MINUTES
 	next_vote = 90 MINUTES //Minimum round length before it can be called for the first time
 	choice_types = list()


### PR DESCRIPTION
## About The Pull Request

Makes evac votes a simple majority, as we don't have runoffs.

## Why It's Good For The Game

52-57% votes failing totransfer feels bad, and unfairly favors one side of this option

## Changelog
```changelog
tweak: evacuation votes now require a simple majority as they lack runoff votes.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
