### PR TITLE
Removed Extraneous Instructional Spawners

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -45476,7 +45476,6 @@
 "cbZ" = (
 /obj/structure/table/standard,
 /obj/machinery/recharger,
-/obj/spawner/instructional/low,
 /turf/simulated/floor/carpet/turcarpet,
 /area/eris/crew_quarters/clothingstorage)
 "cca" = (
@@ -45729,7 +45728,6 @@
 	},
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
-/obj/spawner/instructional/low,
 /turf/simulated/floor/carpet/turcarpet,
 /area/eris/crew_quarters/clothingstorage)
 "ccH" = (


### PR DESCRIPTION
Two instructional spawners were still on the map, causing runtimes.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The two instructional spawners in the lounge by the workout room weren't deleted on my old deletion pass. They were causing a few runtimes on startup (aroun 10?). Now they are gone, so they should be causing zero (0) runtimes (I hope.)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This should clear up some extra runtimes. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
del: Deleted a pair of extra instructional spawners that weren't working.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
