### PR TITLE
Maint loot tweaks

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -3257,6 +3257,8 @@
 "aid" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/table/standard,
+/obj/item/weapon/inflatable_duck,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
 "aie" = (
@@ -3273,7 +3275,6 @@
 	pixel_y = 28
 	},
 /obj/item/weapon/stool/padded,
-/obj/spawner/toy/plushie,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
 "aig" = (
@@ -3284,6 +3285,7 @@
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/personal,
+/obj/spawner/toy/plushie,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/eris/crew_quarters/sleep)
 "aih" = (
@@ -4567,8 +4569,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
 "ald" = (
-/obj/item/weapon/inflatable_duck,
-/turf/simulated/floor/exoplanet/water/shallow,
+/obj/structure/bed/padded,
+/turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
 "ale" = (
 /obj/structure/table/rack/shelf,
@@ -4883,7 +4885,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/spawner/toy/plushie,
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
@@ -107371,6 +107372,7 @@
 /area/space)
 "pMN" = (
 /obj/machinery/camera/network/fist_section,
+/obj/structure/bed/padded,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
 "pPE" = (
@@ -109410,6 +109412,11 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
+"wpU" = (
+/obj/structure/table/standard,
+/obj/spawner/toy/plushie,
+/turf/simulated/floor/tiled/steel,
+/area/eris/crew_quarters/sleep)
 "wqX" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -109506,6 +109513,13 @@
 /obj/landmark/join/start/assistant,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/clothingstorage)
+"wHl" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/bed/padded,
+/turf/simulated/floor/tiled/steel,
+/area/eris/crew_quarters/sleep)
 "wHO" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
@@ -123638,7 +123652,7 @@ agD
 agX
 aib
 agY
-acf
+ald
 wOc
 aia
 ajS
@@ -123840,10 +123854,10 @@ agD
 ahr
 aib
 ahH
-alD
+wHl
 wOc
 alR
-ald
+alR
 alR
 alR
 alR
@@ -124244,7 +124258,7 @@ agD
 ahr
 aib
 ahF
-acf
+wpU
 wOc
 ajc
 alx

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -66500,6 +66500,14 @@
 "cZW" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "CSOBedPriv";
+	layer = 2.6;
+	name = "CMO Bedroom Privacy Shutter";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/eris/command/meo/quarters)
 "cZX" = (
@@ -67282,6 +67290,14 @@
 "dcc" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "FOBedPriv";
+	layer = 2.6;
+	name = "First Officer Bedroom Privacy Shutter";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/eris/command/fo/quarters)
 "dcd" = (
@@ -69454,6 +69470,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/button/remote/blast_door{
+	id = "CSOBedPriv";
+	name = "CSO Bedroom Privacy Shutters";
+	pixel_x = -4;
+	pixel_y = -32
+	},
 /turf/simulated/floor/wood,
 /area/eris/command/meo/quarters)
 "dgQ" = (
@@ -69895,6 +69917,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/machinery/button/remote/blast_door{
+	id = "FOBedPriv";
+	name = "First Office Bedroom Privacy Shutters";
+	pixel_x = -4;
+	pixel_y = -32
+	},
 /turf/simulated/floor/carpet/blucarpet,
 /area/eris/command/fo/quarters)
 "dhC" = (
@@ -70272,6 +70300,14 @@
 "dit" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "CMOBedPriv";
+	layer = 2.6;
+	name = "CMO Bedroom Privacy Shutter";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/eris/command/mbo/quarters)
 "diu" = (
@@ -72023,6 +72059,12 @@
 /obj/item/weapon/storage/firstaid/regular{
 	pixel_x = -2;
 	pixel_y = 4
+	},
+/obj/machinery/button/remote/blast_door{
+	id = "CMOBedPriv";
+	name = "CMO Bedroom Privacy Shutters";
+	pixel_x = -4;
+	pixel_y = -32
 	},
 /turf/simulated/floor/wood,
 /area/eris/command/mbo/quarters)
@@ -104655,6 +104697,14 @@
 "hWM" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/firedoor,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "CMOBedPriv";
+	layer = 2.6;
+	name = "CMO Bedroom Privacy Shutter";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/eris/command/mbo/quarters)
 "iaa" = (
@@ -108504,7 +108554,7 @@
 "trr" = (
 /obj/machinery/button/remote/blast_door{
 	id = "RDPrivacy";
-	name = "Merchant Office Privacy Shutters";
+	name = "CSO Office Privacy Shutters";
 	pixel_x = -4;
 	pixel_y = -32
 	},

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -14362,6 +14362,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/spawner/pack/tech_loot/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5starboard)
 "aJh" = (
@@ -30413,9 +30414,10 @@
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/neotheology/bioreactor)
 "bth" = (
-/obj/spawner/junk/low_chance,
-/turf/simulated/floor/tiled/techmaint_panels,
-/area/eris/maintenance/section3deck1central)
+/obj/structure/table/standard,
+/obj/spawner/lowkeyrandom,
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section2deck4central)
 "bti" = (
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/eris/maintenance/section3deck1central)
@@ -30856,7 +30858,6 @@
 /area/eris/maintenance/section3deck1central)
 "buj" = (
 /obj/spawner/traps/low_chance,
-/obj/spawner/junk/low_chance,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/eris/maintenance/section3deck1central)
 "buk" = (
@@ -35125,10 +35126,9 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section4deck4central)
 "bEA" = (
-/obj/effect/floor_decal/industrial/warning,
-/obj/spawner/scrap/dense,
-/turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section4deck4central)
+/obj/spawner/pack/machine/low_chance,
+/turf/simulated/floor/tiled/steel/techfloor_grid,
+/area/eris/maintenance/section3deck4starboard)
 "bEB" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 4
@@ -52551,9 +52551,9 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/hallway/side/cryo)
 "csL" = (
-/obj/spawner/closet/low_chance,
-/turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section1deck4central)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/wall,
+/area/eris/maintenance/section3deck3starboard)
 "csM" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -61194,7 +61194,6 @@
 /area/eris/maintenance/section4deck3port)
 "cNf" = (
 /obj/structure/table/standard,
-/obj/spawner/pack/tech_loot,
 /obj/spawner/pack/tech_loot,
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/hallway/side/section3starboard)
@@ -75772,7 +75771,6 @@
 "duS" = (
 /obj/structure/table/standard,
 /obj/spawner/pack/tech_loot,
-/obj/spawner/pack/tech_loot,
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 26
@@ -84512,8 +84510,7 @@
 /area/eris/rnd/docking)
 "dOX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/window_lwall_spawn/smartspawn,
-/turf/simulated/floor/plating,
+/turf/simulated/wall,
 /area/eris/maintenance/section3deck3starboard)
 "dOY" = (
 /obj/machinery/door/airlock/maintenance_engineering{
@@ -85752,6 +85749,7 @@
 "dSb" = (
 /obj/structure/table/standard,
 /obj/item/weapon/paper_bin,
+/obj/spawner/pack/tech_loot/low_chance,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/eris/maintenance/section3deck3starboard)
 "dSc" = (
@@ -86597,9 +86595,9 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck2starboard)
 "dUi" = (
-/obj/machinery/holoposter{
-	pixel_x = 32
-	},
+/obj/structure/table/standard,
+/obj/item/device/lighting/toggleable/lamp,
+/obj/spawner/pack/tech_loot/low_chance,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/eris/maintenance/section3deck3starboard)
 "dUj" = (
@@ -88779,11 +88777,15 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/hallway/side/section3starboard)
 "dZh" = (
-/obj/structure/table/standard,
-/obj/spawner/pack/tech_loot,
-/obj/spawner/pack/tech_loot,
-/turf/simulated/floor/tiled/steel/gray_platform,
-/area/eris/hallway/side/section3starboard)
+/obj/structure/bed/chair{
+	dir = 1
+	},
+/obj/landmark/join/start/assistant,
+/obj/machinery/holoposter{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel/brown_perforated,
+/area/eris/maintenance/section3deck3starboard)
 "dZi" = (
 /obj/structure/table/standard,
 /obj/spawner/pack/tech_loot,
@@ -89533,7 +89535,6 @@
 /area/eris/maintenance/section3deck3starboard)
 "eaS" = (
 /obj/structure/table/standard,
-/obj/spawner/pack/gun_loot/low_chance,
 /obj/spawner/pack/gun_loot/low_chance,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/eris/maintenance/section3deck3starboard)
@@ -100744,6 +100745,7 @@
 	dir = 4
 	},
 /obj/structure/railing,
+/obj/spawner/mob/roaches/cluster/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "eAM" = (
@@ -100789,6 +100791,7 @@
 	dir = 4
 	},
 /obj/structure/railing,
+/obj/item/weapon/material/shard,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "eAP" = (
@@ -102370,6 +102373,7 @@
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/item/weapon/material/shard,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "eEr" = (
@@ -103643,6 +103647,10 @@
 /obj/item/ammo_magazine/ammobox/magnum/rubber,
 /turf/simulated/floor/tiled/dark/gray_perforated,
 /area/eris/command/bridge)
+"eWV" = (
+/obj/item/weapon/material/shard,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck1central)
 "eYw" = (
 /obj/machinery/firealarm{
 	pixel_y = 28
@@ -103702,6 +103710,11 @@
 /obj/spawner/traps,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck5central)
+"fcY" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/spawner/mob/roaches/cluster/low_chance,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck1central)
 "feG" = (
 /obj/machinery/light{
 	dir = 4;
@@ -103740,6 +103753,20 @@
 /obj/structure/railing/grey,
 /turf/simulated/open,
 /area/eris/crew_quarters/bar)
+"fkl" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/item/weapon/material/shard,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck1central)
 "flM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -103822,6 +103849,14 @@
 /obj/spawner/junk/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/security/prison)
+"fwz" = (
+/obj/structure/bed/chair,
+/obj/landmark/join/start/assistant,
+/obj/machinery/holoposter{
+	pixel_x = 32
+	},
+/turf/simulated/floor/tiled/steel/brown_perforated,
+/area/eris/maintenance/section3deck3starboard)
 "fyF" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -104011,6 +104046,14 @@
 /obj/item/weapon/bedsheet/blue,
 /turf/simulated/floor/wood,
 /area/eris/hallway/side/bridgehallway)
+"gns" = (
+/obj/machinery/door/airlock/maintenance_common{
+	locked = 1;
+	name = "Service Maintenance";
+	req_access = list(12)
+	},
+/turf/simulated/floor/tiled/techmaint_cargo,
+/area/eris/maintenance/section3deck1central)
 "gqG" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -104443,6 +104486,14 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/eris/engineering/atmoscontrol)
+"hBW" = (
+/obj/structure/table/rack/shelf,
+/obj/spawner/pack/tech_loot,
+/obj/spawner/pack/tech_loot,
+/obj/spawner/pack/cloth,
+/obj/spawner/pack/rare,
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section2deck1port)
 "hEH" = (
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/wood,
@@ -105254,6 +105305,13 @@
 /obj/effect/shuttle_landmark/merc/atmos,
 /turf/space,
 /area/space)
