### PR TITLE
Unathi Age Lore Compliance and Double Horn Fix

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -32,7 +32,7 @@
 	darksight = 3
 //	ambiguous_genders = TRUE
 	gluttonous = 1
-	slowdown = 0.15 // OCCULUS EDIT - Normalizing slowdown values
+	slowdown = 0.3
 	total_health = 125
 	brute_mod = 0.90	//syzygy edit
 	burn_mod = 0.90		//also edit

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -32,7 +32,7 @@
 	darksight = 3
 //	ambiguous_genders = TRUE
 	gluttonous = 1
-	slowdown = 0.3
+	slowdown = 0.15 // OCCULUS EDIT - Normalizing slowdown values
 	total_health = 125
 	brute_mod = 0.90	//syzygy edit
 	burn_mod = 0.90		//also edit
@@ -48,7 +48,7 @@
 //	species_language = LANGUAGE_UNATHI
 //	health_hud_intensity = 2.5
 
-	min_age = 32
+	min_age = 18 // OCCULUS EDIT - so now you can roleplay as someone who's not middle aged if you're just a unathi-based custom species
 	max_age = 260
 
 //	economic_modifier = 7

--- a/code/modules/sprite_accessories/sprite_accessories_vr.dm
+++ b/code/modules/sprite_accessories/sprite_accessories_vr.dm
@@ -416,7 +416,7 @@
 	icon = 'icons/mob/human_face_vr.dmi'
 	icon_state = "soghun_dubhorns"
 	do_colouration = 1
-	color_blend_mode = ICON_ADD
+	color_blend_mode = ICON_MULTIPLY
 
 /datum/sprite_accessory/ears/unathi_bighorn
 	name = "Unathi Horns Big"


### PR DESCRIPTION
## About The Pull Request
You can now set Unathi age from 18 to 260, so people who simply used the unathi as a base sprite for their custom species don't need to be middle aged now. Also we don't have any lore fleshing out Unathi age ranges to begin with, so meh.

Unathi double horns now properly render when selected as an ear as well, instead of being all white.

## Why It's Good For The Game

Fixing broken things, roleplaying.

## Changelog
```changelog Toriate
tweak: Unathi selectable age range has been normalized.
```
