### PR TITLE
Logging for the storyteller

### DIFF
--- a/code/game/gamemodes/storyteller_print.dm
+++ b/code/game/gamemodes/storyteller_print.dm
@@ -264,6 +264,8 @@
 		var/pooltype = href_list["modify_points"]
 		var/add_points = input("Pool [pooltype] currently has [round(points[pooltype], 0.01)]. How many do you wish to add? Enter a negative value to subtract points","Altering Points",eng) as num
 		modify_points(add_points, pooltype)
+		message_admins("[key_name(usr)] added [add_points] points to the [pooltype] pool.") //Occulus Edit: Logging
+		log_admin("[key_name(usr)] added [add_points] points to the [pooltype] pool.") //Occulus Edit: Logging
 
 	storyteller_panel()
 


### PR DESCRIPTION
## About The Pull Request

Adds a log and notification when someone messes with point pools in a storyteller

## Why It's Good For The Game

Tracking this stuff is good.

## Changelog
```changelog
admin: point pool modifications by the storyteller panel are now logged
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
