### PR TITLE
unfuckles carpet crates

### DIFF
--- a/code/game/objects/items/stacks/tiles/tile_types.dm
+++ b/code/game/objects/items/stacks/tiles/tile_types.dm
@@ -95,31 +95,7 @@
 /obj/item/stack/tile/carpet/oracarpet
 	name = "orange carpet"
 	icon_state = "tile_oracarpet"
-//occulus additions start for carpet crate packs
-/obj/item/stack/tile/carpet/cpack
-	amount = 30
 
-/obj/item/stack/tile/carpet/bcarpet/cpack
-	amount = 30
-
-/obj/item/stack/tile/carpet/blucarpet/cpack
-	amount = 30
-
-/obj/item/stack/tile/carpet/turcarpet/cpack
-	amount = 30
-
-/obj/item/stack/tile/carpet/sblucarpet/cpack
-	amount = 30
-
-/obj/item/stack/tile/carpet/gaycarpet/cpack
-	amount = 30
-
-/obj/item/stack/tile/carpet/purcarpet/cpack
-	amount = 30
-
-/obj/item/stack/tile/carpet/oracarpet/cpack
-	amount = 30
-//Occulus addition end
 /*
  * Flooring parent
  */

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1432,22 +1432,24 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	group = "Miscellaneous"
 //Occulus Addition
 /datum/supply_pack/warmcarpet
-	contains = list(/obj/item/stack/tile/carpet/cpack,
-				/obj/item/stack/tile/carpet/oracarpet/cpack,
-				/obj/item/stack/tile/carpet/gaycarpet/cpack,
-				/obj/item/stack/tile/carpet/sblucarpet/cpack
+	contains = list(/obj/item/stack/tile/carpet,
+				/obj/item/stack/tile/carpet/oracarpet,
+				/obj/item/stack/tile/carpet/gaycarpet,
+				/obj/item/stack/tile/carpet/sblucarpet
 				)
+	amount = 30
 	name = "Warm Carpet Crate"
 	cost = 3500
 	crate_name = "warm carpet crate"
 	group = "Miscellaneous"
 
 /datum/supply_pack/coldcarpet
-	contains = list(/obj/item/stack/tile/carpet/blucarpet/cpack,
-					/obj/item/stack/tile/carpet/turcarpet/cpack,
-					/obj/item/stack/tile/carpet/bcarpet/cpack,
-					/obj/item/stack/tile/carpet/purcarpet/cpack
+	contains = list(/obj/item/stack/tile/carpet/blucarpet,
+					/obj/item/stack/tile/carpet/turcarpet,
+					/obj/item/stack/tile/carpet/bcarpet,
+					/obj/item/stack/tile/carpet/purcarpet
 					)
+	amount = 30
 	name = "Cool Carpet Crate"
 	cost = 3500
 	crate_name = "cool carpet crate"
@@ -1670,15 +1672,16 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 //Occulus addition start
 /datum/supply_pack/randomised/carpet
 	num_contained = 4
-	contains = list(/obj/item/stack/tile/carpet/cpack,
-					/obj/item/stack/tile/carpet/bcarpet/cpack,
-					/obj/item/stack/tile/carpet/blucarpet/cpack,
-					/obj/item/stack/tile/carpet/turcarpet/cpack,
-					/obj/item/stack/tile/carpet/sblucarpet/cpack,
-					/obj/item/stack/tile/carpet/gaycarpet/cpack,
-					/obj/item/stack/tile/carpet/purcarpet/cpack,
-					/obj/item/stack/tile/carpet/oracarpet/cpack
+	contains = list(/obj/item/stack/tile/carpet,
+					/obj/item/stack/tile/carpet/bcarpet,
+					/obj/item/stack/tile/carpet/blucarpet,
+					/obj/item/stack/tile/carpet/turcarpet,
+					/obj/item/stack/tile/carpet/sblucarpet,
+					/obj/item/stack/tile/carpet/gaycarpet,
+					/obj/item/stack/tile/carpet/purcarpet,
+					/obj/item/stack/tile/carpet/oracarpet
 					)
+	amount = 30
 	name = "Surplus Carpet Crate"
 	cost = 2500
 	crate_name = "Surplus Carpet Crate"


### PR DESCRIPTION

## About The Pull Request

Makes the carpets in carpet crates actually work.

## Why It's Good For The Game

fixes a fucky wucky i made OwO

## Changelog
```changelog
fix: fixes carpet crates by tying the amount to the crate, and not making a child that i thought would inherit the parent tile type, but for some reason didn't, and so i had to make this innane PR fixing an issue i should have tested, but had no idea it wouldn't have worked except for the few times i DID accidentally come acrossed it but never checked because i'm an idiot.
```


