### PR TITLE
Fixes makeshift AK not appearing in gun crafting.

### DIFF
--- a/code/datums/craft/recipes/guns.dm
+++ b/code/datums/craft/recipes/guns.dm
@@ -98,13 +98,3 @@
 		list(CRAFT_MATERIAL, 10, MATERIAL_WOOD),
 		list(QUALITY_HAMMERING, 10)
 	)
-// start nonmodular occulus edit
- /datum/craft_recipe/gun/guns_craft_frame //occulus edit: originally in misc.dm as /datum/craft_recipe/gun/guns_craft_frame - bear
-	name = "Gun assembly"
-	result = /obj/item/craft_frame/guns
-	steps = list(
-		list(CRAFT_MATERIAL, 5, MATERIAL_PLASTEEL, "time" = 30),
-		list(QUALITY_WELDING, 10, 10)
-	)
-	related_stats = list(STAT_MEC)
-// end nonmodular occuluis edit

--- a/code/datums/craft/recipes/misc.dm
+++ b/code/datums/craft/recipes/misc.dm
@@ -292,13 +292,11 @@
 	name = "Makeshift prosthetic right arm"
 	result = /obj/item/organ/external/robotic/makeshift/r_arm*/
 
-//start nonmodular occulus edit
-/* /datum/craft_recipe/guns_craft_frame Occulus Edit: This is now under gun.dm as /datum/craft_recipe/gun/guns_craft_frame
+ /datum/craft_recipe/gun/guns_craft_frame
 	name = "Gun assembly"
 	result = /obj/item/craft_frame/guns
 	steps = list(
 		list(CRAFT_MATERIAL, 5, MATERIAL_PLASTEEL, "time" = 30),
 		list(QUALITY_WELDING, 10, 10)
 	)
-	related_stats = list(STAT_MEC) */
-//END nonmodular occulus edit
+	related_stats = list(STAT_MEC)


### PR DESCRIPTION
## About The Pull Request

Fixes makeshift AK not appearing in gun crafting. For...some reason, it wasn't appearing when the gun assembly crafting was in the same file...?? I'm honestly kind of stumped. Matched it with Eris' crafting files and it works fine, now. I got no idea, dude.

## Why It's Good For The Game

things working as intended is a good thing.
![image](https://user-images.githubusercontent.com/54826962/128335043-9c966386-6726-4bc0-8ab3-e1c855a24a82.png)
![image](https://user-images.githubusercontent.com/54826962/128335075-83bddafa-a615-41eb-af89-273a5a8508ec.png)


## Changelog
```changelog
tweak: moved gun assembly to misc
fix: makeshift AK craftable now
```