### PR TITLE
Stat caps, infections on examine, and empath perk

### DIFF
--- a/code/__DEFINES/perks.dm
+++ b/code/__DEFINES/perks.dm
@@ -35,6 +35,7 @@
 #define PERK_ABSOLUTE_GRAB /datum/perk/oddity/absolute_grab
 #define PERK_SURE_STEP /datum/perk/oddity/sure_step
 #define PERK_MARKET_PROF /datum/perk/oddity/market_prof
+#define PERK_EMPATH /datum/perk/oddity/empath //Occulus edit
 
 //job perks
 #define PERK_ARTIST /datum/perk/job/artist

--- a/code/datums/mob_stats.dm
+++ b/code/datums/mob_stats.dm
@@ -29,7 +29,7 @@
 /datum/stat_holder/proc/changeStat(statName, Value)
 	var/datum/stat/S = stat_list[statName]
 	S.changeValue(Value)
-	
+
 /datum/stat_holder/proc/setStat(statName, Value)
 	var/datum/stat/S = stat_list[statName]
 	S.setValue(Value)
@@ -170,8 +170,21 @@
 		if(SM.id == id)
 			return SM
 
-/datum/stat/proc/changeValue(affect)
-	value = value + affect
+/datum/stat/proc/changeValue(affect)//Occulus Edit start: Softcaps
+	var/affectover
+	if(value+affect > 80)
+		if(value > 80)
+			value = round(value+(affect*0.25))
+		else
+			affectover = (value+affect-80)*0.25
+			value= round((80+affectover))
+	else if(value+affect > 60)
+		if(value > 60)
+			value = round(value+(affect*0.5))
+		else
+			affectover = (value+affect-60)*0.5
+			value = round((60+affectover))
+	else( value = value + affect)//Occulus Edit End
 
 /datum/stat/proc/getValue(pure = FALSE)
 	if(pure)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -266,10 +266,6 @@
 			wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.joint] is dislocated!</span><br>"
 		if(((temp.status & ORGAN_BROKEN) && temp.brute_dam > temp.min_broken_damage) || (temp.status & ORGAN_MUTATED))
 			wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] is dented and swollen!</span><br>"
-		for(var/obj/item/organ/internal/blood_vessel/BV in temp.internal_organs)//Occulus Edit: Ruptured Blood Vessel
-			if(BV.damage > 0)//occulus Edit: Ruptured blood vessel
-				wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] swollen and discolored!</span><br>"//Occulus Edit: Ruptured Blood vessel
-
 
 	//Handles the text strings being added to the actual description.
 	//If they have something that covers the limb, and it is not missing, put flavortext.  If it is covered but bleeding, add other flavortext.

--- a/zzzz_modular_occulus/code/datums/perks/oddity.dm
+++ b/zzzz_modular_occulus/code/datums/perks/oddity.dm
@@ -6,3 +6,8 @@
 /datum/perk/nt_oddity/holy_light
 	name = "Mekhane's Touch"
 	desc = "You have been blessed by Mekhane. You now provide a weak healing aura, healing both brute and burn damage to any nearby Children of Mekhane as well as yourself."
+
+/datum/perk/oddity/empath
+	name = "Empath"
+	desc = "You have a sixth sense about people. You can tell when they are stressed."
+	icon_state = "flowers"

--- a/zzzz_modular_occulus/code/game/gamemodes/occultist/occultist_mind.dm
+++ b/zzzz_modular_occulus/code/game/gamemodes/occultist/occultist_mind.dm
@@ -28,6 +28,8 @@
 			var/obj/item/organ/internal/brain/occultist/B = new /obj/item/organ/internal/brain/occultist
 			B.replaced(head)
 			src.ckey = mindxfer
+	if(stats)
+		stats.addPerk(PERK_EMPATH)
 
 /obj/item/organ/internal/brain/occultist/Topic(href, href_list)
 	if(href_list["P"])

--- a/zzzz_modular_occulus/code/game/jobs/job/medical.dm
+++ b/zzzz_modular_occulus/code/game/jobs/job/medical.dm
@@ -18,6 +18,7 @@
 		access_genetics, access_maint_tunnels)
 
 /datum/job/psychiatrist
+	perks = list(/datum/perk/selfmedicated, /datum/perk/oddity/empath)
 	access = list(
 		access_moebius, access_medical_equip, access_morgue, access_psychiatrist, access_chemistry, access_maint_tunnels
 	)

