### PR TITLE
Adds a missing disposal pipe to the Cargo office

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -54204,6 +54204,9 @@
 	name = "Cargo Office";
 	req_access = list(31)
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/office)
 "cxJ" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As per title, there's a missing disposals pipe for the Cargo office (specifically, under the door.)
Fixes #680 

## Why It's Good For The Game

Broken disposal pipes make drones sad :(

## Changelog
```changelog
fix: Fixes the Cargo Office disposals missing a pipe.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
