### PR TITLE
Refactors the Church vat, Cryo, Some drugs, and a bunch of other small things

### DIFF
--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -50,8 +50,8 @@
 		return
 
 	if(occupant)
-		if(occupant.stat != DEAD)
-			process_occupant()
+		//if(occupant.stat != DEAD)Occulus Edit
+		process_occupant()
 
 	if(air_contents)
 		temperature_archived = air_contents.temperature
@@ -223,11 +223,15 @@
 	if(air_contents.total_moles < 10)
 		return
 	if(occupant)
-		if(occupant.stat == DEAD)
-			return
+		if(occupant.stat == DEAD)//Occulus Edit start
+			occupant.timeofdeath += 1
+		else
+			occupant.stat = UNCONSCIOUS
+
+		occupant.add_chemical_effect(CE_BLOODCLOT, 0.3)//Occulus Edit: Clotting effect
 		occupant.bodytemperature += 2*(air_contents.temperature - occupant.bodytemperature)*current_heat_capacity/(current_heat_capacity + air_contents.heat_capacity())
 		occupant.bodytemperature = max(occupant.bodytemperature, air_contents.temperature) // this is so ugly i'm sorry for doing it i'll fix it later i promise
-		occupant.stat = UNCONSCIOUS
+
 		if(occupant.bodytemperature < T0C)
 			occupant.sleeping = max(5, (1/occupant.bodytemperature)*2000)
 			occupant.Paralyse(max(5, (1/occupant.bodytemperature)*3000))

--- a/code/modules/core_implant/cruciform/machinery/obelisk.dm
+++ b/code/modules/core_implant/cruciform/machinery/obelisk.dm
@@ -70,6 +70,9 @@
 
 	var/list/affected_mobs = SSmobs.mob_living_by_zlevel[(get_turf(src)).z]
 
+	if(!active)
+		return
+
 	var/to_fire = max_targets
 	for(var/mob/living/A in affected_mobs)
 		if(!(get_dist(src, A) <= area_radius))
@@ -100,6 +103,8 @@
 	if(to_fire)//If there is anything else left, fuck up the plants
 		for(var/obj/effect/plant/shroom in GLOB.all_maintshrooms)
 			if(shroom.z == src.z && get_dist(src, shroom) <= area_radius)
+				bluespace_entropy(1, get_turf(shroom))//Occulus Edit, Obelisk feedback
+				playsound(shroom.loc, "sparks", 50, 1)//Occulus Edit, Obelisk feedback
 				qdel(shroom)
 				if(!--to_fire)
 					return

--- a/code/modules/core_implant/cruciform/machinery/vat.dm
+++ b/code/modules/core_implant/cruciform/machinery/vat.dm
@@ -191,6 +191,10 @@
 			victim.adjustBruteLoss(- 2 * (fluid_level / VAT_FLUID_STEP) * heal_modifier)
 		if(victim.getFireLoss() >= 50)
 			victim.adjustFireLoss(- 2  * (fluid_level / VAT_FLUID_STEP) * heal_modifier)
+		if(victim.getCloneLoss() > 0 && victim.get_core_implant(/obj/item/weapon/implant/core_implant/cruciform))
+			victim.adjustCloneLoss (-1 * (fluid_level / VAT_FLUID_STEP) * heal_modifier)
+			adjust_fluid_level(- 5)
+
 	// OCCULUS EDIT END
 		victim.adjustOxyLoss(- 2  * (fluid_level / VAT_FLUID_STEP) * heal_modifier)
 		victim.adjustToxLoss(- 1 * (fluid_level / VAT_FLUID_STEP) * heal_modifier)
@@ -307,6 +311,12 @@
 		if(CR)
 			I = CR
 			break
+
+	if(!I)//Occulus Edit: Check if someone has a cruciform
+		for(var/datum/stat/S in M.stats)//If they don't, penalize stats
+			var/reductionamount = min(S.value/5, 15)//20% or 15, whichever is lower
+			S -= reductionamount//Stats go dooown
+
 	if(I || M.stable_genes)
 		if(I)
 			I.activate()
@@ -317,6 +327,7 @@
 	else
 		if(M.genetic_corruption < 28) //Even if you had no organs missing and just bled out, don't expect to wake up non-mutated
 			M.genetic_corruption += 28
+			corrupt_dna(victim)
 		M.Weaken(rand(10, 25))
 		M.updatehealth()
 		M.sanity.level = 0