--- a/zzzz_modular_occulus/code/modules/mob/living/carbon/human/examine.dm
+++ b/zzzz_modular_occulus/code/modules/mob/living/carbon/human/examine.dm
@@ -265,10 +265,26 @@
 		if(temp.dislocated == 2)
 			wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.joint] is dislocated!</span><br>"
 		if(((temp.status & ORGAN_BROKEN) && temp.brute_dam > temp.min_broken_damage) || (temp.status & ORGAN_MUTATED))
-			wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] is dented and swollen!</span><br>"
+			wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] is mangled!</span><br>"
+		if(temp.germ_level > INFECTION_LEVEL_ONE && temp.germ_level < INFECTION_LEVEL_TWO)//Occulus Edit: Infection status on examine
+			wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] is discolored!</span><br>"
+		else if(temp.germ_level > INFECTION_LEVEL_TWO && temp.germ_level < INFECTION_LEVEL_THREE)
+			wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] is oozing pus!</span><br>"
+		else if(temp.germ_level > INFECTION_LEVEL_THREE)
+			wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] is covered in decaying tissue!</span><br>"
+		if(temp.status & ORGAN_DEAD)
+			wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] is necrotic</span><br>"//Occulus Edit End
 		for(var/obj/item/organ/internal/blood_vessel/BV in temp.internal_organs)//Occulus Edit: Ruptured Blood Vessel
-			if(BV.damage > 0)//occulus Edit: Ruptured blood vessel
+			if(BV.damage > 4)//occulus Edit: Ruptured blood vessel that is above the self-heal threshold
 				wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] swollen and discolored!</span><br>"//Occulus Edit: Ruptured Blood vessel
+	if(user.stats.getPerk(PERK_EMPATH))
+		if(sanity.level <= 40 && sanity.level > 20)
+			msg += "[T.He] looks stressed out.\n"
+		else if(sanity.level <= 20 && sanity.level > 0)
+			msg += "<span class='warning'>[T.He] looks ready to do something rash!</span>\n"
+		else if(sanity.level == 0)
+			msg += "<span class ='danger'>[T.He] needs help! Now! Something is wrong!\n"
+
 
 
 	//Handles the text strings being added to the actual description.

--- a/zzzz_modular_occulus/code/modules/mob/living/carbon/human/examine.dm
+++ b/zzzz_modular_occulus/code/modules/mob/living/carbon/human/examine.dm
@@ -271,9 +271,9 @@
 		else if(temp.germ_level > INFECTION_LEVEL_TWO && temp.germ_level < INFECTION_LEVEL_THREE)
 			wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] is oozing pus!</span><br>"
 		else if(temp.germ_level > INFECTION_LEVEL_THREE)
-			wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] is covered in decaying tissue!</span><br>"
+			wound_flavor_text["[temp.name]"] += "<span class='danger'>[T.His] [temp.name] is covered in decaying tissue!</span><br>"
 		if(temp.status & ORGAN_DEAD)
-			wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] is necrotic</span><br>"//Occulus Edit End
+			wound_flavor_text["[temp.name]"] += "<span class='danger'>[T.His] [temp.name] is necrotic!</span><br>"//Occulus Edit End
 		for(var/obj/item/organ/internal/blood_vessel/BV in temp.internal_organs)//Occulus Edit: Ruptured Blood Vessel
 			if(BV.damage > 4)//occulus Edit: Ruptured blood vessel that is above the self-heal threshold
 				wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] swollen and discolored!</span><br>"//Occulus Edit: Ruptured Blood vessel


### PR DESCRIPTION
## About The Pull Request

Adds a few small QoL features

- Softcaps for stats
- Empath perks for Psychatrists
- Infections now show on wounds

## Why It's Good For The Game

More feedback is good for the game.

## Changelog
```changelog
tweak: examine text now shows infections on external organs, as well as severity
tweak: adjusted examine text for broken limbs
tweak: blood vessel damage now only shows IB text if you have above 5 blood vessel damage
tweak: infections now show on examine if they are above infection level 1
balance: Stat gains above 60 are now halved
balance: Stat gains above 80 are now quartered
add: Empath perk for Psychiatrists and Occultists. This perk can also be found on oddities like market professional. Empath gives you popup text if the examined person has sanity below 40, 20, or at 0 respectively.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
