### PR TITLE
Removing duplicate definition/override

### DIFF
--- a/zzzz_modular_occulus/code/game/occulus-lore-fixes.dm
+++ b/zzzz_modular_occulus/code/game/occulus-lore-fixes.dm
@@ -131,10 +131,6 @@
 	name = "MK PR \"Purger\""
 	desc = "A more recent \"Mekhane\" brand plasma rifle, developed in direct response to compete against the highly successful \"Cassad\" design."
 
-/obj/item/weapon/gun/energy/plasma/brigador
-	name = "Frozen Star PP \"Brigador\""
-	desc = "\"Frozen Star\" brand energy pistol, for personal overprotection without the bulk of the Cassad."
-
 /obj/item/weapon/gun/energy/plasma/martyr // or should it be  Zealot
 	name = "MK PR \"Martyr\""
 	desc = "A \"Mekhane\" weapon that uses advanced biomass conversion controllable blasts of energized matter. is a disposable side arm, good enough to save you and be recycled."


### PR DESCRIPTION
## About The Pull Request

removing duplicate definition/override
This is now fixed in PR #667

## Why It's Good For The Game

Cleans up some files

## Changelog
```changelog
admin: Brigador override is now in a single file
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
