### PR TITLE
Rounds off Union Exports

### DIFF
--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -68,7 +68,7 @@ SUBSYSTEM_DEF(supply)
 			continue
 
 		msg += "[export_text]<br>"
-		points += E.total_cost
+		points += round(E.total_cost) // Occulus Edit - Fixes the Union account getting non-integer credits. (round() rounds down)
 
 	msg += "<br>Total exports value: [points] credits.<br>"
 	exports.Cut()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Deletes pennies from Union exports. This uses round() which in byond, is just flooring something. (Read: Rounding down.)
The rounding only happens right before the credits are added to the Union account, so there won't be any losses if three items have XXX.4 credit value.

## Why It's Good For The Game

Pennies shouldn't exist.

## Changelog
```changelog
tweak: Union exports will no longer put pennies (less than whole credits) into the account.
```