### PR TITLE
Fixes orphaned Sending Trade Beacon circuit board. 

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -3056,6 +3056,7 @@
 #include "zzzz_modular_occulus\code\modules\telescience\telepad_computer.dm"
 #include "zzzz_modular_occulus\code\modules\telescience\telepad_relay.dm"
 #include "zzzz_modular_occulus\code\modules\telescience\teleport_blocker.dm"
+#include "zzzz_modular_occulus\code\modules\trade\machinery\circuits\trade_beacon.dm"
 #include "zzzz_modular_occulus\maps\submaps\deepmaint_rooms\core\core_rooms.dm"
 #include "zzzz_modular_occulus\maps\submaps\deepmaint_rooms\normal\normal_rooms.dm"
 #include "zzzz_modular_occulus\prosthesis\implementation.dm"

--- a/code/modules/trade/machinery/circuits/trade_beacon.dm
+++ b/code/modules/trade/machinery/circuits/trade_beacon.dm
@@ -9,6 +9,6 @@
 	name = T_BOARD("receiving trade beacon")
 	build_path = /obj/machinery/trade_beacon/receiving
 
-/obj/item/weapon/electronics/circuitboard/sending_beacon
+/obj/item/weapon/electronics/circuitboard/trade_beacon/sending // Occulus Edit
 	name = T_BOARD("sending trade beacon")
 	build_path = /obj/machinery/trade_beacon/sending

--- a/zzzz_modular_occulus/code/modules/trade/machinery/circuits/trade_beacon.dm
+++ b/zzzz_modular_occulus/code/modules/trade/machinery/circuits/trade_beacon.dm
@@ -1,0 +1,3 @@
+/obj/item/weapon/electronics/circuitboard/trade_beacon
+    name = T_BOARD("trade beacon")
+    build_path = /obj/machinery/trade_beacon


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes a broken object path that meant the sending beacon did not inherit traits from /obj/item/weapon/electronics/circuitboard/trade_beacon

Also fixes #627 by adding a name and build path. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Fixes a runtime, and also allows people to properly build a sending trade beacon if wanted.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
fix: fixed sending trade beacon circuit file path
fix: fixed base trade beacon circuit runtiming when being used in construction
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
