### PR TITLE
Update blattedin.dm

### DIFF
--- a/code/modules/mob/living/carbon/superior_animal/roach/blattedin.dm
+++ b/code/modules/mob/living/carbon/superior_animal/roach/blattedin.dm
@@ -7,7 +7,7 @@
 	color = "#0F4800"
 	strength = 0.15
 	var/heal_strength = 5
-	metabolism = REM * 0.1
+	metabolism = REM//Quick and dirty Occulus Edit
 
 	heating_point = T0C + 260
 	heating_products = list("carbon", "protein")


### PR DESCRIPTION
## About The Pull Request

Prevents Blattedin from getting stuck in internal mob reagent processes

## Why It's Good For The Game

REM is not supposed to be multiplied by fractional numbers. Going too low in your metabolism rate breaks certain chems. This is a hotfix for blattedin specifically.

Generally you can go to REM * 0.25 before things get really wonky, but even then we really shouldn't be reducing metabolism AT ALL. And whoever changed this initially was extremely foolish

## Changelog
```changelog
fix: Blattedin no longer should get stuck processing in mobs.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