+"jWU" = (
+/obj/machinery/door/airlock/maintenance_common{
+	name = "Service Maintenance";
+	req_access = list(12)
+	},
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/eris/maintenance/section3deck3starboard)
 "kcK" = (
 /obj/machinery/floor_light/prebuilt{
 	color = "#8F00FF";
@@ -105319,6 +105377,10 @@
 	},
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics)
+"klI" = (
+/obj/spawner/pack/machine,
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck3starboard)
 "kmM" = (
 /obj/machinery/shield_diffuser,
 /turf/simulated/floor/tiled/dark/danger,
@@ -107411,6 +107473,20 @@
 /obj/spawner/scrap/sparse/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
+"qgz" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/spawner/mob/roaches/cluster/low_chance,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck1central)
 "qiG" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/firedoor,
@@ -107438,6 +107514,20 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/medical/chemistry)
+"qlh" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/spawner/junk/low_chance,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck1central)
 "qlJ" = (
 /obj/structure/railing{
 	dir = 4
@@ -107916,6 +108006,16 @@
 "rOY" = (
 /turf/simulated/floor/carpet/bcarpet,
 /area/eris/maintenance/section4deck4central)
+"rPO" = (
+/obj/structure/table/rack/shelf,
+/obj/spawner/tool,
+/obj/spawner/tool,
+/obj/spawner/tool,
+/obj/spawner/tool,
+/obj/spawner/pack/gun_loot/low_chance,
+/obj/spawner/material/building/low_chance,
+/turf/simulated/floor/tiled/steel/brown_platform,
+/area/eris/maintenance/section3deck3starboard)
 "rTw" = (
 /obj/structure/railing/grey{
 	dir = 1
@@ -108340,6 +108440,11 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
+"tgK" = (
+/obj/structure/barricade,
+/obj/item/weapon/material/shard,
+/turf/simulated/floor/plating,
+/area/eris/maintenance/section3deck1central)
 "thO" = (
 /obj/structure/fitness/weightlifter,
 /turf/simulated/floor/tiled/steel/gray_platform,
@@ -108514,6 +108619,10 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
 /area/eris/crew_quarters/bar)
+"tQP" = (
+/obj/structure/girder/low,
+/turf/simulated/floor/plating,
+/area/eris/maintenance/section3deck1central)
 "tRM" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/camera/network/third_section{
@@ -109057,6 +109166,10 @@
 /obj/item/weapon/stool,
 /turf/simulated/floor/wood,
 /area/eris/maintenance/section4deck4central)
+"vrQ" = (
+/obj/item/weapon/material/shard,
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck1central)
 "vuQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/railing{
@@ -109127,6 +109240,11 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
 /area/space)
+"vID" = (
+/obj/structure/railing,
+/obj/item/weapon/material/shard,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck1central)
 "vIJ" = (
 /obj/machinery/door/airlock/maintenance_common{
 	name = "Service Maintenance";
@@ -109624,6 +109742,10 @@
 /obj/item/weapon/bedsheet,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
+"xpp" = (
+/obj/spawner/mob/roaches/cluster/low_chance,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck1central)
 "xue" = (
 /obj/structure/railing{
 	dir = 1
@@ -109715,6 +109837,10 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/crew_quarters/sleep)
+"xIi" = (
+/obj/structure/barricade,
+/turf/simulated/floor/plating,
+/area/eris/maintenance/section3deck1central)
 "xJV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -170383,7 +170509,7 @@ aht
 aXq
 aZJ
 csS
-csL
+aLc
 cvH
 bbP
 bcq
@@ -171016,7 +171142,7 @@ bbM
 bhY
 bkB
 bkX
-blW
+bth
 blW
 bns
 boQ
@@ -171255,7 +171381,7 @@ aaa
 bsY
 byA
 bCU
-bEA
+wbZ
 bFH
 bFN
 bFN
@@ -176712,7 +176838,7 @@ dtE
 dtJ
 dtG
 dtZ
-dtF
+dsb
 bVX
 aaa
 aaa
@@ -178122,7 +178248,7 @@ cap
 cxp
 cHV
 bVX
-dtJ
+bEA
 dtF
 dtG
 dtF
@@ -216699,7 +216825,7 @@ bAN
 ciC
 ciC
 bAN
-dZh
+dZi
 dTs
 ewW
 avn
@@ -217897,7 +218023,7 @@ dvd
 dvd
 cVX
 evK
-dJd
+csL
 dRs
 dRs
 dRs
@@ -218106,7 +218232,7 @@ dRt
 dRt
 dRt
 dRt
-dRt
+rPO
 dvd
 dIK
 dFw
@@ -218303,11 +218429,11 @@ evH
 evM
 dvd
 ewa
-dSa
+dUi
 ewg
 dUc
 ewa
-dSa
+dUi
 ewg
 dvd
 dvd
@@ -218319,7 +218445,7 @@ dvd
 dGQ
 dvd
 dvd
-eaa
+klI
 dFw
 dFD
 dFD
@@ -218506,9 +218632,9 @@ dFG
 dvd
 ewa
 dSb
-ewg
-dUi
-ewa
+dZh
+dUc
+fwz
 dSb
 ewg
 dvd
@@ -218521,7 +218647,7 @@ dFw
 dFw
 dZK
 dvd
-eaa
+klI
 dFw
 dFD
 eaR
@@ -218709,7 +218835,7 @@ dvd
 dRv
 dRv
 dRv
-dRv
+jWU
 dRv
 dRv
 dRv
@@ -285739,7 +285865,7 @@ aaa
 aaa
 alb
 amc
-aof
+hBW
 anQ
 dMn
 amc
@@ -291234,7 +291360,7 @@ aRM
 bue
 buA
 boN
-bik
+bfe
 bfe
 bfe
 bfe
@@ -292442,12 +292568,12 @@ ezV
 cNH
 boS
 bsk
-bth
+bti
 buh
 bti
 buJ
-boN
-bkK
+tQP
+xpp
 eEs
 cNH
 dXi
@@ -292646,11 +292772,11 @@ boS
 bsl
 bti
 buh
-bth
+bti
 buK
-boN
-bkK
-eEs
+tQP
+blH
+vID
 cNH
 dXi
 bkK
@@ -292846,12 +292972,12 @@ ezV
 cNH
 boS
 bso
-bth
+bti
 bui
-bth
+bti
 buJ
-boN
-bkK
+tgK
+eWV
 eED
 bed
 bAY
@@ -293048,12 +293174,12 @@ ezV
 cNH
 boS
 bsp
-bth
+bti
 buj
-bth
+bti
 psz
-boN
-bkK
+xIi
+blH
 eAO
 cNH
 dXi
@@ -293249,11 +293375,11 @@ bmj
 esh
 boN
 boS
-boN
+tQP
 boS
-aNe
+gns
 boS
-boN
+xIi
 boS
 eEq
 eAL
@@ -293451,8 +293577,8 @@ bmi
 esg
 cNH
 aQV
-cNH
-cNH
+vrQ
+vrQ
 cNH
 cNH
 cNH
@@ -293652,12 +293778,12 @@ ezK
 ezP
 eAa
 eAf
+fkl
 eAf
 eAf
-eAf
-eAf
-eAf
-eAf
+qlh
+qlh
+qgz
 eAf
 eEr
 eAN
@@ -293854,7 +293980,7 @@ aQX
 aQX
 bnP
 aQX
-aQX
+fcY
 aQX
 aQX
 aQX
@@ -294454,7 +294580,7 @@ cNH
 dXi
 dXi
 baG
-aRA
+cNH
 ezx
 boS
 aLZ
@@ -296281,7 +296407,7 @@ cNH
 aNe
 cNH
 cNH
-aRA
+cNH
 boS
 aLZ
 aLZ

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -1620,12 +1620,8 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/security/prison)
 "aeg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance_interior{
-	name = "Service Maintenance";
-	req_access = list(12)
-	},
-/turf/simulated/floor/tiled/techmaint_cargo,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/crew_quarters/sleep)
 "aeh" = (
 /obj/structure/closet/crate/trashcart,
@@ -2774,7 +2770,7 @@
 /area/eris/command/commander)
 "agW" = (
 /obj/machinery/atmospherics/pipe/zpipe/up,
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/crew_quarters/sleep)
 "agX" = (
 /obj/structure/multiz/ladder/up,
@@ -3233,11 +3229,8 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/structure/table/standard,
-/obj/item/weapon/inflatable_duck,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
 "aia" = (
@@ -3250,33 +3243,20 @@
 /turf/simulated/floor/exoplanet/water/shallow,
 /area/eris/crew_quarters/sleep)
 "aib" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/bed/padded,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
 "aic" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/maintenance_interior{
+	name = "Service Maintenance";
+	req_access = list(12)
 	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/camera/network/fist_section,
-/obj/structure/bed/padded,
-/turf/simulated/floor/tiled/steel,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/crew_quarters/sleep)
 "aid" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 4
-	},
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
 "aie" = (
@@ -3452,12 +3432,6 @@
 	},
 /turf/simulated/floor/wood,
 /area/eris/command/commander)
-"aiC" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/eris/crew_quarters/sleep)
 "aiD" = (
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/crew_quarters/sleep)
@@ -3469,6 +3443,9 @@
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 22
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/crew_quarters/sleep)
@@ -3692,7 +3669,9 @@
 /area/eris/crew_quarters/sleep)
 "aje" = (
 /obj/structure/multiz/ladder/up,
-/obj/machinery/atmospherics/pipe/zpipe/up,
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/crew_quarters/sleep)
 "ajf" = (
@@ -3859,9 +3838,6 @@
 "ajx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/fist_section{
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 28
@@ -3871,10 +3847,10 @@
 "ajy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock{
-	name = "Showers"
-	},
 /obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Laundry Room"
