### PR TITLE
Elevator bug fixes!

### DIFF
--- a/zzzz_modular_occulus/code/game/machinery/dorms_elevator.dm
+++ b/zzzz_modular_occulus/code/game/machinery/dorms_elevator.dm
@@ -204,14 +204,13 @@
 	var/obj/machinery/computer/cryopod/elevator_storage/lostFound
 
 /obj/machinery/button/remote/elevator_call_button/trigger()
-	for(var/obj/machinery/computer/cryopod/elevator_storage/storage in range(usr, 5))
-		lostFound = storage
 	for(var/obj/machinery/door/airlock/D in range(src, 5))
 		if (D.id_tag == id && D.locked) //Gotta check if the airlock is locked. This is how we know whether the elevator is at our floor or at the dorms.
 			for (var/obj/item/W in get_area(D)) // For every item inside the elevator area... (The area that the elevator airlock is in)
 				if (!istype(W, /obj/item/device/radio/intercom)) //Stop eating my fucking intercom you cockwaffle
-					W.forceMove(lostFound) // Move the items to the lost and found in order to clean up the elevator.
-					lostFound.frozen_items += W // And add them to the inventory list.
+					for (lostFound in range(usr, 5)) // Get any Lost and Found units within 5 tiles...
+						W.forceMove(lostFound) // Move the items to the lost and found unit in order to clean up the elevator.
+						lostFound.frozen_items += W // And add them to the inventory list.
 			for(var/obj/machinery/button/remote/elevator_panel/B in range(src, 5))
 				if (B.elevator_moving == FALSE) //If the elevator is no longer moving I.E., the timer it sets has finished, then we are ready to call it back down.
 					if(world.time - cooldown_timer > cooldown)

--- a/zzzz_modular_occulus/code/game/machinery/dorms_elevator.dm
+++ b/zzzz_modular_occulus/code/game/machinery/dorms_elevator.dm
@@ -4,26 +4,43 @@
 
 /obj/machinery/button/remote/elevator_panel/proc/despawn_passenger(var/mob/living/user)
 	var/mob/living/passenger = user
-	//var/mob/living/carbon/human/passengerplayer = user
+	var/obj/machinery/computer/cryopod/elevator_storage/lostFound
 
-	for(var/obj/item/W in passenger)
-		if (istype(W, /obj/item/modular_computer/pda))
-			var/obj/item/modular_computer/pda/found_pda = W
-			found_pda.eject_id()
-		else if (istype(W, /obj/item/weapon/implant))
-			var/obj/item/weapon/implant/found_implant = W
-			found_implant.uninstall()
-			qdel(found_implant)
-		else if (istype(W, /obj/item/weapon/storage || /obj/item/clothing/suit/storage))
-			for(var/T in preserve_items)
-				for (var/obj/item/w_storage in W.contents)
-					if (istype(w_storage, T))
-						passenger.drop_from_inventory(w_storage)
+	for(var/obj/machinery/computer/cryopod/elevator_storage/D in range(usr, 5))
+		lostFound = D
+	for(var/obj/item/W in passenger) // For every object (that we call W) on the passenger...
+		if (istype(W, /obj/item/modular_computer/pda)) // If the object is a PDA...
+			var/obj/item/modular_computer/pda/found_pda = W // Give it the "found_pda" variable...
+			if (found_pda.card_slot.stored_card != null && istype(found_pda.card_slot.stored_card, /obj/item/weapon/card/id/captains_spare)) // Check that there is an ID inside AND it is the captain's spare...
+				found_pda.card_slot.stored_card.forceMove(lostFound) // If so, move it to the Lost and Found unit.
+			else if (found_pda.card_slot.stored_card != null) // If the ID is NOT a captain's spare, but there is an ID inside the PDA...
+				var/obj/item/weapon/card/id/PDA_ID = found_pda.card_slot.stored_card // This is required to get qdel to work...
+				found_pda.card_slot.stored_card = null // Set it to NULL (or else it won't delete properly...)
+				qdel(PDA_ID) // And delete it.
+		else if (istype(W, /obj/item/weapon/implant)) // If the object is an implant...
+			var/obj/item/weapon/implant/found_implant = W // Give it a variable name...
+			found_implant.uninstall() // Uninstall first, since we can't delete it without doing this first...
+			qdel(found_implant) // Then delete it.
+		else if (istype(W, /obj/item/weapon/storage || /obj/item/clothing/suit/storage)) //If the object is either a bag or suit with storage...
+			for(var/T in preserve_items) // We assign every preserved item to the variable T...
+				for (var/obj/item/w_storage in W.contents) //We assign the variable "w_storage" to every singe item inside the bag or suit...
+					if (istype(w_storage, /obj/item/weapon/storage)) // If the item in the bag turns out to be a storage container...
+						for (var/obj/item/ww_storage in w_storage.contents) // We assign all items inside the storage container to "ww_storage"...
+							if (istype(ww_storage, T)) // Check if the item in that container is part of the preserved items...
+								passenger.drop_from_inventory(ww_storage) // If so, drop it.
+								ww_storage.forceMove(lostFound) // Then move it to the Lost and Found unit.
+								lostFound.frozen_items += ww_storage // And add it to the list of currently inventoried items.
+					else if (istype(w_storage, T)) // If it is not a storage container, check if it's a preserved item...
+						passenger.drop_from_inventory(w_storage) // Drop it.
+						w_storage.forceMove(lostFound) // And move it to the Lost and Found unit.
+						lostFound.frozen_items += w_storage // And add it to the list of currently inventoried items.
 						continue
 		else
