### PR TITLE
Rebalance of SPUDs and Knockoff Roombas, and Engineering QOL

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -60662,7 +60662,7 @@
 	id = "complicator";
 	name = "EES SED ID lock";
 	pixel_x = 28;
-	req_access = list(56)
+	req_access = list(23)
 	},
 /turf/simulated/open,
 /area/eris/engineering/engine_room)
@@ -107234,12 +107234,16 @@
 	dir = 8
 	},
 /obj/structure/table/rack/shelf,
-/obj/item/stack/material/steel/full,
+/obj/item/stack/material/steel/full{
+	pixel_x = -4;
+	pixel_y = -4
+	},
 /obj/item/stack/material/wood/random,
 /obj/item/stack/material/wood/random,
-/obj/item/stack/material/wood/random,
-/obj/item/stack/material/wood/random,
-/obj/item/stack/material/wood/random,
+/obj/item/stack/material/plastic/full{
+	pixel_x = 4;
+	pixel_y = 3
+	},
 /turf/simulated/floor/plating,
 /area/eris/engineering/construction)
 "ogT" = (

--- a/zzzz_modular_occulus/code/game/objects/items/devices/bosstown.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/devices/bosstown.dm
@@ -9,6 +9,7 @@
 	price_tag = 20000 // One of a kind relic-tier price and tech levels
 	origin_tech = list(TECH_DATA = 5, TECH_ENGINEERING = 5, TECH_MAGNET = 5)
 	matter = list(MATERIAL_PLASTIC = 2, MATERIAL_GLASS = 1, MATERIAL_STEEL = 5)
+	spawn_blacklisted = TRUE
 	var/cooldown = 20 MINUTES
 	var/last_search = -20 MINUTES
 	var/obj/item/device/radio/radio
@@ -40,6 +41,7 @@
 			for(var/i = 1, i <= num_spawns_per_area,i++)
 				new /obj/spawner/mob/cluster/roombattler(heck)
 		radio.autosay("Synthetic entities detected at [english_list(areanames)]." , "Mk.XIV Synthetic Entity Detector", "Engineering")
+		new /obj/item/weapon/paper(user.loc, areanames.Join("\n"), "SED Location Report")
 	else
 		to_chat(user, SPAN_WARNING("The [src] needs time to recharge!"))
 

--- a/zzzz_modular_occulus/code/modules/mob/living/simple_animal/hostile/roombattler.dm
+++ b/zzzz_modular_occulus/code/modules/mob/living/simple_animal/hostile/roombattler.dm
@@ -7,8 +7,8 @@
 	turns_per_move = 5
 	move_to_delay = 7
 	speed = 8
-	maxHealth = 200
-	health = 200
+	maxHealth = 100
+	health = 100
 	resistance = 5
 	speak = list(
 				"New target acquired.",
@@ -33,7 +33,7 @@
 
 	environment_smash = 1
 
-	agony_coefficient = 0 // super armored unit, doesn't take damage from non-lethals.
+	agony_coefficient = 0.5 // super armored unit, doesn't take much damage from non-lethals.
 
 	faction = "bosstown"
 
@@ -45,7 +45,7 @@
 	spawn_tags = SPAWN_ROOMBATTLER
 	rarity_value = 5
 
-	var/loot_table = list(/obj/spawner/techpart,
+	var/loot_table = list(/obj/spawner/powercell/medium,
 						/obj/spawner/tool_upgrade/rare)
 
 /mob/living/simple_animal/hostile/roombattler/death()
@@ -72,13 +72,13 @@
 	projectilesound = 'sound/weapons/guns/fire/pistol_fire.ogg'
 	minimum_distance = 3
 	ranged_cooldown = 5 SECONDS
-	maxHealth = 100
-	health = 100
-	agony_coefficient = 0.5 // half shields, half health, half defense
+	maxHealth = 50
+	health = 50
+	agony_coefficient = 0.8 // half shields, half health, half defense
 
 	rarity_value = 10
 
-	loot_table = list(/obj/spawner/techpart,
+	loot_table = list(/obj/spawner/gun_upgrade,
 					/obj/spawner/pack/gun_loot)
 
 /obj/item/projectile/bullet/clrifle/rubber/weak

--- a/zzzz_modular_occulus/code/modules/mob/living/simple_animal/hostile/spud.dm
+++ b/zzzz_modular_occulus/code/modules/mob/living/simple_animal/hostile/spud.dm
@@ -5,8 +5,8 @@
 	icon_state = "spud"
 	speak_chance = 5
 	turns_per_move = 3
-	maxHealth = 250
-	health = 250
+	maxHealth = 100
+	health = 100
 	resistance = 5
 	speak = list(
 				"New target acquired.",
@@ -32,7 +32,7 @@
 
 	environment_smash = 1
 
-	agony_coefficient = 0.5 // armored unit, doesn't take much damage from non-lethals.
+	agony_coefficient = 0.8 // armored unit, doesn't take much damage from non-lethals.
 
 	faction = "neutral"
 
@@ -64,8 +64,6 @@
 	name = "\improper FS SPUD unit"
 	desc = "A popular product from Automita Dynamics Incorporated, the Synchronized Pseudopodal Utility Demonstrator unit is a modular robot capable of fufilling all manner of tasks. This one has a cool Frozen Star paintjob."
 	icon_state = "frozen"
-	melee_damage_lower = 15
-	melee_damage_upper = 30
 	light_color = COLOR_LIGHTING_RED_BRIGHT
 	rarity_value = 10
 
@@ -73,13 +71,11 @@
 	name = "\improper blood-red SPUD unit"
 	desc = "A popular product from Automita Dynamics Incorporated, the Synchronized Pseudopodal Utility Demonstrator unit is a modular robot capable of fufilling all manner of tasks. This one has a snazzy blood-red paintjob and makes angry sounding beeps."
 	icon_state = "syndi"
-	melee_damage_lower = 15
-	melee_damage_upper = 30
 	light_color = COLOR_LIGHTING_GREEN_BRIGHT
 	faction = "bosstown"
 	spawn_tags = SPAWN_ROOMBATTLER
 	rarity_value = 100
-	loot_table = list(/obj/spawner/contraband,
+	loot_table = list(/obj/item/weapon/computer_hardware/hard_drive/portable/research_points,
 					/obj/spawner/tool/advanced/onestar)
 
 /mob/living/simple_animal/hostile/spud/syndi/infiltrator //Infiltrator unit designed to synergize with local hostile fauna


### PR DESCRIPTION
## About The Pull Request

This PR halves the health and damage resistance of SPUDs and Knockoff Roombas. Their loot tables have also been tweaked slightly. In addition, the SED is now blacklisted, accessible to regular engineers, and will print out a list of spawn locations. Finally, map tweaks are included to tidy up the materials available in EES' gunsmithing room.

## Why It's Good For The Game

Overall QoL improvement for engineers, Knockoff Roombas are less CBT to fight.

## Changelog
```changelog
add: SED now prints out a list of detected robot locations in addition to relaying it via radio.
balance: all SPUDs and combat roombas spawned by the SED now have half the health and non-lethal damage resistance they had previously.
```
