### PR TITLE
More support for toolmod bugfixes

### DIFF
--- a/code/game/objects/items/weapons/tools/hammer.dm
+++ b/code/game/objects/items/weapons/tools/hammer.dm
@@ -126,6 +126,7 @@
 	item_state = "chargehammer"
 	w_class = ITEM_SIZE_HUGE
 	switched_on_force = WEAPON_FORCE_BRUTAL
+	switched_off_force = WEAPON_FORCE_PAINFUL //Occulus Edit
 	structure_damage_factor = STRUCTURE_DAMAGE_BREACHING
 	switched_on_qualities = list(QUALITY_HAMMERING = 60)
 	switched_off_qualities = list(QUALITY_HAMMERING = 35)

--- a/code/game/objects/items/weapons/tools/knives.dm
+++ b/code/game/objects/items/weapons/tools/knives.dm
@@ -133,6 +133,7 @@
 	item_state = "bluespace_dagger"
 	matter = list(MATERIAL_PLASTEEL = 3, MATERIAL_PLASTIC = 2, MATERIAL_SILVER = 10, MATERIAL_GOLD = 5, MATERIAL_PHORON = 20)
 	switched_on_force = WEAPON_FORCE_NORMAL+1
+	switched_off_force = WEAPON_FORCE_NORMAL//Occulus Edit
 	armor_penetration = ARMOR_PEN_DEEP
 	embed_mult = 25 //You WANT it to embed
 	suitable_cell = /obj/item/weapon/cell/small
@@ -210,6 +211,7 @@
 	sharp = FALSE
 	force = WEAPON_FORCE_WEAK
 	switched_on_force = WEAPON_FORCE_NORMAL+2
+	switched_off_force = WEAPON_FORCE_WEAK//Occulus Edit
 	armor_penetration = ARMOR_PEN_GRAZING
 	matter = list(MATERIAL_PLASTEEL = 4, MATERIAL_STEEL =6)
 	switched_on_qualities = list(QUALITY_CUTTING = 20, QUALITY_WIRE_CUTTING = 10, QUALITY_SCREW_DRIVING = 5)
@@ -233,6 +235,8 @@
 	w_class = switched_on_w_class
 	if (!isnull(switched_on_force))
 		force = switched_on_force
+		if(wielded)//Occulus Edit: REEEEEE!
+			force *= 1.3//Occulus Edit: REEEE
 	update_icon()
 	update_wear_icon()
 
@@ -245,7 +249,10 @@
 	to_chat(user, SPAN_NOTICE("You flip [src] back into the handle gracefully."))
 	switched_on = FALSE
 	tool_qualities = switched_off_qualities
-	force = initial(force)
+	if (!isnull(switched_off_force))//Occulus Edit: Fixing togglable tool damage
+		force = switched_off_force//Occulus Edit fixing togglable tool damage
+		if(wielded)//Occulus Edit: REEEEEE!
+			force *= 1.3//Occulus Edit: REEEE
 	w_class = initial(w_class)
 	update_icon()
 	update_wear_icon()
@@ -261,6 +268,7 @@
 	sharp = FALSE
 	force = WEAPON_FORCE_WEAK
 	switched_on_force = WEAPON_FORCE_PAINFUL
+	switched_off_force = WEAPON_FORCE_WEAK //Occulus_Edit
 	w_class = ITEM_SIZE_TINY
 	var/switched_on_w_class = ITEM_SIZE_SMALL
 	matter = list(MATERIAL_PLASTEEL = 4, MATERIAL_STEEL = 6, MATERIAL_GOLD= 0.5)
@@ -282,6 +290,8 @@
 	tool_qualities = switched_on_qualities
 	if (!isnull(switched_on_force))
 		force = switched_on_force
+		if(wielded)
+			force *= 1.3
 	w_class = switched_on_w_class
 	update_icon()
 	update_wear_icon()
@@ -295,7 +305,10 @@
 	to_chat(user, SPAN_NOTICE("You press the button and [src] swiftly retracts."))
 	switched_on = FALSE
 	tool_qualities = switched_off_qualities
-	force = initial(force)
+	if (!isnull(switched_off_force))//Occulus Edit: Fixing togglable tool damage
+		force = switched_off_force//Occulus Edit fixing togglable tool damage
+		if(wielded)//Occulus Edit: REEEEEE!
+			force *= 1.3//Occulus Edit: REEEE
 	w_class = initial(w_class)
 	update_icon()
 	update_wear_icon()

--- a/code/game/objects/items/weapons/tools/pickaxe.dm
+++ b/code/game/objects/items/weapons/tools/pickaxe.dm
@@ -52,6 +52,7 @@
 	matter = list(MATERIAL_STEEL = 4, MATERIAL_PLATINUM = 2, MATERIAL_DIAMOND = 2)
 	origin_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 2, TECH_POWER = 3)
 	switched_on_force = WEAPON_FORCE_ROBUST
+	switched_off_force = WEAPON_FORCE_DANGEROUS//Occulus Edit
 	tool_qualities = list(QUALITY_EXCAVATION = 15, QUALITY_PRYING = 25)
 	switched_off_qualities = list(QUALITY_EXCAVATION = 15, QUALITY_PRYING = 25)
 	switched_on_qualities = list(QUALITY_DIGGING = 40, QUALITY_PRYING = 20)

--- a/code/game/objects/items/weapons/tools/simple_weapons.dm
+++ b/code/game/objects/items/weapons/tools/simple_weapons.dm
@@ -185,6 +185,7 @@
 	switched_on_qualities = list(QUALITY_CUTTING = 25)
 	origin_tech = list(TECH_COMBAT = 5, TECH_MATERIAL = 6)
 	switched_on_force = WEAPON_FORCE_BRUTAL
+	switched_off_force = WEAPON_FORCE_DANGEROUS * 1.5
 	rarity_value = 60
 	spawn_blacklisted = TRUE
 

--- a/code/game/objects/items/weapons/tools/weldingtools.dm
+++ b/code/game/objects/items/weapons/tools/weldingtools.dm
@@ -6,6 +6,7 @@
 	flags = CONDUCT
 	force = WEAPON_FORCE_WEAK
 	switched_on_force = WEAPON_FORCE_PAINFUL
+	switched_off_force = WEAPON_FORCE_WEAK //Occulus Edit
 	throwforce = WEAPON_FORCE_WEAK
 	worksound = WORKSOUND_WELDING
 	matter = list(MATERIAL_STEEL = 5)

--- a/zzzz_modular_occulus/code/game/objects/items/tools/batons.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/tools/batons.dm
@@ -7,6 +7,7 @@
 	slot_flags = SLOT_BELT
 	force = WEAPON_FORCE_PAINFUL
 	switched_on_force = WEAPON_FORCE_PAINFUL
+	switched_off_force = WEAPON_FORCE_PAINFUL
 	sharp = FALSE
 	edge = FALSE
 	throwforce = WEAPON_FORCE_PAINFUL


### PR DESCRIPTION
## About The Pull Request

Adds a switched_off value and turn_off proc adjustments for a bunch of tools that use it

## Why It's Good For The Game

More fixes, small ones.

## Changelog
```changelog
fix: More support for modifying tools that have on and off states. Like butterly knives and switchblades.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
