### PR TITLE
nerfs the cube.

### DIFF
--- a/code/game/objects/items/devices/techno_tribalism.dm
+++ b/code/game/objects/items/devices/techno_tribalism.dm
@@ -62,8 +62,8 @@
 
 				for(var/quality in W.tool_qualities)
 
-					if(W.tool_qualities[quality] >= 35)
-						var/stat_cost = round(W.tool_qualities[quality] / 15)
+					if(W.tool_qualities[quality] >= 30)//Occulus Edit
+						var/stat_cost = round(W.tool_qualities[quality] / 25)//Occulus Edit
 						if(quality == QUALITY_BOLT_TURNING || quality == QUALITY_SCREW_DRIVING || quality == QUALITY_CUTTING)
 							oddity_stats[STAT_COG] += stat_cost
 							useful = TRUE


### PR DESCRIPTION
## About The Pull Request

Slightly nerfs the cube due to it giving oddities with up to 20 in a particular stat if minmaxed. now they are more in-line with other oddities.

## Why It's Good For The Game

This has been a long time coming. I've got plans to add soft caps to stats soon too.

## Changelog
```changelog
balance: The Cube now accepts items with 30 or more in a quality, and gives 1 stat per 20 of that quality (rounded down)
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
