### PR TITLE
Soulcrypt nutrition consumption reduced to a tenth

### DIFF
--- a/code/modules/soulcrypt/base_implant.dm
+++ b/code/modules/soulcrypt/base_implant.dm
@@ -272,7 +272,7 @@ The module base code is held in module.dm
 		send_host_message("Emergency charge complete! Active modules are now available.", MESSAGE_NOTICE)
 		emergency_charge = FALSE
 
-	wearer.adjustNutrition(-nutrition_to_remove) // REEE THIS NEEDS TO BE NEGATIVE
+	wearer.adjustNutrition(-nutrition_to_remove / 10) // REEE THIS NEEDS TO BE NEGATIVE // REE THIS DRAINS TOO QUICKLY
 
 /obj/item/weapon/implant/core_implant/soulcrypt/proc/handle_integrity()
 	if(integrity < (max_integrity * 0.15) && (next_integrity_warning < world.time))


### PR DESCRIPTION
## About The Pull Request
Divides the amount of nutrition consumed by a soulcrypt by 10.

## Why It's Good For The Game
Going from full nutrition to 0 in 40 life ticks is not fun.

## Changelog
```changelog Toriate
balance: Soulcrypt nutrition cost reduced to a tenth of what it was
```
