### PR TITLE
Nobles start with 5x the regular amount in their accounts

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -100,7 +100,7 @@
 	// if(!species_modifier)
 	// 	species_modifier = economic_species_modifier[/datum/species/human]
 
-	var/modifier = 1				// OCCULUS EDIT v
+	var/modifier = 1		// OCCULUS EDIT v
 	if(H.stats.getPerk(PERK_NOBLE)) // OCCULUS EDIT - Nobles get 5x the starting balance
 		modifier *= 5
 	

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -96,11 +96,15 @@
 		return
 
 	//give them an account in the station database
-	var/species_modifier = (H.species ? economic_species_modifier[H.species.type] : 2)
-	if(!species_modifier)
-		species_modifier = economic_species_modifier[/datum/species/human]
+	// var/species_modifier = (H.species ? economic_species_modifier[H.species.type] : 2) // OCCULUS EDIT - Nobles get 5x the starting balance (This bit is uneeded, as it wasn't used whatsoever)
+	// if(!species_modifier)
+	// 	species_modifier = economic_species_modifier[/datum/species/human]
 
-	var/money_amount = one_time_payment(species_modifier)
+	var/modifier = 1				// OCCULUS EDIT v
+	if(H.stats.getPerk(PERK_NOBLE)) // OCCULUS EDIT - Nobles get 5x the starting balance
+		modifier *= 5
+	
+	var/money_amount = one_time_payment(modifier)
 	var/datum/money_account/M = create_account(H.real_name, money_amount, null)
 	if(H.mind)
 		var/remembered_info = ""

--- a/code/game/jobs/wages.dm
+++ b/code/game/jobs/wages.dm
@@ -1,8 +1,8 @@
 //Determines starting account balance
 /datum/job/proc/one_time_payment(var/custom_factor = 1)
 	if (initial_balance != -1)
-		return round (initial_balance * RAND_DECIMAL(0.7, 1.3))
-	return round(wage * RAND_DECIMAL(1.5, 3.5))
+		return round (initial_balance * RAND_DECIMAL(0.7, 1.3) * custom_factor) // OCCULUS EDIT - Nobles get 5x the starting balance
+	return round(wage * RAND_DECIMAL(1.5, 3.5) * custom_factor)					// OCCULUS EDIT ^
 
 
 //How much is this user getting paid?

--- a/code/game/jobs/wages.dm
+++ b/code/game/jobs/wages.dm
@@ -2,7 +2,7 @@
 /datum/job/proc/one_time_payment(var/custom_factor = 1)
 	if (initial_balance != -1)
 		return round (initial_balance * RAND_DECIMAL(0.7, 1.3) * custom_factor) // OCCULUS EDIT - Nobles get 5x the starting balance
-	return round(wage * RAND_DECIMAL(1.5, 3.5) * custom_factor)					// OCCULUS EDIT ^
+	return round(wage * RAND_DECIMAL(1.5, 3.5) * custom_factor)			// OCCULUS EDIT ^
 
 
 //How much is this user getting paid?


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I remember someone saying that they wanted to give nobles 10x the starting amount of money when they spawned in, and I felt the motivation so :P

It did seem that 10x was a little too high, so I opted for 5x.

## Why It's Good For The Game

Nobles are probably rich.

## Changelog
```changelog
tweak: Nobles start with 5x the normal money amount.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
