### PR TITLE
Big Bluespace Harpoon Refactor

### DIFF
--- a/code/game/objects/items/weapons/space_harpoon.dm
+++ b/code/game/objects/items/weapons/space_harpoon.dm
@@ -39,9 +39,6 @@
 		update_icon()
 
 /obj/item/weapon/bluespace_harpoon/afterattack(atom/A, mob/user)
-	if(user.mind && player_is_antag(user.mind)) //OCCULUS EDIT - Too much salt, this is better than nerfing it to the ground
-		to_chat(user, SPAN_NOTICE("Sorry, antagonists aren't allowed to use this."))
-		return
 	if(get_dist(A, user) > range)
 		return ..()
 //	if(!(A in view(user))) // OCCULUS EDIT - This prevents z-level traversal somehow, so eh.


### PR DESCRIPTION
## About The Pull Request
This PR restores the BSH to a usable state, as it was previously broken from heavyhanded, untested nerfs. It also buffs it slightly by allowing graceful transitions to lower z-levels, whereas it'd previously make you fall.

- There is now a visible message when someone starts using the BSH
- The BSH's firing time can be reduced to 1 second with 80 COG
- The BSH's chance to misfire can be reduced to 0 with 80 COG
- The BSH's base chance to misfire has been doubled to 10%
- The BSH's textual feedback has been improved
- The BSH's Receiving mode now actually works

Unfortunately, allowing z-level traversal makes it possible to use Mesons to teleport to normally not visible areas

## Why It's Good For The Game
We don't behave like the gremlins on Eris, so there's no reason for BSHs to be utterly useless.

## Changelog
```changelog Toriate
refactor: The Bluespace Harpoon has been restored to working order, and even improved. However, antagonists can no longer make use of it.
```
