### PR TITLE
Occultist Framework Addition: Call Swarm, Banish Swarm, Unearthly Wail

### DIFF
--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -275,6 +275,8 @@
 		G.proj_damage_adjust[BRUTE] += weapon_upgrades[GUN_UPGRADE_DAMAGE_BRUTE]
 	if(weapon_upgrades[GUN_UPGRADE_DAMAGE_BURN])
 		G.proj_damage_adjust[BURN] += weapon_upgrades[GUN_UPGRADE_DAMAGE_BURN]
+	if(weapon_upgrades[GUN_UPGRADE_DAMAGE_PSY])//Occulus Edit: Psy mods
+		G.proj_damage_adjust[PSY] += weapon_upgrades[GUN_UPGRADE_DAMAGE_PSY]//Occulus Edit: Psy mods
 	if(weapon_upgrades[GUN_UPGRADE_DAMAGE_TOX])
 		G.proj_damage_adjust[TOX] += weapon_upgrades[GUN_UPGRADE_DAMAGE_TOX]
 	if(weapon_upgrades[GUN_UPGRADE_DAMAGE_OXY])

--- a/code/modules/projectiles/guns/mods/research_mods.dm
+++ b/code/modules/projectiles/guns/mods/research_mods.dm
@@ -129,7 +129,7 @@
 	..()
 	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
 	I.weapon_upgrades = list(
-	GUN_UPGRADE_DAMAGE_PSY = 0.4)
+	GUN_UPGRADE_DAMAGE_PSY = 10)//This needs to be higher than 0.4 to actually do anything.
 	I.req_gun_tags = list(GUN_PROJECTILE)
 	I.gun_loc_tag = GUN_MECHANISM
 

--- a/zzzz_modular_occulus/code/game/gamemodes/occultist/occultist_mind.dm
+++ b/zzzz_modular_occulus/code/game/gamemodes/occultist/occultist_mind.dm
@@ -37,7 +37,7 @@
 	..()
 
 /obj/item/organ/internal/brain/occultist/proc/spendpoints(var/amount)
-	if(madnesspoints > amount)
+	if(madnesspoints < amount)
 		return FALSE
 	else
 		madnesspoints -= amount

--- a/zzzz_modular_occulus/code/game/gamemodes/occultist/occultist_powers.dm
+++ b/zzzz_modular_occulus/code/game/gamemodes/occultist/occultist_powers.dm
@@ -4,7 +4,7 @@
 	var/verbpath //the verb we add if we add a verb
 
 /datum/power/occultist/proc/addPower(var/mob/living/carbon/human/themaster)
-	to_chat(themaster, "DEBUG. Adding: [src] to the occultist")
+	to_chat(themaster, "You focus your mind and discover [src]!")
 
 // T1 Powers
 
@@ -116,8 +116,8 @@
 // T2 Powers
 
 /mob/living/carbon/human/proc/spendpoints(var/amount)
-	if(get_organ(BP_BRAIN_CULTIST))
-		if(get_organ(BP_BRAIN_CULTIST).spendpoints(amount))
+	for(var/obj/item/organ/internal/brain/occultist/O in src.contents)
+		if(O.spendpoints(amount))
 			return TRUE
 		else
 			return FALSE
@@ -142,29 +142,94 @@
 	else
 		to_chat(src, "You are currently sane...fix that.")
 
-/datum/power/occultist/candle
-	name = "Like a Candle"
-	desc = "Grants target a glimpse into the power of the void."
-	activecost = 5
-
-/datum/power/occultist/wail
-	name = "Unearthly Wail"
-	desc = "Allows you to unleash a blood-curdling wail, draining sanity."
+/datum/power/occultist/callswarm
+	name = "Call Swarm"
+	desc = "Calls a swarm of roaches to your location. They are not friendly to you."
 	activecost = 1
+	verbpath = /mob/living/carbon/human/proc/Call_Swarm
 
-/datum/power/occultist/darkness
-	name = "Bring Darkness"
-	desc = "Breaks all lights around you."
-	activecost = 1
+/mob/living/carbon/human/proc/Call_Swarm()
+	set category = "Occultist"
+	set desc = "Call a swarm to your location."
+
+	if(spendpoints(1))
+		playsound(src.loc, 'sound/voice/shriek1.ogg', 100, 1, 8, 8)
+		spawn(2)
+		playsound(src.loc, 'sound/voice/shriek1.ogg', 100, 1, 8, 8)
+		//Playing the sound twice will make it sound really horrible
+		visible_message(SPAN_DANGER("[src] emits a horrifying wail as nearby burrows stir to life!"))
+		for (var/obj/structure/burrow/B in find_nearby_burrows())
+			B.distress(TRUE)
+	else
+		to_chat(src, "You lack enough madness to summon a swarm.")
 
 /datum/power/occultist/banish
 	name = "Banish Swarm"
 	desc = "Banishes all roaches within 15 tiles of you to the nearest burrow."
 	activecost = 1
+	verbpath = /mob/living/carbon/human/proc/Banish_Swarm
 
