### PR TITLE
Probrably stops the atuodoc from charging for autoscans

### DIFF
--- a/code/modules/surgery/autodoc.dm
+++ b/code/modules/surgery/autodoc.dm
@@ -197,7 +197,7 @@
 	if(current_step > picked_patchnotes.len)
 		stop()
 		to_chat(patient, SPAN_NOTICE("Operations complete."))	// OCCULUS EDIT: Tell the patient when it's over
-		scan_user(patient, TRUE)
+		scan_user(patient, TRUE)				// OCCULUS EDIT - Autodoc won't charge for automatically rescanning during operation
 	else
 
 		var/datum/autodoc_patchnote/next_note = picked_patchnotes[current_step]

--- a/code/modules/surgery/autodoc.dm
+++ b/code/modules/surgery/autodoc.dm
@@ -197,7 +197,7 @@
 	if(current_step > picked_patchnotes.len)
 		stop()
 		to_chat(patient, SPAN_NOTICE("Operations complete."))	// OCCULUS EDIT: Tell the patient when it's over
-		scan_user(patient)
+		scan_user(patient, TRUE)
 	else
 
 		var/datum/autodoc_patchnote/next_note = picked_patchnotes[current_step]
@@ -456,8 +456,8 @@
 		return
 	..()
 
-/datum/autodoc/capitalist_autodoc/scan_user(mob/living/carbon/human/human)
-	if(!charge(AUTODOC_SCAN_COST))
+/datum/autodoc/capitalist_autodoc/scan_user(mob/living/carbon/human/human, no_charge = FALSE) // OCCULUS EDIT - Autodoc won't charge for automatically rescanning during operation
+	if(!no_charge && !charge(AUTODOC_SCAN_COST))
 		return
 	. = ..()
 

--- a/code/modules/surgery/autodoc.dm
+++ b/code/modules/surgery/autodoc.dm
@@ -456,8 +456,8 @@
 		return
 	..()
 
-/datum/autodoc/capitalist_autodoc/scan_user(mob/living/carbon/human/human, no_charge = FALSE) // OCCULUS EDIT - Autodoc won't charge for automatically rescanning during operation
-	if(!no_charge && !charge(AUTODOC_SCAN_COST))
+/datum/autodoc/capitalist_autodoc/scan_user(mob/living/carbon/human/human, no_charge = FALSE)	// OCCULUS EDIT - Autodoc won't charge for automatically rescanning during operation
+	if(!no_charge && !charge(AUTODOC_SCAN_COST))						// OCCULUS EDIT ^
 		return
 	. = ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a variable to the proc that checks if people can pay, which, if passed TRUE, doesn't try to charge the patient.
Helps stop peoples accounts from being drained just for using the autodoc (more than it would have already, that is.)

If this works, this Fixes #351 

## Why It's Good For The Game

Hidden fees are bad.

## Changelog
```changelog
fix: Fixed the autodoc charging for a rescan after each operation is done.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