-			for(var/T in preserve_items)
-				if(istype(W, T))
-					passenger.drop_from_inventory(W)
+			for(var/T in preserve_items) // If the object is not a PDA, implant, suit, vest or storage container...
+				if(istype(W, T)) // And is part of the preserved list...
+					passenger.drop_from_inventory(W) // Drop it.
+					W.forceMove(lostFound) // Then move it to the Lost and Found unit.
+					lostFound.frozen_items += W // And add it to the list of currently inventoried items.
 					continue
 
 	log_and_message_admins("[key_name(passenger)]" + "[passenger.mind ? " ([passenger.mind.assigned_role])" : ""]" + " ended their shift via the elevator to the dormitories.")
@@ -33,7 +50,7 @@
 
 	//When the passenger is put into storage, their respawn time is reduced.
 	//This check exists for the benefit of people who get put into cryostorage while SSD and come back later
-	if (passenger.in_perfect_health())
+	if (passenger.in_perfect_health()) //None of this shit works, but I'm too scared to remove it...
 		if (passenger.mind && passenger.mind.key)
 			//Whoever inhabited this body is long gone, we need some black magic to find where and who they are now
 			var/mob/M = key2mob(passenger.mind.key)
@@ -49,6 +66,32 @@
 	// This despawn is not a gib() in this sense, it is used to remove objectives tied on these despawned mobs in cryos
 	passenger.despawn()
 
+
+//// This code is for the elevator lost and found unit.
+
+/obj/machinery/computer/cryopod/elevator_storage
+	name = "Elevator Lost and Found Unit"
+	desc = "An interface that sweeps up any lost and found items from the elevator and stores them for easy retrieval."
+	icon = 'icons/obj/Cryogenic2.dmi'
+	icon_state = "cellconsole"
+	light_power = 1.5
+	light_color = COLOR_LIGHTING_BLUE_MACHINERY
+	density = FALSE
+	interact_offline = 1
+	var/list/preserve_items = list(
+		/obj/item/weapon/hand_tele,
+		/obj/item/weapon/card/id/captains_spare,
+		/obj/item/device/aicard,
+		/obj/item/device/mmi,
+		/obj/item/device/paicard,
+		/obj/item/weapon/gun,
+		/obj/item/weapon/pinpointer,
+		/obj/item/clothing/suit,
+		/obj/item/clothing/shoes/magboots,
+		/obj/item/blueprints,
+		/obj/item/clothing/head/space,
+		/obj/item/weapon/storage/internal
+		)
 
 
 //// This code is for the buttons and airlock in the elevator in the dorms area that offers players
@@ -158,10 +201,17 @@
 	desc = "An button used to call the elevator down to the current floor."
 	var/cooldown = 24 SECONDS
 	var/cooldown_timer
+	var/obj/machinery/computer/cryopod/elevator_storage/lostFound
 
 /obj/machinery/button/remote/elevator_call_button/trigger()
+	for(var/obj/machinery/computer/cryopod/elevator_storage/storage in range(usr, 5))
+		lostFound = storage
 	for(var/obj/machinery/door/airlock/D in range(src, 5))
 		if (D.id_tag == id && D.locked) //Gotta check if the airlock is locked. This is how we know whether the elevator is at our floor or at the dorms.
