### PR TITLE
Fixes adjusting clothing not updating the sprite

### DIFF
--- a/zzzz_modular_occulus/code/modules/clothing/clothing.dm
+++ b/zzzz_modular_occulus/code/modules/clothing/clothing.dm
@@ -9,4 +9,4 @@
 	usr.visible_message("[usr] adjusts their jumpsuit.", \
 	"You adjust your jumpsuit.")
 	rolldown = !rolldown
-	usr.update_icons()
+	usr.update_inv_w_uniform()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes the "Adjust clothing" verb from not actually updating the sprite.
As a note, update_icon apparently only refreshes the icon overlays, **not** updates them to changed stuff.
Go take a look at https://github.com/Occulus-Server/Occulus-Eris/blob/master/code/modules/mob/living/carbon/human/update_icons.dm to know more.

For those astute, this is a webedit. It should be fine™.

## Why It's Good For The Game

No more taking off/putting on outfits to readjust the spite.

## Changelog
```changelog
fix: Fixes the "Toggle Jumpsuit" verb. Now it correctly updates the suit to the adjusted sprite, instead of when you take off/put it back on.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