-/datum/power/occultist/callswarm
-	name = "Call Swarm"
-	desc = "Calls a swarm of roaches to your location. They are not friendly to you."
+/mob/living/carbon/human/proc/Banish_Swarm()
+	set category = "Occultist"
+	set desc = "Banish nearby roaches from your location"
+
+	if(spendpoints(1))
+		playsound(src.loc, 'sound/voice/hiss6.ogg', 100, 1, 8, 8)
+		spawn(2)
+		playsound(src.loc, 'sound/voice/hiss6.ogg', 100, 1, 8, 8)
+		//Playing the sound twice will make it sound really horrible
+		visible_message(SPAN_DANGER("[src] emits a haunting scream as it turns to flee, taking the nearby horde with it...."))
+		for (var/obj/structure/burrow/B in find_nearby_burrows())
+			B.evacuate()
+	else
+		to_chat(src, "You lack enough madness to banish a swarm.")
+
+/datum/power/occultist/vfaith
+	name = "Faith of the Voidmother"
+	desc = "Restores your sanity to full"
+	activecost = 1
+	verbpath = /mob/living/carbon/human/proc/Faith_of_the_Voidmother
+
+/mob/living/carbon/human/proc/Faith_of_the_Voidmother()
+	set category = "Occultist"
+	set desc = "Banish nearby roaches from your location"
+
+	if(spendpoints(1))
+		src.sanity.level = 100
+		to_chat(src, "You steel your mind against the dangers of the ship. This is not the path.")
+	else
+		to_chat(src, "You lack enough madness to restore your mind.")
+
+/datum/power/occultist/wail
+	name = "Unearthly Wail"
+	desc = "Allows you to unleash a blood-curdling wail, draining sanity."
+	activecost = 1
+	verbpath = /mob/living/carbon/human/proc/Unearthly_Wail
+
+
+/mob/living/carbon/human/proc/Unearthly_Wail()
+	set category = "Occultist"
+	set desc = "Channel the raw energies of the universe for a brief time."
+
+	if(spendpoints(1))
+		playsound(src.loc, pick('sound/hallucinations/wail.ogg','sound/hallucinations/veryfar_noise.ogg','sound/hallucinations/far_noise.ogg'), 100, 1, 8, 8)
+		sleep(2)
+		playsound(src.loc, pick('sound/hallucinations/wail.ogg','sound/hallucinations/veryfar_noise.ogg','sound/hallucinations/far_noise.ogg'), 100, 1, 8, 8)
+		sleep(2)
+		playsound(src.loc, pick('sound/hallucinations/wail.ogg','sound/hallucinations/veryfar_noise.ogg','sound/hallucinations/far_noise.ogg'), 100, 1, 8, 8)
+		for(var/mob/living/carbon/human/targets in view(src))
+			if(targets == src)
+				continue
+			else
+				targets.sanity.level -= 25
+				to_chat(targets, SPAN_DANGER("As [src] howls something claws at the edge of your mind!"))
+				targets.hallucination(30,50)
+	else
+		to_chat(src, "You lack enough madness to channel this!")
+
+/datum/power/occultist/darkness
+	name = "Bring Darkness"
+	desc = "Breaks all lights around you."
 	activecost = 1
 
 /datum/power/occultist/rust
@@ -172,10 +237,7 @@
 	desc = "Causes one object in your hand to rust and become useless."
 	activecost = 1
 
-/datum/power/occultist/vfaith
-	name = "Faith of the Voidmother"
-	desc = "Restores your sanity to full"
-	activecost = 1
+
 
 //T3 Powers
 

--- a/zzzz_modular_occulus/code/game/gamemodes/occultist/occultist_weapons.dm
+++ b/zzzz_modular_occulus/code/game/gamemodes/occultist/occultist_weapons.dm
@@ -130,6 +130,27 @@
 	proj_damage_adjust = list(PSY = 10)
 	penetration_multiplier = 0.9
 
+/obj/item/weapon/gun_upgrade/mechanism/occultist
+	name = "Occultist psionic catalyst"
+	desc = "Controversal device amplifies greatly this. Allows the natural psionic user abilityof the will world into the them."
+	icon_state = "psionic_catalyst"
+	spawn_blacklisted = TRUE
+
+/obj/item/weapon/gun_upgrade/mechanism/occultist/New()
+	var/datum/component/item_upgrade/I = AddComponent(/datum/component/item_upgrade)
+	I.weapon_upgrades = list(
+	GUN_UPGRADE_DAMAGE_PSY = 10)
+	I.destroy_on_removal = TRUE
+	I.removal_time *= 100
+	I.removal_difficulty *= 100
+	I.gun_loc_tag = GUN_MECHANISM
+
+/obj/item/weapon/gun/projectile/automatic/sol/cult/New()
+	..()
+	var/obj/item/weapon/gun_upgrade/mechanism/occultist/catalyst
+	catalyst = new /obj/item/weapon/gun_upgrade/mechanism/occultist
+	SEND_SIGNAL(catalyst, COMSIG_IATTACK, src, null)
+
 /obj/item/weapon/gun/energy/laser/cult
 	name = "OCLT LG \"Moonrise\""
 	desc = "Radiant and deadly. Zealotry \"Mekhane\" ire. Laser carbine of the brand it represents like."


### PR DESCRIPTION
## About The Pull Request

Adds several new powers and fixes some things that were not working before with Occultist

Call Swarm: Allows you to call a swarm like a Fuhrer does! Costs 1 Madness to use.
Banish Swarm: Allows you to call a retreat like a Fuhrer does! Costs 1 Madness to use.
Faith of the Voidmother: Instantly restores your sanity to full. Costs 1 Madness to use
Unearthly Wail: Drops the sanity of everyone who can see you by 25 points instantly. Very obvious to use and instantly reveals you as an Occultist. Costs 1 Madness to use.

## Why It's Good For The Game

Steadily moving on. We should be good to start playtesting this in a week or so.

## Changelog
```changelog
fix: Psy attachments now function.
fix: active cost occult powers now actually work
fix: The Eclipse is now functioning. All Occultist weapons now function!
add: Call Swarm power
add: Banish Swarm power
add: Faith of the Voidmother power
add: Unearthly Wail power
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