@@ -338,10 +349,11 @@
 	if (user.incapacitated(INCAPACITATION_DEFAULT))
 		return
 	if (victim)
-		user_unbuckle_mob(user)
-		if(ishuman(victim))
+		if(istype(victim, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = victim
 			H.stable_genes = FALSE
+			H.genetic_corruption = 0
+		user_unbuckle_mob(user)
 		return
 /*	if(fluid_level < VAT_FILL_FULL)
 		fluid_level += VAT_FLUID_STEP
@@ -371,16 +383,17 @@
 			break
 	var/corruption_points = 0
 	if(!C && !H.stable_genes)
-		corruption_points = H.genetic_corruption/7
+		corruption_points = H.genetic_corruption
 	else
-		corruption_points = H.genetic_corruption/28 //CHURCH DISCOUNT YEEEEEEEEEEEEEEEEEEAH
-		testing("CHURCH DISCOUNT")
-	if(corruption_points <= 3) //Essentially, regenerating a head shall be safer
+		corruption_points = H.genetic_corruption/2 //The church is more resistant to genetic corruption
+	if(corruption_points <= 7) //If you have under 15 genetic corruption (30 for church members) you incur no penalty
 		return
 
-	while(corruption_points > 0)
-		scramble(TRUE, H, 20 + corruption_points * 2)
-		corruption_points -= 1
+	H.setCloneLoss(corruption_points-7)
+
+	//while(corruption_points > 0)
+	//	scramble(TRUE, H, 20 + corruption_points * 2)
+	//	corruption_points -= 1
 
 
 /obj/machinery/neotheology/clone_vat/attackby(obj/item/O, mob/user)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1664,7 +1664,7 @@ var/list/rank_prefix = list(\
 	var/obj/item/organ/internal/heart_organ = random_organ_by_process(OP_HEART)
 	var/obj/item/organ/internal/brain_organ = random_organ_by_process(BP_BRAIN)
 
-	if(!is_asystole() && !(heart_organ && brain_organ) || (heart_organ.is_broken() || brain_organ.is_broken()))
+	if(!(heart_organ && brain_organ) || (heart_organ.is_broken() || brain_organ.is_broken()))//Occulus Edit: is_asystole is ALWAYS going to get called on a dead mob. Because they are DEAD. DIMWITS
 		return 0
 
 	if(world.time >= (timeofdeath + NECROZTIME))
@@ -1676,14 +1676,14 @@ var/list/rank_prefix = list(\
 
 	if(health <= (HEALTH_THRESHOLD_DEAD - oxyLoss))
 		visible_message(SPAN_WARNING("\The [src] twitches a bit, but their body is too damaged to sustain life!"))
-		timeofdeath = 0
+		//timeofdeath = 0 Occulus yeet
 		return 0
 
 	visible_message(SPAN_NOTICE("\The [src] twitches a bit as their heart restarts!"))
 	pulse = PULSE_NORM
 	handle_pulse()
 	tod = null
-	timeofdeath = 0
+	//timeofdeath = 0 Occulus yeet
 	stat = UNCONSCIOUS
 	jitteriness += 3 SECONDS
 	updatehealth()

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -172,14 +172,14 @@
 
 /obj/item/organ/proc/handle_germ_effects()
 	//** Handle the effects of infections
-	var/antibiotics = owner.reagents.get_reagent_amount("spaceacillin")
+	var/antibiotics = owner.reagents.get_reagent_amount("spaceacillin") + owner.ingested.get_reagent_amount("spaceacillin")//Occulus Edit: spacae pills should work again
 
 	if (germ_level > 0 && germ_level < INFECTION_LEVEL_ONE/2 && prob(30))
 		germ_level--
 
 	if (germ_level >= INFECTION_LEVEL_ONE/2)
 		//aiming for germ level to go from ambient to INFECTION_LEVEL_TWO in an average of 15 minutes
-		if(antibiotics < 5 && prob(round(germ_level/6)))
+		if(antibiotics < 1 && prob(round(germ_level/6)))//Occulus Edit: Any amount of antibiotics will work as long as you have them in you.
 			germ_level++
 
 	if(germ_level >= INFECTION_LEVEL_ONE)
@@ -188,7 +188,7 @@
 
 	if (germ_level >= INFECTION_LEVEL_TWO)
 		//spread germs
-		if (antibiotics < 5 && parent.germ_level < germ_level && ( parent.germ_level < INFECTION_LEVEL_ONE*2 || prob(30) ))
+		if (antibiotics < 1 && parent.germ_level < germ_level && ( parent.germ_level < INFECTION_LEVEL_ONE*2 || prob(30) ))//Occulus edit: Any amount of antibiotics will work as long as you have them in you
 			parent.germ_level++
 
 		if (prob(3))	//about once every 30 seconds
@@ -234,9 +234,9 @@
 /obj/item/organ/proc/handle_antibiotics()
 	var/antibiotics = 0
 	if(owner)
-		antibiotics = owner.reagents.get_reagent_amount("spaceacillin")
+		antibiotics = owner.reagents.get_reagent_amount("spaceacillin") + owner.ingested.get_reagent_amount("spaceacillin")
 
-	if (!germ_level || antibiotics < 5)
+	if (!germ_level || antibiotics < 1)//Occulus Edit: You only need 1u of antibiotics for them to work as long as they last
 		return
 
 	if (germ_level < INFECTION_LEVEL_ONE)

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -149,6 +149,7 @@
 	color = "#8080FF"
 	metabolism = REM * 0.5
 	scannable = 1
+	affects_dead = 1//Occulus Edit
 
 /datum/reagent/medicine/cryoxadone/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(M.bodytemperature < 170)
@@ -168,6 +169,7 @@
 	color = "#80BFFF"
 	metabolism = REM * 0.5
 	scannable = 1
+	affects_dead = 1//Occulus Edit
 
 /datum/reagent/medicine/clonexadone/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(M.bodytemperature < 170)
@@ -177,6 +179,8 @@
 		M.heal_organ_damage(3 * effect_multiplier, 3 * effect_multiplier, 5 * effect_multiplier, 5 * effect_multiplier)
 		M.adjustToxLoss(-(3 + (M.getToxLoss() * 0.05)) * effect_multiplier)
 		M.add_chemical_effect(CE_PULSE, -2)
+		if(M.stat == DEAD)//Occulus Edit
+			M.timeofdeath += 20//Occulus Edit
 
 /* Painkillers */
 

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -25531,6 +25531,7 @@
 /obj/machinery/camera/network/third_section{
 	dir = 4
 	},
+/obj/structure/medical_stand,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/neotheology/storage)
 "bhD" = (
@@ -25538,6 +25539,10 @@
 	dir = 8;
 	pixel_x = 22
 	},
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/item/weapon/reagent_containers/blood/OMinus,
+/obj/structure/closet/crate/freezer,
+/obj/item/weapon/tank/anesthetic,
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/neotheology/storage)
 "bhE" = (
@@ -30547,6 +30552,9 @@
 /area/eris/rnd/lab)
 "btd" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/structure/sink/kitchen{
+	pixel_y = 26
+	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/bioreactor)
 "bte" = (
@@ -44550,6 +44558,7 @@
 	pixel_y = 6
 	},
 /obj/structure/table/woodentable,