+	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
 "ajz" = (
@@ -4591,8 +4567,8 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
 "ald" = (
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/turf/simulated/floor/tiled/techmaint,
+/obj/item/weapon/inflatable_duck,
+/turf/simulated/floor/exoplanet/water/shallow,
 /area/eris/crew_quarters/sleep)
 "ale" = (
 /obj/structure/table/rack/shelf,
@@ -4891,6 +4867,12 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/crew_quarters/sleep)
 "alR" = (
@@ -5128,22 +5110,26 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/eris/crew_quarters/sleep)
-"amv" = (
-/obj/machinery/atmospherics/unary/vent_pump/on,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 8
+	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/crew_quarters/sleep)
 "amw" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/crew_quarters/sleep)
 "amx" = (
+/obj/spawner/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
 "amy" = (
@@ -5441,14 +5427,19 @@
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
 "anj" = (
-/obj/machinery/atmospherics/pipe/zpipe/up{
-	dir = 1
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -22
 	},
-/turf/simulated/floor/plating/under,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/crew_quarters/sleep)
 "ank" = (
 /obj/structure/disposalpipe/up{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/zpipe/up{
+	dir = 8
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
@@ -5871,20 +5862,8 @@
 /obj/spawner/junk/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck1port)
-"aog" = (
-/obj/structure/closet/oldstyle,
-/obj/spawner/gun/cheap/low_chance,
-/obj/item/clothing/mask/gas/ihs,
-/obj/spawner/gun_parts/low_chance,
-/obj/spawner/gun_parts/low_chance,
-/obj/spawner/gun_parts/low_chance,
-/turf/simulated/floor/tiled/techmaint_panels,
-/area/eris/maintenance/section2deck5port)
 "aoh" = (
-/obj/structure/closet/oldstyle,
-/obj/spawner/ammo/lowcost/low_chance,
-/obj/spawner/ammo/lowcost/low_chance,
-/obj/spawner/ammo/lowcost/low_chance,
+/obj/spawner/pack/machine,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/eris/maintenance/section2deck5port)
 "aoi" = (
@@ -6033,13 +6012,6 @@
 	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/maintenance/section2deck5port)
-"aoB" = (
-/obj/structure/table/rack,
-/obj/spawner/ammo/lowcost/low_chance,
-/obj/spawner/ammo/lowcost/low_chance,
-/obj/spawner/ammo,
-/turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section2deck5port)
 "aoC" = (
 /obj/machinery/deployable/barrier,
 /turf/simulated/floor/tiled/techmaint_panels,
@@ -6175,9 +6147,13 @@
 /area/space)
 "aoR" = (
 /obj/structure/table/rack,
-/obj/spawner/boxes,
-/obj/spawner/boxes,
-/obj/spawner/boxes/low_chance,
+/obj/spawner/gun_parts,
+/obj/spawner/gun_parts/low_chance,
+/obj/spawner/gun_parts/low_chance,
+/obj/spawner/gun_parts/low_chance,
+/obj/spawner/gun_parts/low_chance,
+/obj/spawner/gun_parts/low_chance,
+/obj/spawner/pouch/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck5port)
 "aoS" = (
@@ -6372,6 +6348,9 @@
 /area/eris/crew_quarters/bar)
 "apy" = (
 /obj/spawner/junk/low_chance,
+/obj/machinery/atmospherics/pipe/zpipe/up{
+	dir = 8
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
 "apz" = (
@@ -9531,12 +9510,10 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck2starboard)
 "axd" = (
-/obj/spawner/junk/low_chance,
-/obj/spawner/junk/low_chance,
-/obj/spawner/junk/low_chance,
-/obj/structure/multiz/ladder,
-/turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section3deck2starboard)
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/eris/crew_quarters/sleep)
 "axe" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -13445,8 +13422,9 @@
 /obj/structure/closet,
 /obj/spawner/pack/tech_loot/low_chance,
 /obj/spawner/pack/tech_loot/low_chance,
-/obj/spawner/gun_parts/low_chance,
-/obj/spawner/gun_parts/low_chance,
+/obj/spawner/lowkeyrandom,
+/obj/spawner/lowkeyrandom/low_chance,
+/obj/spawner/lowkeyrandom/low_chance,
 /turf/simulated/floor/tiled/steel,
 /area/eris/maintenance/section2deck4central)
 "aGH" = (
@@ -13870,9 +13848,10 @@
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/engineering/atmos)
 "aHN" = (
-/obj/spawner/boxes/low_chance,
-/obj/spawner/boxes/low_chance,
 /obj/structure/table/rack/shelf,
+/obj/spawner/booze,
+/obj/spawner/pack/tech_loot,
+/obj/spawner/pack/tech_loot,
 /turf/simulated/floor/tiled/steel,
 /area/eris/maintenance/section2deck4central)
 "aHO" = (
@@ -16535,10 +16514,6 @@
 /area/eris/maintenance/section4deck5port)
 "aOS" = (
 /obj/structure/table/standard,
-/obj/spawner/lowkeyrandom,
-/obj/spawner/lowkeyrandom/low_chance,
-/obj/spawner/lowkeyrandom/low_chance,
-/obj/spawner/pack/tech_loot,
 /obj/spawner/pack/tech_loot,
 /obj/spawner/pack/tech_loot,
 /turf/simulated/floor/tiled/techmaint,
@@ -17291,15 +17266,10 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck5port)
 "aQs" = (
-/obj/structure/table/standard,
-/obj/spawner/tank,
-/obj/spawner/pack/tech_loot,
-/obj/spawner/pack/tech_loot,
-/obj/spawner/pack/tech_loot,
-/obj/spawner/pack/tech_loot,
-/obj/spawner/pack/tech_loot,
-/turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section1deck4central)
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/sleep)
 "aQt" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
 	id_tag = "atmos_access_console";
@@ -19190,17 +19160,9 @@
 /area/eris/security/prisoncells)
 "aUD" = (
 /obj/structure/table/standard,
-/obj/spawner/lowkeyrandom,
-/obj/spawner/lowkeyrandom/low_chance,
-/obj/spawner/lowkeyrandom/low_chance,
-/obj/spawner/pack/tech_loot,
-/obj/spawner/pack/tech_loot,
-/obj/spawner/pack/tech_loot,
-/obj/spawner/material/building/low_chance,
-/obj/spawner/material/building/low_chance,
-/obj/spawner/material/building/low_chance,
-/obj/spawner/material/building/low_chance,
-/obj/spawner/material/building/low_chance,
+/obj/spawner/boxes,
+/obj/spawner/boxes,
+/obj/spawner/cloth/armor/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "aUE" = (
@@ -19327,10 +19289,8 @@
 /turf/simulated/wall,
 /area/eris/security/warden)
 "aUQ" = (
-/obj/machinery/door/airlock/maintenance_common{
-	name = "Central Maintenance"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/eris/crew_quarters/sleep)
 "aUR" = (
@@ -19349,13 +19309,10 @@
 /area/eris/maintenance/section1deck3central)
 "aUS" = (
 /obj/structure/closet/crate,
-/obj/spawner/pack/tech_loot,
-/obj/spawner/pack/tech_loot,
-/obj/spawner/pack/tech_loot,
-/obj/spawner/pack/tech_loot/low_chance,
-/obj/spawner/pack/tech_loot/low_chance,
-/obj/spawner/electronics/low_chance,
-/obj/spawner/electronics/low_chance,
+/obj/spawner/tool_upgrade/low_chance,
+/obj/spawner/tool_upgrade/low_chance,
+/obj/spawner/pack/cloth,
+/obj/spawner/pack/cloth,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "aUT" = (
@@ -20326,14 +20283,12 @@
 /area/eris/maintenance/section2deck4port)
 "aWX" = (
 /obj/structure/closet/crate,
-/obj/spawner/pack/tech_loot,
-/obj/spawner/pack/tech_loot,
-/obj/spawner/pack/tech_loot,
-/obj/spawner/pack/tech_loot/low_chance,
-/obj/spawner/pack/tech_loot/low_chance,
-/obj/spawner/electronics/low_chance,
-/obj/spawner/electronics/low_chance,
-/obj/spawner/junkfood/rotten/low_chance,
+/obj/spawner/soda/low_chance,
+/obj/spawner/tool_upgrade/low_chance,
+/obj/spawner/tool_upgrade/low_chance,
+/obj/spawner/pack/cloth,
+/obj/spawner/pack/cloth,
+/obj/spawner/gun/energy_cheap/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "aWY" = (
@@ -20346,16 +20301,21 @@
 /turf/simulated/open,
 /area/eris/security/prisoncells)
 "aXa" = (
-/obj/machinery/atmospherics/pipe/tank/air{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/maintenance_common{
+	name = "Central Maintenance"
 	},
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/section1deck4central)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/sleep)
 "aXb" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4
 	},
-/turf/simulated/floor/plating/under,
+/obj/structure/table/standard,
+/obj/spawner/firstaid/low_chance,
+/obj/spawner/tank,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "aXc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -20417,8 +20377,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
 	dir = 10
 	},
-/obj/spawner/flora/low_chance,
-/turf/simulated/floor/plating/under,
+/obj/structure/table/standard,
+/obj/spawner/lowkeyrandom/low_chance,
+/obj/spawner/lowkeyrandom/low_chance,
+/obj/spawner/lowkeyrandom/low_chance,
+/obj/spawner/lowkeyrandom/low_chance,
+/obj/spawner/lowkeyrandom,
+/obj/spawner/lowkeyrandom,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "aXk" = (
 /obj/structure/railing{
@@ -20431,13 +20397,19 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
 	dir = 6
 	},
-/turf/simulated/floor/plating/under,
+/obj/structure/table/standard,
+/obj/spawner/pack/tech_loot,
+/obj/spawner/pack/tech_loot,
+/obj/spawner/pack/tech_loot,
+/obj/spawner/pack/tech_loot,
+/obj/spawner/pack/tech_loot,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "aXm" = (
 /obj/machinery/atmospherics/pipe/tank/air{
 	dir = 8
 	},
-/turf/simulated/floor/plating/under,
+/turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
 "aXn" = (
 /obj/structure/table/standard,
@@ -21037,26 +21009,9 @@
 /obj/spawner/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
-"aYA" = (
-/obj/machinery/atmospherics/pipe/zpipe/down,
-/obj/structure/railing{
-	dir = 4
-	},
-/turf/simulated/open,
-/area/eris/crew_quarters/sleep)
-"aYB" = (
-/obj/structure/catwalk,
-/obj/structure/multiz/ladder,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/simulated/open,
-/area/eris/crew_quarters/sleep)
 "aYC" = (
-/obj/machinery/atmospherics/pipe/zpipe/down,
-/obj/structure/railing{
-	dir = 8
-	},
+/obj/structure/catwalk,
+/obj/spawner/junk/low_chance,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "aYD" = (
@@ -21226,7 +21181,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/spawner/traps/wire_splicing/low_chance,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "aYU" = (
@@ -21239,24 +21194,29 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/structure/catwalk,
+/obj/structure/catwalk,
+/obj/landmark/join/start/assistant,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "aYV" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "aYW" = (
-/obj/structure/catwalk,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "aYX" = (
 /obj/structure/railing{
-	dir = 8
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "aYY" = (
@@ -21448,6 +21408,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "aZu" = (
@@ -21585,10 +21546,11 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "aZD" = (
-/obj/spawner/junk/low_chance,
-/obj/spawner/junk/low_chance,
-/turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section1deck4central)
+/obj/structure/railing{
+	dir = 8
+	},
+/turf/simulated/open,
+/area/eris/crew_quarters/sleep)
 "aZE" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawn,
@@ -21659,17 +21621,11 @@
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section3deck1central)
 "aZO" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "aZP" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "aZQ" = (
@@ -21679,7 +21635,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/turf/simulated/open,
+/turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
 "aZR" = (
 /obj/structure/railing{
@@ -21688,7 +21644,7 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/turf/simulated/open,
+/turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
 "aZS" = (
 /obj/structure/disposalpipe/segment{
@@ -21809,7 +21765,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -21818,13 +21773,17 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing,
+/obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "bab" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -21836,13 +21795,20 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing,
+/obj/spawner/traps/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "bac" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/railing,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -21852,6 +21818,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/catwalk,
+/obj/structure/barricade,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "bad" = (
@@ -21865,7 +21833,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -21877,13 +21844,20 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/structure/railing,
+/obj/spawner/junk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "baf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/railing,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -21892,7 +21866,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/spawner/junk/low_chance,
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing,
+/obj/spawner/junk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "bag" = (
@@ -21937,12 +21915,11 @@
 /obj/structure/railing{
 	dir = 4
 	},
-/turf/simulated/open,
+/turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
 "bam" = (
-/obj/structure/railing{
-	dir = 8
-	},
+/obj/machinery/atmospherics/pipe/zpipe/down,
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "ban" = (
@@ -21978,10 +21955,9 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "bap" = (
-/obj/structure/table/standard,
-/obj/spawner/firstaid/low_chance,
-/turf/simulated/floor/tiled/techmaint,
-/area/eris/maintenance/section1deck4central)
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/eris/crew_quarters/sleep)
 "baq" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -22165,17 +22141,11 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "baQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/spawner/traps/low_chance,
 /turf/simulated/floor/plating/under,
-/area/eris/maintenance/section1deck4central)
+/area/eris/crew_quarters/sleep)
 "baR" = (
 /obj/structure/closet,
 /obj/spawner/pack/tech_loot,
@@ -22512,6 +22482,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/spawner/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
 "bbB" = (
@@ -22531,7 +22502,6 @@
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
 "bbC" = (
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -22541,6 +22511,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "bbD" = (
@@ -22556,32 +22527,16 @@
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "bbE" = (
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
-/turf/simulated/open,
-/area/eris/crew_quarters/sleep)
-"bbF" = (
 /obj/structure/catwalk,
-/obj/structure/sign/atmos_air{
-	pixel_y = 32
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "bbG" = (
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -22590,7 +22545,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "bbH" = (
@@ -22642,7 +22597,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/spawner/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "bbK" = (
@@ -22735,7 +22689,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/spawner/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "bbV" = (
@@ -22795,21 +22748,10 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "bbZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/spawner/junk/low_chance,
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/section1deck4central)
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/tiled/techmaint_cargo,
+/area/eris/crew_quarters/sleep)
 "bca" = (
 /obj/structure/table/reinforced,
 /obj/item/device/t_scanner,
@@ -22874,6 +22816,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/catwalk,
+/obj/spawner/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
 "bcf" = (
@@ -22889,10 +22832,10 @@
 /obj/machinery/camera/network/fist_section{
 	dir = 1
 	},
+/obj/spawner/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
 "bcg" = (
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -22904,31 +22847,19 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/open,
-/area/eris/crew_quarters/sleep)
-"bch" = (
 /obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "bci" = (
-/obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "bcj" = (
@@ -22937,17 +22868,18 @@
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section3deck1central)
 "bck" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "bcl" = (
-/obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -22961,6 +22893,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "bcm" = (
@@ -23076,7 +23009,8 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/spawner/traps/wire_splicing/low_chance,
+/obj/structure/table/standard,
+/obj/spawner/material/building/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "bct" = (
@@ -23340,17 +23274,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/maintenance/section4deck4port)
 "bcO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance_common{
+	name = "Central Maintenance"
 	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/spawner/junk/low_chance,
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/section1deck4central)
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/sleep)
 "bcP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -23394,7 +23324,11 @@
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/spawner/junk/low_chance,
+/obj/structure/table/standard,
+/obj/spawner/material/building/low_chance,
+/obj/spawner/material/building/low_chance,
+/obj/spawner/material/building/low_chance,
+/obj/spawner/material/building/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck4central)
 "bcT" = (
@@ -23544,14 +23478,6 @@
 	},
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/quartermaster/disposaldrop)
-"bdg" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/open,
-/area/eris/crew_quarters/sleep)
 "bdh" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -23794,14 +23720,14 @@
 	dir = 4
 	},
 /obj/structure/railing,
-/turf/simulated/open,
+/turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
 "bdF" = (
 /obj/structure/railing{
 	dir = 8
 	},
 /obj/structure/railing,
-/turf/simulated/open,
+/turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
 "bdG" = (
 /obj/machinery/door/airlock/maintenance_common{
@@ -24039,28 +23965,20 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/medical/medbreak)
 "bep" = (
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /obj/structure/lattice,
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "beq" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
-/obj/structure/lattice,
+/obj/structure/railing,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "ber" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/lattice,
-/turf/simulated/open,
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
 "bes" = (
 /obj/structure/disposalpipe/segment,
@@ -24193,36 +24111,22 @@
 /obj/machinery/atmospherics/pipe/zpipe/down{
 	dir = 1
 	},
-/obj/structure/railing{
-	dir = 4
-	},
 /obj/structure/lattice,
-/turf/simulated/open,
-/area/eris/crew_quarters/sleep)
-"beH" = (
 /obj/structure/catwalk,
-/obj/structure/multiz/ladder,
-/obj/machinery/light/small,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "beI" = (
-/obj/machinery/atmospherics/pipe/zpipe/down{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/structure/lattice,
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "beJ" = (
 /obj/structure/disposalpipe/down{
 	dir = 1
 	},
-/obj/structure/railing{
-	dir = 8
+/obj/machinery/atmospherics/pipe/zpipe/down{
+	dir = 1
 	},
-/obj/structure/lattice,
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "beK" = (
@@ -24439,9 +24343,18 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep/cryo)
 "bfk" = (
-/obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/tiled/steel/panels,
-/area/eris/maintenance/section3deck1central)
+/obj/machinery/atmospherics/valve{
+	dir = 4
+	},
+/obj/structure/table/standard,
+/obj/spawner/pack/tech_loot,
+/obj/spawner/pack/tech_loot,
+/obj/spawner/pack/tech_loot,
+/obj/spawner/lowkeyrandom/low_chance,
+/obj/spawner/lowkeyrandom/low_chance,
+/obj/spawner/lowkeyrandom,
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section1deck4central)
 "bfl" = (
 /obj/structure/table/standard,
 /obj/spawner/ammo/lowcost/low_chance,
@@ -24478,10 +24391,6 @@
 /obj/spawner/traps/low_chance,
 /turf/simulated/open,
 /area/eris/maintenance/section2deck4port)
-"bfs" = (
-/obj/machinery/atmospherics/unary/heater,
-/turf/simulated/floor/tiled/steel/panels,
-/area/eris/maintenance/section3deck1central)
 "bft" = (
 /obj/structure/table/standard,
 /obj/item/weapon/stock_parts/matter_bin,
@@ -24637,10 +24546,18 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
 "bfL" = (
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/catwalk,
-/obj/spawner/flora/low_chance,
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/section2deck4central)
+/obj/spawner/junk/low_chance,
+/turf/simulated/open,
+/area/eris/crew_quarters/sleep)
 "bfM" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -25695,15 +25612,22 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4starboard)
 "bio" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 5
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/steel/panels,
-/area/eris/maintenance/section3deck1central)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section1deck4central)
 "bip" = (
-/obj/machinery/atmospherics/pipe/simple/visible{
-	dir = 9
-	},
+/obj/spawner/pack/machine,
 /turf/simulated/floor/tiled/steel/panels,
 /area/eris/maintenance/section3deck1central)
 "biq" = (
@@ -26090,8 +26014,8 @@
 /area/eris/maintenance/section2deck4starboard)
 "bjh" = (
 /obj/structure/table/standard,
-/obj/spawner/lowkeyrandom,
-/obj/spawner/pack/tech_loot,
+/obj/spawner/science/low_chance,
+/obj/spawner/science/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck4port)
 "bji" = (
@@ -26391,7 +26315,7 @@
 "bjN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/airlock/maintenance_common,
 /turf/simulated/floor/plating,
 /area/eris/crew_quarters/sleep)
 "bjO" = (
@@ -27306,11 +27230,19 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "blE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawn,
-/turf/simulated/floor/plating,
-/area/eris/crew_quarters/sleep)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/structure/catwalk,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section1deck4central)
 "blF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -27433,8 +27365,6 @@
 "blW" = (
 /obj/structure/table/standard,
 /obj/spawner/lowkeyrandom,
-/obj/spawner/material/building/low_chance,
-/obj/spawner/material/building/low_chance,
 /obj/spawner/material/building/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck4central)
@@ -27700,7 +27630,7 @@
 "bmA" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/airlock/maintenance_common,
 /turf/simulated/floor/plating,
 /area/eris/crew_quarters/sleep)
 "bmB" = (
@@ -28323,6 +28253,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/spawner/scrap/sparse,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "bnL" = (
@@ -28675,7 +28606,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/airlock/maintenance_common{
+	name = "Central Maintenance"
+	},
 /turf/simulated/floor/plating,
 /area/eris/crew_quarters/sleep)
 "boF" = (
@@ -28702,9 +28635,20 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
 "boI" = (
-/obj/spawner/mob/roaches/cluster,
-/turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/maintenance/section3deck1central)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/spawner/flora/low_chance,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section1deck4central)
 "boJ" = (
 /obj/structure/disposalpipe/junction{
 	dir = 2;
@@ -28724,9 +28668,22 @@
 /turf/simulated/open,
 /area/eris/crew_quarters/toilet/medbay)
 "boL" = (
-/obj/spawner/mob/roaches/cluster/low_chance,
-/turf/simulated/floor/tiled/white/brown_platform,
-/area/eris/maintenance/section3deck1central)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/catwalk,
+/obj/spawner/traps/low_chance,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section1deck4central)
 "boM" = (
 /obj/structure/sink{
 	dir = 4;
@@ -28797,7 +28754,8 @@
 "boW" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/airlock/maintenance_common,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating,
 /area/eris/crew_quarters/sleep)
 "boX" = (
@@ -28973,9 +28931,21 @@
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/medical/morgue)
 "bpq" = (
-/obj/spawner/mob/roaches/cluster/low_chance,
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/eris/maintenance/section3deck1central)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/spawner/junk/low_chance,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section1deck4central)
 "bpr" = (
 /obj/structure/table/standard,
 /obj/spawner/medical_lowcost,
@@ -29350,6 +29320,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/spawner/scrap/sparse,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "bqn" = (
@@ -29700,6 +29671,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/spawner/scrap/sparse,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "brj" = (
@@ -30035,17 +30007,6 @@
 "bse" = (
 /turf/simulated/floor/carpet/turcarpet,
 /area/eris/crew_quarters/librarybackroom)
-"bsf" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/section3deck4central)
 "bsg" = (
 /obj/spawner/junk/low_chance,
 /obj/spawner/junk/low_chance,
@@ -30138,6 +30099,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/spawner/traps,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "bsu" = (
@@ -30878,8 +30840,6 @@
 /obj/structure/table/rack/shelf,
 /obj/spawner/techpart,
 /obj/spawner/techpart,
-/obj/spawner/techpart,
-/obj/spawner/techpart,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/eris/maintenance/section3deck1central)
 "bui" = (
@@ -31098,8 +31058,8 @@
 /obj/structure/table/rack/shelf,
 /obj/spawner/pack/cloth,
 /obj/spawner/pack/cloth,
-/obj/spawner/pack/cloth,
 /obj/spawner/pack/cloth/low_chance,
+/obj/spawner/pouch,
 /turf/simulated/floor/tiled/techmaint_panels,
 /area/eris/maintenance/section3deck1central)
 "buL" = (
@@ -31459,6 +31419,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/spawner/scrap/dense,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "bvH" = (
@@ -31474,6 +31435,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/spawner/scrap/dense,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "bvI" = (
@@ -31485,6 +31447,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/spawner/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "bvJ" = (
@@ -31963,14 +31926,16 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4central)
 "bwG" = (
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
 /obj/spawner/junk/low_chance,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "bwH" = (
@@ -32851,6 +32816,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/spawner/flora/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "byO" = (
@@ -38010,10 +37976,6 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section4deck4port)
 "bKs" = (
-/obj/structure/catwalk,
-/obj/structure/sign/atmos_waste{
-	pixel_y = -32
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -38024,6 +37986,7 @@
 	},
 /obj/machinery/light/small,
 /obj/spawner/flora/low_chance,
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "bKt" = (
@@ -41417,11 +41380,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/table/standard,
+/obj/structure/closet/wardrobe/color/black,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/crew_quarters/clothingstorage)
 "bRW" = (
-/obj/structure/closet/wardrobe/color/mixed,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "West APC";
@@ -41435,16 +41397,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/steel/gray_platform,
-/area/eris/crew_quarters/clothingstorage)
-"bRX" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/closet/wardrobe/color/white,
-/turf/simulated/floor/tiled/steel/gray_platform,
-/area/eris/crew_quarters/clothingstorage)
-"bRY" = (
-/obj/structure/closet/wardrobe/color/black,
-/obj/structure/disposalpipe/segment,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/crew_quarters/clothingstorage)
 "bSa" = (
@@ -45913,6 +45866,9 @@
 /area/eris/maintenance/section2deck3port)
 "ccX" = (
 /obj/structure/disposalpipe/segment,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "ccY" = (
@@ -50063,6 +50019,14 @@
 "cmG" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawn,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id = "RDPrivacy";
+	layer = 2.6;
+	name = "CSO Office Privacy Shutter";
+	opacity = 0
+	},
 /turf/simulated/floor/plating,
 /area/eris/command/meo)
 "cmH" = (
@@ -51682,13 +51646,13 @@
 /turf/simulated/floor,
 /area/shuttle/mining/station)
 "cqz" = (
-/obj/effect/window_lwall_spawn/smartspawn,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawnphoron,
 /turf/simulated/floor/plating,
 /area/eris/maintenance/substation/section3)
 "cqA" = (
@@ -52587,17 +52551,9 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/hallway/side/cryo)
 "csL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/catwalk,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/spawner/traps/wire_splicing/low_chance,
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/section3deck4central)
+/obj/spawner/closet/low_chance,
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section1deck4central)
 "csM" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -52618,7 +52574,7 @@
 	name = "Service Maintenance";
 	req_access = list(12)
 	},
-/turf/simulated/floor/tiled/techmaint_cargo,
+/turf/simulated/floor/plating,
 /area/eris/maintenance/section3deck4central)
 "csP" = (
 /obj/structure/multiz/stairs/active/bottom,
@@ -54342,8 +54298,8 @@
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
 "cxj" = (
-/obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawnphoron,
 /turf/simulated/floor/plating,
 /area/eris/maintenance/substation/section3)
 "cxk" = (
@@ -55492,13 +55448,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/spawner/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "czW" = (
@@ -55736,6 +55690,8 @@
 /obj/structure/railing{
 	dir = 1
 	},
+/obj/structure/railing,
+/obj/spawner/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cAz" = (
@@ -55878,7 +55834,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/spawner/traps/low_chance,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
@@ -55920,6 +55875,8 @@
 	dir = 2;
 	icon_state = "pipe-y"
 	},
+/obj/structure/railing,
+/obj/spawner/traps,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cAS" = (
@@ -55976,6 +55933,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/railing,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cAZ" = (
@@ -56363,7 +56321,6 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/spawner/scrap/sparse/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cBO" = (
@@ -56597,14 +56554,12 @@
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/crew_quarters/kitchen)
 "cCn" = (
+/obj/structure/railing,
 /obj/structure/railing{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/section3deck4central)
+/turf/simulated/open,
+/area/eris/crew_quarters/sleep)
 "cCo" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -57034,11 +56989,11 @@
 /turf/simulated/floor/tiled/steel/bar_flat,
 /area/eris/crew_quarters/bar)
 "cDk" = (
-/obj/structure/railing,
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cDl" = (
@@ -57445,6 +57400,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cEf" = (
@@ -57693,7 +57649,6 @@
 "cEH" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cEI" = (
@@ -57798,6 +57753,9 @@
 	dir = 8
 	},
 /obj/structure/railing,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/simulated/open,
 /area/eris/maintenance/section3deck4central)
 "cEU" = (
@@ -57814,6 +57772,9 @@
 /area/eris/maintenance/section3deck3port)
 "cEV" = (
 /obj/structure/railing,
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cEW" = (
@@ -58274,7 +58235,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/spawner/flora/low_chance,
+/obj/spawner/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cFZ" = (
@@ -58682,11 +58643,6 @@
 /obj/spawner/traps/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4starboard)
-"cGT" = (
-/obj/spawner/junk/low_chance,
-/obj/structure/railing,
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/section3deck4central)
 "cGU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -58709,7 +58665,7 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/hallway/main/section3)
 "cGW" = (
-/obj/spawner/scrap,
+/obj/structure/railing,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cGX" = (
@@ -58779,11 +58735,12 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/hallway/side/bridgehallway)
 "cHe" = (
-/obj/structure/multiz/ladder/up,
-/obj/structure/catwalk,
-/obj/spawner/scrap/sparse/low_chance,
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/section3deck4central)
+/obj/structure/railing,
+/obj/structure/railing{
+	dir = 4
+	},
+/turf/simulated/open,
+/area/eris/crew_quarters/sleep)
 "cHf" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 1
@@ -58865,20 +58822,29 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/drone_fabrication)
 "cHo" = (
-/obj/spawner/scrap/sparse,
+/obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/spawner/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
-/area/eris/maintenance/section3deck4central)
+/area/eris/maintenance/section1deck4central)
 "cHp" = (
 /obj/structure/table/standard,
 /obj/spawner/rations,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/eris/maintenance/section3deck3starboard)
 "cHq" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
-/obj/spawner/scrap/dense,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/spawner/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
-/area/eris/maintenance/section3deck4central)
+/area/eris/maintenance/section1deck4central)
 "cHr" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/alarm{
@@ -58920,10 +58886,12 @@
 /turf/simulated/floor/plating,
 /area/eris/hallway/main/section4)
 "cHx" = (
-/obj/structure/catwalk,
-/obj/spawner/scrap/sparse,
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/section3deck4central)
+/obj/structure/table/rack/shelf,
+/obj/spawner/pack/tech_loot,
+/obj/spawner/pack/tech_loot,
+/obj/spawner/pack/tech_loot,
+/turf/simulated/floor/tiled/steel,
+/area/eris/maintenance/section2deck4central)
 "cHy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -59021,10 +58989,13 @@
 /turf/simulated/floor/tiled/dark/cyancorner,
 /area/eris/command/bridge)
 "cHI" = (
-/obj/spawner/junk/low_chance,
-/obj/structure/catwalk,
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/section3deck4central)
+/obj/structure/table/rack/shelf,
+/obj/spawner/pack/tech_loot,
+/obj/spawner/pack/tech_loot,
+/obj/spawner/pack/tech_loot/low_chance,
+/obj/spawner/pack/tech_loot/low_chance,
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section2deck4central)
 "cHJ" = (
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -60036,13 +60007,16 @@
 /area/eris/storage/primary)
 "cKo" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/railing{
-	dir = 8
+/obj/structure/catwalk,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/railing,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/spawner/traps/wire_splicing/low_chance,
 /turf/simulated/floor/plating/under,
-/area/eris/maintenance/section3deck4central)
+/area/eris/maintenance/section2deck4central)
 "cKp" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
@@ -60276,7 +60250,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/railing,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "cKM" = (
@@ -61452,6 +61425,8 @@
 /obj/spawner/lowkeyrandom/low_chance,
 /obj/spawner/lowkeyrandom/low_chance,
 /obj/spawner/lowkeyrandom/low_chance,
+/obj/spawner/material/building/low_chance,
+/obj/spawner/material/building/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck2starboard)
 "cNK" = (
@@ -61718,6 +61693,8 @@
 /obj/spawner/lowkeyrandom/low_chance,
 /obj/spawner/lowkeyrandom/low_chance,
 /obj/spawner/lowkeyrandom/low_chance,
+/obj/spawner/material/building/low_chance,
+/obj/spawner/material/building/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck2starboard)
 "cOt" = (
@@ -62043,6 +62020,8 @@
 /obj/spawner/lowkeyrandom/low_chance,
 /obj/spawner/lowkeyrandom/low_chance,
 /obj/spawner/lowkeyrandom/low_chance,
+/obj/spawner/material/building/low_chance,
+/obj/spawner/material/building/low_chance,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck2starboard)
 "cPm" = (
@@ -66537,6 +66516,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/obj/spawner/traps/wire_splicing,
 /turf/simulated/floor/plating,
 /area/eris/maintenance/substation/section3)
 "cZY" = (
@@ -66738,7 +66718,6 @@
 /turf/simulated/floor/plating,
 /area/eris/maintenance/substation/section3)
 "daz" = (
-/obj/spawner/junk/low_chance,
 /turf/simulated/floor/plating,
 /area/eris/maintenance/substation/section3)
 "daA" = (
@@ -67768,9 +67747,8 @@
 /area/eris/maintenance/section2deck2port)
 "dcY" = (
 /obj/structure/table/standard,
-/obj/spawner/pack/tech_loot,
-/obj/spawner/powercell,
-/obj/spawner/powercell,
+/obj/spawner/material/building,
+/obj/spawner/material/building,
 /turf/simulated/floor/plating,
 /area/eris/maintenance/substation/section3)
 "dcZ" = (
@@ -67801,17 +67779,17 @@
 /area/eris/engineering/engine_room)
 "ddb" = (
 /obj/structure/table/standard,
-/obj/spawner/pack/tech_loot,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/spawner/powercell,
-/obj/spawner/powercell,
+/obj/spawner/material/building,
+/obj/spawner/material/building,
 /turf/simulated/floor/plating,
 /area/eris/maintenance/substation/section3)
 "ddc" = (
 /obj/structure/table/standard,
+/obj/spawner/powercell,
 /obj/spawner/powercell,
 /obj/spawner/powercell,
 /obj/spawner/powercell,
@@ -67846,14 +67824,6 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section2deck2port)
-"ddh" = (
-/obj/structure/closet/crate,
-/obj/spawner/powercell,
-/obj/spawner/powercell,
-/obj/spawner/powercell,
-/obj/spawner/powercell,
-/turf/simulated/floor/plating,
-/area/eris/maintenance/substation/section3)
 "ddi" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -67910,13 +67880,11 @@
 /area/eris/maintenance/section2deck2starboard)
 "ddq" = (
 /obj/structure/closet/crate,
-/obj/spawner/material/building,
-/obj/spawner/material/building,
-/obj/spawner/material/building,
-/obj/spawner/material/building,
-/obj/spawner/pack/tech_loot/low_chance,
-/obj/spawner/pack/tech_loot/low_chance,
-/obj/spawner/pack/tech_loot/low_chance,
+/obj/spawner/pack/tech_loot,
+/obj/spawner/pack/tech_loot,
+/obj/spawner/pack/tech_loot,
+/obj/spawner/pack/tech_loot,
+/obj/spawner/pack/tech_loot,
 /turf/simulated/floor/plating,
 /area/eris/maintenance/substation/section3)
 "ddr" = (
@@ -68929,8 +68897,8 @@
 /turf/simulated/floor/carpet/turcarpet,
 /area/eris/command/captain)
 "dfB" = (
-/obj/spawner/junk/low_chance,
-/turf/simulated/floor/tiled/techmaint,
+/obj/structure/girder,
+/turf/simulated/floor/plating,
 /area/eris/maintenance/section3deck4central)
 "dfC" = (
 /obj/structure/bed/chair/wood{
@@ -68950,8 +68918,9 @@
 /turf/simulated/floor/wood,
 /area/eris/command/bridgebar)
 "dfE" = (
-/turf/simulated/wall/r_wall,
-/area/eris/maintenance/substation/section3)
+/obj/structure/girder/low,
+/turf/simulated/floor/plating,
+/area/eris/maintenance/section3deck4central)
 "dfF" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/storage/box/lights/tubes,
@@ -71787,12 +71756,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/structure/railing{
-	dir = 1
-	},
-/obj/structure/railing{
-	dir = 4
-	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "dlI" = (
@@ -73221,9 +73184,6 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/structure/railing{
-	dir = 4
-	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "doQ" = (
@@ -73313,6 +73273,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/railing,
+/obj/spawner/junk/low_chance,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "dpc" = (
@@ -73956,9 +73918,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/railing{
-	dir = 4
-	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "dqy" = (
@@ -73978,6 +73937,7 @@
 /obj/machinery/atmospherics/pipe/zpipe/up{
 	dir = 4
 	},
+/obj/spawner/scrap/dense,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "dqB" = (
@@ -73989,8 +73949,8 @@
 /turf/simulated/floor/plating,
 /area/eris/medical/reception)
 "dqD" = (
-/obj/spawner/junk/low_chance,
-/turf/simulated/floor/plating/under,
+/obj/structure/girder/displaced,
+/turf/simulated/floor/plating,
 /area/eris/maintenance/section3deck4central)
 "dqE" = (
 /obj/machinery/gravity_generator/main/station,
@@ -80902,6 +80862,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/button/remote/blast_door{
+	id = "maint_hatch_bar_north";
+	name = "Maintenance Hatch Control";
+	pixel_x = -6;
+	pixel_y = 26;
+	req_access = null
+	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/hallway/side/section3port)
 "dHh" = (
@@ -84224,6 +84191,9 @@
 /obj/structure/railing{
 	dir = 4
 	},
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "dOk" = (
@@ -84391,8 +84361,8 @@
 /obj/item/weapon/book/manual/excavation,
 /obj/item/weapon/book/manual/nuclear,
 /obj/item/weapon/book/manual/chef_recipes,
-/obj/spawner/lowkeyrandom/low_chance,
-/obj/spawner/lowkeyrandom/low_chance,
+/obj/spawner/instructional,
+/obj/spawner/instructional,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/maintenance/section2deck1starboard)
 "dOD" = (
@@ -100948,6 +100918,7 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
+/obj/spawner/mob/roaches/cluster,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck1central)
 "eAY" = (
@@ -102485,6 +102456,8 @@
 "eEC" = (
 /obj/structure/table/standard,
 /obj/item/weapon/book/manual/wiki/engineering_singularity,
+/obj/spawner/instructional,
+/obj/spawner/instructional,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/maintenance/section2deck1starboard)
 "eED" = (
@@ -103710,6 +103683,11 @@
 /obj/machinery/slotmachine,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
+"eZG" = (
+/obj/structure/railing,
+/obj/structure/lattice,
+/turf/simulated/open,
+/area/eris/maintenance/section3deck2starboard)
 "eZV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/steel,
@@ -103852,7 +103830,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/table/standard,
+/obj/structure/closet/wardrobe/color/white,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/crew_quarters/clothingstorage)
 "fyP" = (
@@ -103935,6 +103913,12 @@
 /obj/item/weapon/paper_bin,
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/reception)
+"fJR" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/spawner/junk/low_chance,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck4central)
 "fKd" = (
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/quartermaster/storage)
@@ -103964,8 +103948,7 @@
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/misc)
 "fUU" = (
-/obj/machinery/door/airlock/maintenance_common,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/eris/crew_quarters/sleep)
 "fVc" = (
@@ -103980,7 +103963,7 @@
 /area/eris/maintenance/section4deck1central)
 "fZr" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/closet/wardrobe/color/black,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/crew_quarters/clothingstorage)
 "fZX" = (
@@ -103998,7 +103981,7 @@
 /area/eris/crew_quarters/bar)
 "gcz" = (
 /obj/machinery/door/airlock{
-	name = "Showers"
+	name = "Laundry Room"
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel,
@@ -104315,6 +104298,16 @@
 	},
 /turf/simulated/floor/tiled/steel/monofloor,
 /area/eris/quartermaster/hangarsupply)
+"haK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/spawner/scrap/sparse,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck4central)
 "hcG" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
@@ -104341,13 +104334,6 @@
 /obj/item/weapon/implant/core_implant/soulcrypt,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/surgery)
-"hfC" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/turf/simulated/open,
-/area/eris/crew_quarters/sleep)
 "hgv" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/spray/cleaner,
@@ -104463,6 +104449,18 @@
 /area/eris/crew_quarters/library{
 	name = "\improper Cafe"
 	})
+"hGq" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/catwalk,
+/obj/spawner/traps/wire_splicing/low_chance,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck4central)
 "hGz" = (
 /obj/spawner/mob/roaches/low_chance,
 /turf/simulated/floor/plating/under,
@@ -104588,6 +104586,16 @@
 /obj/item/weapon/stool/padded,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/clothingstorage)
+"hTU" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/spawner/traps,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck4central)
 "hVk" = (
 /obj/item/modular_computer/console/preset/security/camera,
 /turf/simulated/floor/tiled/dark/bluecorner,
@@ -104648,9 +104656,6 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/hallway/side/cryo)
 "igS" = (
-/obj/machinery/camera/network/fist_section{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -28
@@ -104725,13 +104730,9 @@
 /area/eris/neotheology/office)
 "iqm" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/turf/simulated/open,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
 "irX" = (
 /obj/structure/railing{
@@ -104814,7 +104815,7 @@
 /obj/machinery/camera/network/fist_section{
 	dir = 4
 	},
-/obj/structure/closet/wardrobe/color/black,
+/obj/structure/closet/secure_closet/personal,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/crew_quarters/clothingstorage)
 "iGR" = (
@@ -104930,6 +104931,12 @@
 "iVW" = (
 /obj/machinery/camera/network/fist_section{
 	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/crew_quarters/sleep)
@@ -105604,6 +105611,12 @@
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section1deck4central)
+"kVM" = (
+/obj/structure/table/rack/shelf,
+/obj/spawner/electronics/low_chance,
+/obj/spawner/lathe_disk/low_chance,
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck1central)
 "kYr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
 	dir = 4
@@ -105712,8 +105725,12 @@
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/maintenance/section2deck1port)
 "lrY" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/visible/universal,
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/structure/railing{
+	dir = 1
+	},
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "ltz" = (
@@ -105859,6 +105876,13 @@
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/command/bridge)
+"lSo" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck4central)
 "lSU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -106450,13 +106474,9 @@
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/quartermaster/office)
 "npN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance_interior{
-	name = "Service Maintenance";
-	req_access = list(12)
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techmaint_cargo,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/wall,
 /area/eris/crew_quarters/sleep)
 "npO" = (
 /obj/structure/disposalpipe/segment,
@@ -106555,6 +106575,10 @@
 /obj/spawner/booze/low_chance,
 /turf/simulated/floor/wood,
 /area/eris/maintenance/section4deck4central)
+"nEL" = (
+/obj/structure/lattice,
+/turf/simulated/open,
+/area/eris/maintenance/section3deck2starboard)
 "nEP" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -106731,6 +106755,16 @@
 /obj/structure/fitness/punchingbag,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/crew_quarters/clothingstorage)
+"onJ" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/spawner/junk/low_chance,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck4central)
 "oom" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table/rack/shelf,
@@ -106746,6 +106780,14 @@
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/kitchen)
+"ouk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/railing,
+/obj/spawner/traps,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck4central)
 "oup" = (
 /obj/structure/railing{
 	dir = 8
@@ -106755,6 +106797,8 @@
 /area/eris/engineering/atmos)
 "ouK" = (
 /obj/structure/closet/secure_closet/personal,
+/obj/spawner/surgery_tool/low_chance,
+/obj/spawner/surgery_tool/low_chance,
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/maintenance/section2deck3port)
 "ova" = (
@@ -106853,6 +106897,15 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
+"oKC" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
+	},
+/obj/structure/railing{
+	dir = 1
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck4central)
 "oKO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
@@ -107089,6 +107142,15 @@
 /area/eris/crew_quarters/library{
 	name = "\improper Cafe"
 	})
+"psz" = (
+/obj/structure/table/rack/shelf,
+/obj/spawner/pack/cloth,
+/obj/spawner/pack/cloth,
+/obj/spawner/pack/cloth/low_chance,
+/obj/spawner/pack/cloth/low_chance,
+/obj/spawner/pouch,
+/turf/simulated/floor/tiled/techmaint_panels,
+/area/eris/maintenance/section3deck1central)
 "psB" = (
 /obj/structure/table/bar_special,
 /obj/structure/curtain/open/bed{
@@ -107195,14 +107257,25 @@
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/crew_quarters/sleep)
 "pGF" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/carbon/superior_animal/roach/fuhrer,
-/turf/simulated/floor/tiled/steel/gray_perforated,
-/area/eris/maintenance/section2deck1port)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/spawner/traps,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck4central)
 "pHG" = (
 /obj/spawner/closet/wardrobe,
 /turf/simulated/floor/carpet/bcarpet,
 /area/eris/maintenance/section4deck4central)
+"pIM" = (
+/obj/spawner/mob/roaches/cluster,
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck1central)
 "pJu" = (
 /obj/structure/table/steel,
 /obj/item/stack/medical/bruise_pack/handmade,
@@ -107235,7 +107308,7 @@
 /turf/simulated/floor/hull,
 /area/space)
 "pMN" = (
-/obj/structure/bed/padded,
+/obj/machinery/camera/network/fist_section,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
 "pPE" = (
@@ -107328,6 +107401,16 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck1port)
+"qew" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/spawner/scrap/sparse/low_chance,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck4central)
 "qiG" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /obj/machinery/door/firedoor,
@@ -107578,6 +107661,7 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/sleep)
 "rgB" = (
@@ -107599,6 +107683,17 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
+"rix" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
+/obj/spawner/traps/wire_splicing/low_chance,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck4central)
 "rjs" = (
 /obj/structure/railing{
 	dir = 1
@@ -108133,6 +108228,18 @@
 /obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/wood,
 /area/eris/maintenance/section4deck4central)
+"sYE" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/catwalk,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/spawner/traps/wire_splicing/low_chance,
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section3deck4central)
 "sYM" = (
 /obj/machinery/disposal/deliveryChute{
 	dir = 1
@@ -108187,6 +108294,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/warden)
+"tbv" = (
+/obj/structure/table/rack/shelf,
+/obj/spawner/electronics,
+/obj/spawner/lathe_disk/advanced/low_chance,
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section3deck1central)
 "tdm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
@@ -108281,6 +108394,15 @@
 /obj/machinery/light/small,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/maintenance/section2deck1port)
+"trr" = (
+/obj/machinery/button/remote/blast_door{
+	id = "RDPrivacy";
+	name = "Merchant Office Privacy Shutters";
+	pixel_x = -4;
+	pixel_y = -32
+	},
+/turf/simulated/floor/carpet/purcarpet,
+/area/eris/command/meo)
 "tsa" = (
 /obj/structure/table/rack/shelf,
 /obj/spawner/tool/advanced,
@@ -108547,11 +108669,11 @@
 /area/eris/quartermaster/office)
 "ulp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
 	},
+/obj/structure/railing,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section3deck4central)
 "uly" = (
@@ -108587,9 +108709,8 @@
 	name = "\improper Cafe"
 	})
 "umE" = (
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
+/obj/structure/railing{
+	dir = 4
 	},
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
@@ -108911,12 +109032,9 @@
 /turf/simulated/floor/tiled/dark,
 /area/eris/rnd/lab)
 "vnV" = (
-/obj/structure/catwalk,
 /obj/structure/multiz/ladder,
 /obj/machinery/light/small,
-/obj/machinery/atmospherics/pipe/zpipe/down{
-	dir = 1
-	},
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "voV" = (
@@ -109009,6 +109127,13 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /turf/space,
 /area/space)
+"vIJ" = (
+/obj/machinery/door/airlock/maintenance_common{
+	name = "Service Maintenance";
+	req_access = list(12)
+	},
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section2deck2port)
 "vJq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -109091,13 +109216,9 @@
 	name = "\improper Cafe"
 	})
 "weZ" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/open,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/catwalk,
+/turf/simulated/floor/plating/under,
 /area/eris/crew_quarters/sleep)
 "wgg" = (
 /obj/structure/cable/green{
@@ -109123,6 +109244,7 @@
 	dir = 1;
 	pixel_y = -23
 	},
+/obj/structure/closet/wardrobe/color/mixed,
 /turf/simulated/floor/tiled/steel,
 /area/eris/crew_quarters/clothingstorage)
 "whK" = (
@@ -109179,12 +109301,11 @@
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
 "wth" = (
-/obj/structure/catwalk,
 /obj/structure/multiz/ladder,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/zpipe/down,
+/obj/structure/catwalk,
 /turf/simulated/open,
 /area/eris/crew_quarters/sleep)
 "wtQ" = (
@@ -109349,7 +109470,10 @@
 /area/eris/engineering/engine_room)
 "wOc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/crew_quarters/sleep)
@@ -109586,8 +109710,8 @@
 /area/eris/maintenance/section2deck2port)
 "xGG" = (
 /obj/structure/multiz/ladder/up,
-/obj/machinery/atmospherics/pipe/zpipe/up{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/visible{
+	dir = 5
 	},
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/crew_quarters/sleep)
@@ -109728,6 +109852,9 @@
 /obj/spawner/powercell,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/breakroom)
+"xXd" = (
+/turf/simulated/wall,
+/area/eris/maintenance/section3deck4central)
 "xZK" = (
 /obj/structure/multiz/stairs/active{
 	dir = 8
@@ -109769,6 +109896,13 @@
 	},
 /turf/simulated/floor/plating,
 /area/eris/crew_quarters/bar)
+"yhB" = (
+/obj/structure/railing{
+	dir = 1
+	},
+/obj/structure/lattice,
+/turf/simulated/open,
+/area/eris/maintenance/section3deck2starboard)
 "yjs" = (
 /obj/structure/railing/grey{
 	dir = 4
@@ -123174,8 +123308,8 @@ aaa
 aaa
 agD
 agW
-ahq
-ahF
+aeg
+aic
 ahZ
 alQ
 alv
@@ -123184,7 +123318,7 @@ aiD
 aiD
 igS
 alv
-alQ
+anj
 amu
 ahF
 ahq
@@ -123376,10 +123510,10 @@ aaa
 aaa
 agD
 agX
-ahr
-aeg
+aib
+agY
 acf
-aiD
+wOc
 aia
 ajS
 ajS
@@ -123387,8 +123521,8 @@ ajS
 ajS
 ajS
 alT
-aiD
-aeg
+wOc
+agY
 ahr
 agX
 agD
@@ -123577,22 +123711,22 @@ aaa
 aaa
 aaa
 agD
-agW
-ahq
-ahH
+ahr
 aib
-aiD
-alR
-alR
-alR
-alR
-alR
-alR
-alR
-amv
 ahH
-ahq
-anj
+alD
+wOc
+alR
+ald
+alR
+alR
+alR
+alR
+alR
+wOc
+agY
+aib
+ahr
 agD
 aaa
 aaa
@@ -123779,11 +123913,11 @@ aaa
 aaa
 aaa
 agD
-agY
-agY
+ahr
+aib
 agY
 pMN
-aiD
+wOc
 rTw
 alR
 alR
@@ -123793,8 +123927,8 @@ alR
 gBU
 iVW
 agY
-agY
-agY
+amx
+ahr
 agD
 aad
 aad
@@ -123981,11 +124115,11 @@ aaa
 abF
 abF
 agD
-agW
-ahq
+ahr
+aib
 ahF
-aic
-aiC
+acf
+wOc
 ajc
 alx
 alx
@@ -123994,9 +124128,9 @@ alx
 alx
 tGo
 wOc
-ahF
-ahq
-anj
+agY
+aib
+ahr
 agD
 aaa
 aaa
@@ -124184,7 +124318,7 @@ abX
 agD
 agD
 aje
-ald
+ahq
 npN
 aid
 aiE
@@ -126632,10 +126766,10 @@ dMt
 dNO
 aaa
 dLB
-aog
+aoh
 dMt
 dNN
-aoB
+aoR
 aoR
 dLB
 apz
@@ -163574,7 +163708,7 @@ aaa
 aaa
 aaa
 agD
-aYA
+bam
 aYV
 bjN
 aZO
@@ -163776,22 +163910,22 @@ aaa
 aaa
 aaa
 agD
-aYB
+wth
 aYW
-aVd
-aYW
-aYW
-aYW
-aVd
-bbD
-bch
-aVd
-aYW
-aYW
-aYW
-aVd
-aYW
-beH
+fUU
+aZD
+aZD
+aZD
+fUU
+bbG
+bci
+bbZ
+aZD
+aZD
+aZD
+bbZ
+cCn
+vnV
 agD
 aaa
 aad
@@ -163980,18 +164114,18 @@ aaa
 agD
 aYC
 aYX
-blE
+agf
 aZP
 aZP
 aZP
 bna
 bwG
 bci
-bna
+agf
 aZP
 aZP
 aZP
-blE
+agf
 beq
 beI
 agD
@@ -164180,22 +164314,22 @@ aaa
 aaa
 aaa
 agD
-agY
-agY
-agY
-agY
-agY
-agY
-agY
-bbF
+beI
+aYX
+aQs
+aZP
+aZP
+aZP
+aQs
+bbG
 bKs
-agY
-agY
-agY
-agY
-agY
-agY
-agY
+aQs
+aZP
+aZP
+aZP
+aQs
+beq
+aYC
 agD
 aaa
 aad
@@ -164382,22 +164516,22 @@ aaa
 aaa
 aaa
 agD
-aYA
-aYV
-bjN
-aZO
-aZO
-aZO
-bmA
+beI
+aYX
+agf
+aZP
+aZP
+aZP
+agf
 bbG
 bck
-bmA
-aZO
-aZO
-aZO
-bjN
-bep
-beG
+agf
+aZP
+aZP
+aZP
+agf
+beq
+beI
 agD
 aaa
 aad
@@ -164588,17 +164722,17 @@ wth
 lrY
 aUQ
 umE
-aYW
-aYW
-bno
-bbD
-bch
-aVd
-aYW
-aYW
-hfC
+umE
+umE
+bbZ
+bfL
+bci
+bbZ
+umE
+umE
+umE
 fUU
-lrY
+cHe
 vnV
 agD
 aaa
@@ -164787,17 +164921,17 @@ aae
 aaa
 agD
 bam
-bam
-agf
+axd
+aXa
 weZ
-aZP
-aZP
-bna
+weZ
+weZ
+bcO
 bbE
 bcl
 boE
-bdg
-bdg
+iqm
+iqm
 iqm
 boW
 ber
@@ -165395,16 +165529,16 @@ aaa
 aaa
 agf
 bBK
-aYW
-aYW
-aYW
+bap
+bap
+bap
 bno
 bbD
 bcn
 bno
-aYW
-aYW
-aYW
+bap
+bap
+bap
 bBK
 agf
 aaa
@@ -165598,14 +165732,14 @@ aaa
 agf
 aOq
 aZR
-bam
-bam
+baQ
+baQ
 agf
 bbD
 bHt
 agf
-bam
-bam
+baQ
+baQ
 bdF
 aOq
 agf
@@ -167014,8 +167148,8 @@ afs
 aVp
 aWc
 csS
-aXa
-aYS
+pCO
+bio
 baa
 cvH
 agD
@@ -167421,7 +167555,7 @@ csS
 aXj
 aYU
 bac
-cyw
+cvH
 aVd
 acf
 alV
@@ -167621,8 +167755,8 @@ aVp
 aWc
 csS
 aXl
-aYU
-bac
+blE
+boL
 cvH
 agY
 aEf
@@ -167822,10 +167956,10 @@ afs
 aVp
 aIz
 csS
-aXb
+bfk
 aZt
 bae
-cvH
+cyw
 agD
 alE
 alE
@@ -168025,9 +168159,9 @@ aVr
 aIz
 csS
 aXm
-aYS
+bio
 baf
-aHW
+cvH
 agD
 alI
 alI
@@ -168313,9 +168447,9 @@ bMz
 bMQ
 bNP
 bOh
+bvW
 bqj
-bqj
-bqj
+bvW
 bPd
 bPd
 bPd
@@ -168430,7 +168564,7 @@ aWf
 aWz
 csS
 aYS
-baa
+bpq
 cvH
 csS
 bbv
@@ -168515,7 +168649,7 @@ bMG
 bMX
 bNQ
 bOK
-bqj
+bvW
 bOD
 bOS
 bqj
@@ -168632,7 +168766,7 @@ aTF
 cHL
 csS
 aZu
-baa
+bpq
 baC
 csS
 aXI
@@ -168833,7 +168967,7 @@ aVH
 aVR
 aTK
 csS
-aYS
+boI
 ban
 baP
 bbm
@@ -168920,7 +169054,7 @@ abF
 bqj
 bON
 bON
-bON
+bPR
 bON
 bMZ
 bMZ
@@ -169037,7 +169171,7 @@ aTK
 csS
 aZC
 bao
-baQ
+baz
 bbn
 bbK
 bbW
@@ -169237,8 +169371,8 @@ aVr
 aIz
 aTK
 csS
-aZD
-cvH
+aLc
+hsA
 cvH
 cvH
 cvH
@@ -169440,8 +169574,8 @@ aIz
 aOp
 csS
 csS
-bap
-aQs
+aFe
+cvH
 cvH
 cvH
 bbY
@@ -169458,7 +169592,7 @@ aDd
 bel
 beK
 aDd
-aHN
+cHx
 aHR
 cio
 aHR
@@ -169643,10 +169777,10 @@ aRc
 aVR
 csS
 csS
-aFe
+aOS
 cvH
 bbN
-bbZ
+bcc
 bcM
 aXh
 aXh
@@ -169846,10 +169980,10 @@ aXo
 aVR
 csS
 aOS
-cgD
+cvH
 bbO
 bcc
-bcO
+bcM
 csS
 abF
 abF
@@ -170049,7 +170183,7 @@ aIz
 csS
 aOS
 cvH
-cvH
+cyw
 bcp
 bcP
 csS
@@ -170067,7 +170201,7 @@ aDd
 bfE
 aCN
 aCN
-aCN
+bem
 bel
 aDd
 aDd
@@ -170249,14 +170383,14 @@ aht
 aXq
 aZJ
 csS
-aOS
+csL
 cvH
 bbP
 bcq
 bcQ
 bcY
 bdr
-bdC
+cHo
 bdC
 bdC
 bdC
@@ -170282,7 +170416,7 @@ bnp
 boH
 bpM
 bmD
-bmD
+cKo
 bmD
 bmD
 cbh
@@ -170305,7 +170439,7 @@ gOy
 doY
 dnl
 doY
-cdz
+hGq
 tar
 mZL
 ctB
@@ -170460,7 +170594,7 @@ bdi
 bds
 bcR
 bcR
-bcR
+cHq
 bcR
 bdi
 aEn
@@ -170491,14 +170625,14 @@ cbl
 cdC
 bfN
 crq
-csL
+crq
 crq
 crq
 crq
 cEv
 cFB
 cHA
-crq
+sYE
 crq
 cZm
 crq
@@ -170671,8 +170805,8 @@ aDd
 beM
 aCN
 bfK
-aCN
-bel
+cHI
+cHI
 aDd
 bgX
 aCN
@@ -170704,9 +170838,9 @@ cdf
 cRs
 cZU
 cdf
-dfB
+cdf
 cAy
-cCn
+cGo
 cET
 cGo
 bbk
@@ -170872,8 +171006,8 @@ bdS
 aDd
 beN
 bfh
-bfL
-beQ
+bfK
+aCN
 aCN
 bbM
 bhf
@@ -170893,12 +171027,12 @@ aaa
 abF
 abF
 bbk
-bbk
-bCZ
+dfB
+dfE
 csO
-bCZ
+dfB
 bbk
-bbk
+dfB
 cdf
 dli
 cHC
@@ -170908,7 +171042,7 @@ bCH
 cJw
 cJw
 dpb
-dpb
+cGo
 cEV
 cGo
 bbk
@@ -171100,7 +171234,7 @@ cdf
 cdf
 cEm
 cvu
-bbk
+dfE
 cdf
 dli
 cHC
@@ -171109,9 +171243,9 @@ cSu
 cZX
 dcY
 cJw
-dpb
-dpb
-bbk
+lSo
+cGo
+xXd
 cGo
 bbk
 abF
@@ -171302,10 +171436,10 @@ cdf
 cdf
 ctH
 cFW
-bCZ
+dfE
 cdf
 dli
-cHC
+pGF
 cJw
 cTs
 dab
@@ -171504,7 +171638,7 @@ cdf
 cdf
 ctH
 cFW
-bCZ
+dqD
 cdf
 dli
 bst
@@ -171513,10 +171647,10 @@ cWb
 day
 ddc
 cxj
-dpb
-dpb
-bbk
-bbk
+ouk
+cGo
+xXd
+xXd
 bbk
 bbk
 bbk
@@ -171706,22 +171840,22 @@ cdf
 cdf
 cEl
 cGN
-bbk
+dfB
 cdf
 dli
-cHC
+pGF
 cJw
 cWe
 daz
-ddh
+ddq
 cJw
-dpb
-dpb
-bbk
+ouk
+cGo
+xXd
 bvG
 dqA
-bbk
-cHe
+xXd
+cae
 bbk
 aaa
 bsY
@@ -171903,12 +172037,12 @@ aad
 abF
 abF
 bbk
-bbk
-bCZ
+dfB
+dqD
 csO
-bCZ
-bbk
-bbk
+dfE
+dfE
+dfB
 chn
 dli
 cHC
@@ -171916,14 +172050,14 @@ cJw
 dsz
 daz
 ddq
-dfE
-dpb
+cJw
+lSo
 cEe
 ccX
 bvH
 cEi
 cGW
-cHq
+cHG
 bbk
 aaa
 bsY
@@ -172118,14 +172252,14 @@ cJw
 cJw
 cxj
 cJw
-dfE
-dpb
-bZy
-crg
+cJw
+lSo
+cHG
+oKC
 bvI
 cFY
-csN
-cHx
+cGW
+cHG
 bbk
 aaa
 bsY
@@ -172312,22 +172446,22 @@ cAZ
 cBR
 cEs
 cEs
-cKo
-cdC
+cEs
+cEs
 dlH
 doP
 dqx
-dqx
-dqx
-dqx
-dqx
+hTU
+hTU
+onJ
+haK
 cAY
-dqx
+rix
 dOj
 byN
 cxF
-csN
-cHo
+cGW
+cHG
 bbk
 aaa
 abF
@@ -172515,21 +172649,21 @@ bnu
 bqm
 bri
 cKL
-bsf
-bsf
+cKL
+cKL
 czV
 cEH
+fJR
+fJR
 cEH
-cEH
-cEH
-cEH
+fJR
 ulp
 cDS
 cFL
 cBw
-dqD
-cGT
-cHo
+bZy
+cGW
+cHG
 bbk
 aad
 abF
@@ -172730,8 +172864,8 @@ cgO
 dnI
 cBw
 bZy
-cGT
-cHI
+cGW
+cHG
 bbk
 aaa
 abF
@@ -172930,10 +173064,10 @@ clj
 clw
 cgO
 dnI
-cBM
+qew
 cDV
 cBu
-cHI
+cHG
 bbk
 aaa
 abF
@@ -207417,8 +207551,8 @@ bws
 caL
 bRT
 bRW
-bRX
-bRY
+fZr
+fZr
 fZr
 fZr
 iEL
@@ -213711,7 +213845,7 @@ cmG
 ctR
 cuE
 cvj
-cvj
+trr
 cwa
 cto
 aaa
@@ -244401,7 +244535,7 @@ dcQ
 bdL
 bdL
 bdL
-fht
+vIJ
 fht
 bdL
 bdL
@@ -259177,9 +259311,9 @@ btI
 btI
 axk
 dro
-drG
-axv
-dqN
+yhB
+nEL
+eZG
 axA
 axl
 btI
@@ -259779,7 +259913,7 @@ aaa
 aaa
 aaa
 btI
-axd
+evc
 btI
 axo
 axo
@@ -259789,7 +259923,7 @@ axv
 axo
 axo
 btI
-axd
+evc
 btI
 axq
 btI
@@ -284797,7 +284931,7 @@ aaa
 aaa
 alb
 wCA
-pGF
+maq
 iAu
 alb
 alb
@@ -292917,7 +293051,7 @@ bsp
 bth
 buj
 bth
-buJ
+psz
 boN
 bkK
 eAO
@@ -295335,7 +295469,7 @@ bib
 cNH
 boS
 bnT
-bqC
+kVM
 bqC
 dXi
 btJ
@@ -295739,7 +295873,7 @@ bij
 cNH
 boS
 bnT
-bqC
+tbv
 brU
 dXi
 eAo
@@ -296542,8 +296676,8 @@ abF
 dXi
 dXi
 dXi
-bfk
-bio
+bfv
+bfv
 bkS
 boS
 boS
@@ -296744,7 +296878,7 @@ abF
 aaa
 abF
 dXi
-bfs
+bip
 bip
 bkT
 boS
@@ -297570,7 +297704,7 @@ eBe
 cNH
 boS
 bBu
-boI
+boF
 boS
 boS
 boS
@@ -298366,7 +298500,7 @@ biH
 blA
 blA
 cNH
-cNH
+pIM
 aRM
 cNH
 cNH
@@ -298784,7 +298918,7 @@ boS
 boF
 boF
 boU
-bpq
+boU
 boU
 btG
 boF
@@ -299388,7 +299522,7 @@ dXi
 boS
 boS
 boF
-boL
+boF
 boV
 bpr
 bpr
@@ -300182,7 +300316,7 @@ aaa
 dXi
 bkJ
 dXi
-bpv
+aLZ
 brh
 brh
 bpv

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -88820,10 +88820,6 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/hallway/side/section3starboard)
 "dZh" = (
-/obj/structure/bed/chair{
-	dir = 1
-	},
-/obj/landmark/join/start/assistant,
 /obj/machinery/holoposter{
 	pixel_x = 32
 	},
@@ -103892,14 +103888,6 @@
 /obj/spawner/junk/low_chance,
 /turf/simulated/floor/tiled/dark/techfloor,
 /area/eris/security/prison)
-"fwz" = (
-/obj/structure/bed/chair,
-/obj/landmark/join/start/assistant,
-/obj/machinery/holoposter{
-	pixel_x = 32
-	},
-/turf/simulated/floor/tiled/steel/brown_perforated,
-/area/eris/maintenance/section3deck3starboard)
 "fyF" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -105356,13 +105344,6 @@
 /obj/effect/shuttle_landmark/merc/atmos,
 /turf/space,
 /area/space)
-"jWU" = (
-/obj/machinery/door/airlock/maintenance_common{
-	name = "Service Maintenance";
-	req_access = list(12)
-	},
-/turf/simulated/floor/tiled/steel/brown_platform,
-/area/eris/maintenance/section3deck3starboard)
 "kcK" = (
 /obj/machinery/floor_light/prebuilt{
 	color = "#8F00FF";
@@ -218696,9 +218677,9 @@ dFG
 dvd
 ewa
 dSb
+ewg
 dZh
-dUc
-fwz
+ewa
 dSb
 ewg
 dvd
@@ -218899,7 +218880,7 @@ dvd
 dRv
 dRv
 dRv
-jWU
+dRv
 dRv
 dRv
 dRv


### PR DESCRIPTION
## About The Pull Request

This PR shifts around some things in maint, mostly the lower-effort spawns for higher value things.
Notable changes include fixing some maints near the pool, the section 1 vaggie spawn, and adding a lower door to the spider pit.

## Why It's Good For The Game

This PR mostly just shakes things up a tiny bit. Overall it's a minor change, but it will make things a bit less predictable in the easier areas of maintaince. 

## Changelog
```changelog
tweak: several spawns in maint have been moved around
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
