### PR TITLE
more bugfixes

### DIFF
--- a/code/game/objects/items/weapons/tools/_tools.dm
+++ b/code/game/objects/items/weapons/tools/_tools.dm
@@ -701,7 +701,7 @@
 	switched_on = FALSE
 	STOP_PROCESSING(SSobj, src)
 	tool_qualities = switched_off_qualities
-	if (!isnull(switched_off_force))//Occulus Edit: Fioxing togglable tool damage
+	if (!isnull(switched_off_force))//Occulus Edit: Fixing togglable tool damage
 		force = switched_off_force//Occulus Edit fixing togglable tool damage
 		if(wielded)//Occulus Edit: REEEEEE!
 			force *= 1.3//Occulus Edit: REEEE
@@ -814,6 +814,7 @@
 	use_power_cost = initial(use_power_cost)
 	force = initial(force)
 	switched_on_force = initial(switched_on_force)
+	switched_off_force= initial(switched_off_force)//Aha, found you you little bugger Occulus Edit
 	extra_bulk = initial(extra_bulk)
 	item_flags = initial(item_flags)
 	name = initial(name)

--- a/code/game/objects/items/weapons/tools/mods/_upgrades.dm
+++ b/code/game/objects/items/weapons/tools/mods/_upgrades.dm
@@ -225,13 +225,13 @@
 	if(tool_upgrades[UPGRADE_FORCE_MOD])
 		T.force += tool_upgrades[UPGRADE_FORCE_MOD]
 		if(T.force_wielded)//Occulus Edit start. Apparantly this was just never considered
-			T.force_wielded *= tool_upgrades[UPGRADE_FORCE_MOD]
+			T.force_wielded += tool_upgrades[UPGRADE_FORCE_MOD]
 		if(T.force_unwielded)
-			T.force_unwielded *= tool_upgrades[UPGRADE_FORCE_MOD]
+			T.force_unwielded += tool_upgrades[UPGRADE_FORCE_MOD]
 		if(T.switched_on_force)
-			T.switched_on_force *= tool_upgrades[UPGRADE_FORCE_MOD]
+			T.switched_on_force += tool_upgrades[UPGRADE_FORCE_MOD]
 		if(T.switched_off_force)
-			T.switched_off_force *= tool_upgrades[UPGRADE_FORCE_MOD]//Occulus Edit end
+			T.switched_off_force += tool_upgrades[UPGRADE_FORCE_MOD]//Occulus Edit end
 	if(tool_upgrades[UPGRADE_FUELCOST_MULT])
 		T.use_fuel_cost *= tool_upgrades[UPGRADE_FUELCOST_MULT]
 	if(tool_upgrades[UPGRADE_POWERCOST_MULT])


### PR DESCRIPTION
## About The Pull Request

Fixes a missed prod in applying upgrades, causing MAJOR issues with batons and other objects that turn on. Like charge hammers

## Why It's Good For The Game

I missed this while testing. Needs in quickly since 8000 damage batons are not intended


## Changelog
```changelog
fix: Stun batons now apply damagemods even more correctly
fix: for real this time.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
