### PR TITLE
Fixed the ID and implants from dropping on the floor when leaving the round via the elevator.

### DIFF
--- a/zzzz_modular_occulus/code/game/machinery/dorms_elevator.dm
+++ b/zzzz_modular_occulus/code/game/machinery/dorms_elevator.dm
@@ -4,9 +4,17 @@
 
 /obj/machinery/button/remote/elevator_panel/proc/despawn_passenger(var/mob/living/user)
 	var/mob/living/passenger = user
+	//var/mob/living/carbon/human/passengerplayer = user
 
 	for(var/obj/item/W in passenger)
-		if (istype(W, /obj/item/weapon/storage || /obj/item/clothing/suit/storage))
+		if (istype(W, /obj/item/modular_computer/pda))
+			var/obj/item/modular_computer/pda/found_pda = W
+			found_pda.eject_id()
+		else if (istype(W, /obj/item/weapon/implant))
+			var/obj/item/weapon/implant/found_implant = W
+			found_implant.uninstall()
+			qdel(found_implant)
+		else if (istype(W, /obj/item/weapon/storage || /obj/item/clothing/suit/storage))
 			for(var/T in preserve_items)
 				for (var/obj/item/w_storage in W.contents)
 					if (istype(w_storage, T))
@@ -17,7 +25,6 @@
 				if(istype(W, T))
 					passenger.drop_from_inventory(W)
 					continue
-
 
 	log_and_message_admins("[key_name(passenger)]" + "[passenger.mind ? " ([passenger.mind.assigned_role])" : ""]" + " ended their shift via the elevator to the dormitories.")
 	announce.autosay("[passenger.real_name]" + "[passenger.mind ? ", [passenger.mind.assigned_role]" : ""]" + ", [on_store_message]", "[on_store_name]")


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

IDs will now get ejected before despawning, which makes them get deleted properly. Implants will get uninstalled before despawning, which will make them get deleted properly.

The only downside to this is that the ID will make an eject sound before despawning. I might see about working on a better way of deleting the ID in the future.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Implants and IDs being dropped was pretty bad. This is a solution to that.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
fix: Cruciforms, soulcrypts and IDs will no longer drop on the floor when leaving the round via the elevator.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
