### PR TITLE
Suit Sensor setting.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -197,6 +197,8 @@
 			dat += "<BR><A href='?src=\ref[src];item=internals'>Toggle internals.</A>"
 
 	// Other incidentals.
+	if(istype(suit) && suit.has_sensor == 1) //Occulus Edit start
+		dat += "<BR><A href='?src=\ref[src];item=sensors'>Set sensors</A>" //Occulus edit end
 	if(handcuffed)
 		dat += "<BR><A href='?src=\ref[src];item=[slot_handcuffed]'>Handcuffed</A>"
 	if(legcuffed)

--- a/code/modules/mob/living/carbon/human/stripping.dm
+++ b/code/modules/mob/living/carbon/human/stripping.dm
@@ -15,7 +15,7 @@
 			if(!user.stats.getPerk(PERK_FAST_FINGERS))
 				visible_message(SPAN_DANGER("\The [user] is trying to empty \the [src]'s pockets!"))
 			else
-				to_chat(user, SPAN_NOTICE("You silently try to empty \the [src]'s pockets."))	
+				to_chat(user, SPAN_NOTICE("You silently try to empty \the [src]'s pockets."))
 			if(do_mob(user,src,HUMAN_STRIP_DELAY,progress = 1))
 				empty_pockets(user)
 			return
@@ -23,6 +23,11 @@
 			visible_message(SPAN_DANGER("\The [user] is trying to remove \the [src]'s splints!"))
 			if(do_mob(user,src,HUMAN_STRIP_DELAY,progress = 1))
 				remove_splints(user)
+			return
+		if("sensors")
+			visible_message("<span class='danger'>\The [user] is trying to set \the [src]'s sensors!</span>")
+			if(do_after(user,HUMAN_STRIP_DELAY,src))
+				toggle_sensors(user)
 			return
 		if("internals")
 			visible_message(SPAN_DANGER("\The [usr] is trying to set \the [src]'s internals!"))
@@ -102,6 +107,17 @@
 		visible_message(SPAN_DANGER("\The [user] empties \the [src]'s pockets!"))
 	else
 		to_chat(user, SPAN_NOTICE("You empty \the [src]'s pockets."))
+
+// Modify the current target sensor level. Occulus edit start
+/mob/living/carbon/human/proc/toggle_sensors(var/mob/living/user)
+	var/obj/item/clothing/under/suit = w_uniform
+	if(!suit)
+		to_chat(user, "<span class='warning'>\The [src] is not wearing a suit with sensors.</span>")
+		return
+	if (suit.has_sensor >= 2)
+		to_chat(user, "<span class='warning'>\The [src]'s suit sensor controls are locked.</span>")
+		return
+	suit.set_sensors(user) //Occulus edit end
 
 // Remove all splints.
 /mob/living/carbon/human/proc/remove_splints(var/mob/living/user)


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Allows people to adjust your sensors if wearing clothes with sensors!
![image](https://user-images.githubusercontent.com/12434413/122134470-a817e600-ce0c-11eb-8732-4544ffd396d1.png)
![image](https://user-images.githubusercontent.com/12434413/122134480-ac440380-ce0c-11eb-8d85-cf19b3d1617c.png)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Primarily, this is a change to let antags set peoples sensors as off, without having to physically yank someones clothes off.
On a server with some of the more niche things, this can leave a bad taste in the mouth if you want to interact with someone normally.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
add: suit sensors toggle from inventory!
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