+/obj/item/weapon/storage/fancy/egg_box,
 /turf/simulated/floor/wood,
 /area/eris/neotheology/storage)
 "bZn" = (
@@ -75478,6 +75487,7 @@
 "dtS" = (
 /obj/structure/table/standard,
 /obj/item/weapon/storage/box/beakers,
+/obj/item/weapon/storage/pill_bottle/spaceacillin,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/medbay)
 "dtT" = (
@@ -108789,6 +108799,12 @@
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engine_room)
+"vhV" = (
+/obj/structure/table/woodentable,
+/obj/item/weapon/storage/firstaid/regular,
+/obj/item/weapon/storage/pill_bottle/spaceacillin,
+/turf/simulated/floor/tiled/dark/cargo,
+/area/eris/neotheology/chapelritualroom)
 "vjd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/carpet,
@@ -163244,7 +163260,7 @@ ccU
 ccU
 byQ
 ccU
-cBm
+vhV
 cBm
 uly
 ccU

--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -19,7 +19,7 @@ Used In File(s): \code\game\machinery\cryo.dm
 			{{/if}}
 		</div>
 	
-		{{if data.occupant.stat < 2}}
+		{{if data.occupant.stat < 3}}
 			<div class="line">
 				<div class="statusLabel">Health:</div>
 				{{:helper.displayBar(data.occupant.health, 0, data.occupant.maxHealth, data.occupant.health >= 0 ? 'good' : 'average', helper.round(data.occupant.health))}}

--- a/zzzz_modular_occulus/code/modules/clothing/suit/suits.dm
+++ b/zzzz_modular_occulus/code/modules/clothing/suit/suits.dm
@@ -118,16 +118,19 @@
 	name = "solgov NCO dress unfirom"
 	icon_state = "whitedress_snco"
 	item_state = "whitedress_snco"
+	desc = "A dress uniform worn by members of the solgov navy. Typically at formal events."
 
 /obj/item/clothing/suit/storage/solgov/wo
 	name = "solgov Warrent Officer dress uniform"
 	icon_state = "whitedress_wo"
 	item_state = "whitedress_wo"
+	desc = "A dress uniform worn by members of the solgov navy. Typically at formal events. This one is styled in warrent officer colors."
 
 /obj/item/clothing/suit/storage/solgov/ltcdr
 	name = "solgov Officer dress uniform"
 	icon_state = "whitedress_comm"
 	item_state = "whitedress_comm"
+	desc = "A dress uniform worn by members of the solgov navy. Typically at formal events. This one is styled in officer colors."
 
 /obj/item/clothing/suit/space/captain
 	name = "captain's armor"

--- a/zzzz_modular_occulus/code/modules/loadout/lists/suits.dm
+++ b/zzzz_modular_occulus/code/modules/loadout/lists/suits.dm
@@ -26,14 +26,17 @@
 
 /datum/gear/suit/solgovdress
 	display_name = "solgov dress jacket"
+	path = /obj/item/clothing/suit/storage/solgov/dressnco
 	cost = 1
 
 /datum/gear/suit/solgovdresswo
 	display_name = "solgov warrant officer dress jacket"
 	allowed_roles = list(JOBS_SECURITY)
 	cost = 1
+	path = /obj/item/clothing/suit/storage/solgov/wo
 
 /datum/gear/suit/solgovdressco
 	display_name = "solgov commander dress jacket"
 	allowed_roles = list(JOBS_COMMAND)
 	cost = 1
+	path = /obj/item/clothing/suit/storage/solgov/ltcdr


### PR DESCRIPTION
## About The Pull Request

This PR does a major rebalance on church and medical revival, as well as touching on a few other minor related issues.

- The Genetic shuffle for the Wine Bath is completely removed.
- The Wine Bath now causes minor genetic damage to people who are revived or have limbs restored in it. The amount of damage depends on how much of your body is regenerated, and if you were revived from death or not.
- The Wine Bath now reduces the skills slightly of non-faithful who are revived by it.
- Mekhane Faithful now heal genetic damage in the winebath.
- Nanotrasen's Cryotubes now slowly repair even the most greviously deceased bodies.
- Clonedextrone now slowly increments your death timer, eventually allowing you to be revived if you spend long enough in a cryotube.
- Spacaecillin now works orally
- Spacaecillin now works down to a single unit. As opposed to requiring five to even function.
- Obelisks no longer zap things if there are no mekhane members around.
- Obelisks now have feedback for zapping mushrooms
- The Resuscitator actually works now
- Cryo tubes now show how much damage you have even if you are dead.
- The church has exchanged some of their free oddities spawners for medical equipment, including a medical stand and anesthetic tank in the acolyte room.
- Both the church and medical now start with a bottle of Spacaecillin pills
- A certain lovable fox has left her big dumb wolf friend a box of snacks in the church dorms.

## Why It's Good For The Game

Hopefully this will be a fair-feeling rebalance between the greatest discrepencies we've had between Medical and MEK. MEK, while capable of medical aid, should really not completely outclass them in any field as the focus of MEK is on food production, tending to their own members, and cleaning.

## Changelog
```changelog
balance: The wine bath genetic shuffle has been completely refactored
balance: The wine bath now reduces the stats of non-faithful who are revived by it 
balance: Cryotubes now restore the dead to workable condition
balance: Cryotubes now stop bleeding
balance: Clonedextrone now reverses death timers.
balance: Spacaecillin now works orally, and in any amount as opposed to 5.
fix: Obelisks no longer zap creatures if the faithful are not present
fix: The Resussicator reagent actually functions on the dead now.
fix: Solgov has stopped issuing "Blue" Aprons as dress uniforms.
tweak: The church has lost two low chance oddity spawners and now has some basic medical equipment.
tweak: Both the church and NT now start with a guaranteed spacaecillin spawn.
tweak: Cryotubes now always show how badly injured the occupant is.
tweak: A present has been left by a certain custodian in the mekhane dorms.
tweak: Obelisks now have feedback for zapping mushrooms.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
