### PR TITLE
Bumps up noble starting funds from 5x to 10x

### DIFF
--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -96,13 +96,13 @@
 		return
 
 	//give them an account in the station database
-	// var/species_modifier = (H.species ? economic_species_modifier[H.species.type] : 2) // OCCULUS EDIT - Nobles get 5x the starting balance (This bit is uneeded, as it wasn't used whatsoever)
+	// var/species_modifier = (H.species ? economic_species_modifier[H.species.type] : 2) // OCCULUS EDIT - Nobles get 10x the starting balance (This bit is uneeded, as it wasn't used whatsoever)
 	// if(!species_modifier)
 	// 	species_modifier = economic_species_modifier[/datum/species/human]
 
-	var/modifier = 1		// OCCULUS EDIT v
-	if(H.stats.getPerk(PERK_NOBLE)) // OCCULUS EDIT - Nobles get 5x the starting balance
-		modifier *= 5
+	var/modifier = 1				// OCCULUS EDIT v
+	if(H.stats.getPerk(PERK_NOBLE)) // OCCULUS EDIT - Nobles get 10x the starting balance
+		modifier *= 10
 	
 	var/money_amount = one_time_payment(modifier)
 	var/datum/money_account/M = create_account(H.real_name, money_amount, null)

--- a/code/game/jobs/wages.dm
+++ b/code/game/jobs/wages.dm
@@ -1,8 +1,8 @@
 //Determines starting account balance
 /datum/job/proc/one_time_payment(var/custom_factor = 1)
 	if (initial_balance != -1)
-		return round (initial_balance * RAND_DECIMAL(0.7, 1.3) * custom_factor) // OCCULUS EDIT - Nobles get 5x the starting balance
-	return round(wage * RAND_DECIMAL(1.5, 3.5) * custom_factor)			// OCCULUS EDIT ^
+		return round (initial_balance * RAND_DECIMAL(0.7, 1.3) * custom_factor) // OCCULUS EDIT - Nobles get 10x the starting balance
+	return round(wage * RAND_DECIMAL(1.5, 3.5) * custom_factor)					// OCCULUS EDIT ^
 
 
 //How much is this user getting paid?


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Jams said he wanted it at 10x for a reason (see below), so here we go. I don't particularly care if this is merged or not.

## Why It's Good For The Game

Image from the preserved fruit themselves:
![image](https://user-images.githubusercontent.com/44811257/124779061-17ae5c00-df07-11eb-988c-cb7e1587b17a.png)


## Changelog
```changelog
tweak: Nobles now get 10x the starting amount, up from 5x.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

(just... ignore the changes to the comments)