### PR TITLE
Removes the non-Mekhane biogenerator for lore and gameplay reasons

### DIFF
--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -1,4 +1,4 @@
-/obj/machinery/biogenerator
+/* /obj/machinery/biogenerator OCCULUS EDIT. Comments out the non-Mekhane Biogenerator for lore reasons
 	name = "Biogenerator"
 	desc = ""
 	icon = 'icons/obj/biogenerator.dmi'
@@ -260,3 +260,4 @@
 
 	build_eff = man_rating
 	eat_eff = bin_rating
+*/

--- a/code/game/objects/items/weapons/circuitboards/machinery/biogenerator.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/biogenerator.dm
@@ -1,4 +1,4 @@
-/obj/item/weapon/electronics/circuitboard/biogenerator
+/* /obj/item/weapon/electronics/circuitboard/biogenerator OCCULUS EDIT. Comments out the non-Mekhane Biogenerator for lore reasons
 	name = T_BOARD("biogenerator")
 	build_path = /obj/machinery/biogenerator
 	board_type = "machine"
@@ -8,3 +8,4 @@
 		/obj/item/weapon/stock_parts/matter_bin = 1,
 		/obj/item/weapon/stock_parts/manipulator = 1
 	)
+*/

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -42,7 +42,7 @@
 		/mob/living/simple_animal/hostile/retaliate/goat,
 		/obj/machinery/sleeper,
 		/obj/machinery/smartfridge/,
-		/obj/machinery/biogenerator,
+		//obj/machinery/biogenerator,OCCULUS EDIT. Comments out the non-Mekhane Biogenerator for lore reasons
 		/obj/machinery/constructable_frame,
 		/obj/machinery/radiocarbon_spectrometer,
 		/obj/machinery/centrifuge,

--- a/code/modules/research/designs/circuits.dm
+++ b/code/modules/research/designs/circuits.dm
@@ -331,11 +331,11 @@
 	sort_string = "KAAAB"
 	category = CAT_COMP
 
-/datum/design/research/circuit/biogenerator
+/* /datum/design/research/circuit/biogenerator OCCULUS EDIT. Comments out the non-Mekhane Biogenerator for lore reasons
 	name = "biogenerator"
 	build_path = /obj/item/weapon/electronics/circuitboard/biogenerator
 	sort_string = "KBAAA"
-	category = CAT_MEDI
+	category = CAT_MEDI */
 
 /datum/design/research/circuit/miningdrill
 	name = "mining drill head"

--- a/code/modules/research/nodes/biotech.dm
+++ b/code/modules/research/nodes/biotech.dm
@@ -75,7 +75,7 @@
 	required_tech_levels = list()
 	cost = 400
 
-	unlocks_designs = list(	/datum/design/research/circuit/biogenerator,
+	unlocks_designs = list(	//datum/design/research/circuit/biogenerator, OCCULUS EDIT. Comments out the non-Mekhane Biogenerator for lore reasons
 							/datum/design/research/item/weapon/flora_gun)
 
 /datum/technology/portable_chemistry


### PR DESCRIPTION
## About The Pull Request

Removes the biogenerator that isn't the Mekhane one. This is essentially a legacy machine that is still in the code and does not fit our lore

## Why It's Good For The Game

Keeps the Church relevant and conforms to our lore of Mekhane being the only organization capable of large scale biomatter manipulation like that

## Changelog
```changelog Cebutris
del: the old biogenerator has been taken out behind the tech-shed
```