+			for (var/obj/item/W in get_area(D)) // For every item inside the elevator area... (The area that the elevator airlock is in)
+				if (!istype(W, /obj/item/device/radio/intercom)) //Stop eating my fucking intercom you cockwaffle
+					W.forceMove(lostFound) // Move the items to the lost and found in order to clean up the elevator.
+					lostFound.frozen_items += W // And add them to the inventory list.
 			for(var/obj/machinery/button/remote/elevator_panel/B in range(src, 5))
 				if (B.elevator_moving == FALSE) //If the elevator is no longer moving I.E., the timer it sets has finished, then we are ready to call it back down.
 					if(world.time - cooldown_timer > cooldown)
@@ -175,7 +225,7 @@
 						update_icon() //While technically no IC players will ever see the panel change as it's coming back down, ghosts will. It's a small addition but it makes the world feel that little bit more alive.
 						sleep(35)
 						B.icon_state = "elevator_panel_floor4"
-						update_icon()
+						update_icon() // Additionally, this seemingly useless part should not be removed as a future update may possibly include players coming down the elevator on spawn.
 						sleep(32)
 						B.icon_state = "elevator_panel_floor3"
 						update_icon()
@@ -186,7 +236,7 @@
 						B.icon_state = "elevator_panel_floor1"
 						update_icon()
 						sleep(40)
-						for(D in range(src, 5))
+						for(D in range(src, 5)) // On arrival, unlock the airlock and open it as an elevator would once it arrives to a floor.
 							if (D.id_tag == id)
 								D.unlock()
 								sleep(15)
@@ -206,13 +256,13 @@
 //// This is the code for the elevator area.
 
 /area/eris/elevator
-	name = "elevator"
+	name = "Elevator"
 	sound_env = SMALL_SOFTFLOOR
 	forced_ambience = list('zzzz_modular_occulus/sound/ambience/elevatormusic.ogg')
 	requires_power = FALSE
-	flags = AREA_FLAG_CRITICAL //A departure area is a critical area and should be protected.
+	flags = AREA_FLAG_CRITICAL //A departure area is a critical area and should be protected. Edit: This does fuck-all lmfao
 
 /area/eris/elevator/Entered(A)
 	..()
-	if(isliving(A))
+	if(isliving(A)) // Don't spam ghosts with this message. Only living players.
 		to_chat(usr, SPAN_DANGER("WARNING!! You will be ghosted and removed from the round while inside the elevator if someone else in the elevator presses the elevator button. Leave the elevator immediately if you do not want to risk being removed from the current round."))


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR fixes one of the main issues the elevator had: Not deleting IDs.

- The elevator will now check to see if your ID is the captain's spare, and if it is not, it will delete the ID correctly without dropping it like it used to.
- Any reserved items the player may have on them will now get put into a Lost and Found unit on the outside of the elevator rather than dropped to the floor.
- The elevator will now clean up all items dropped inside it (except for the intercom obviously) and put them into the Lost and Found unit outside the elevator. Do keep in mind that the clean up process is called when the elevator is called DOWN, i.e., when someone presses the call elevator button outside the elevator.
- Additionally did some commenting and made some of the code a little cleaner and easier to read.

This is part 2 of the elevator addition. Part 3 will come soon, and will include some small easter eggs, an emag option for the elevator and POSSIBLY (if I can figure out how to code it without pulling my hear out) a system that allows players to join via coming down the elevator in order to improve immersion. More info on this will probably be discussed during a future emojicracy, as this will possibly make spawn in times via the elevator slower, or potentially not possible if the elevator is broken IG.

**| | | NERD STUFF FOR JAMS TO READ | | |**

You need to map in a wall and a console to the north of the elevator, and give the console a **specific Y-nudge of 32** in order to follow the same standard as the other panels on the ship.

![image](https://user-images.githubusercontent.com/45645502/127713083-8ca687ac-20a7-49cc-a824-065b1768c45f.png)

![image](https://user-images.githubusercontent.com/45645502/127713097-146e0aa4-bbc4-4dc7-8443-54d714c65362.png)

Here's an example of what it should look like!!!!!

![image](https://user-images.githubusercontent.com/45645502/127713114-e9a43321-9138-4182-9fad-82e4a67cf81d.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

People won't be able to nab other people's dropped IDs and use them. The code is easy to read and understand.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
add: A cleanup system for the elevator that makes it not be a disgusting mess several hours into a shift.
fix: Fixed a bug where ID cards were getting dropped rather than being deleted.
spellcheck: Capitalized the Elevator area, so that it is capitalized similarly to all other areas.
code: Commented a lot of the elevator code for easy reading and understanding.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
