### PR TITLE
Gives the loadout turtleneck sensors

### DIFF
--- a/zzzz_modular_occulus/code/game/objects/items/toys/costume.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/toys/costume.dm
@@ -1,3 +1,4 @@
 obj/item/clothing/under/syndicate/civilian
 	name = "black turtleneck"
-	desc = "some non-descript civilian clothing."
+	desc = "Some non-descript civilian clothing."
+	has_sensor = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Gives the turtleneck in the loadout sensors, and capitalizes the description.

## Why It's Good For The Game

You should probably be able to have sensors on a loadout-start item (which you can disable with screw-turning tools, anyways)

## Changelog
```changelog
tweak: The black turtleneck available in the loadout now has suit sensors.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
