### PR TITLE
Medical QoL improvements.

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2883,6 +2883,7 @@
 #include "zzzz_modular_occulus\code\game\objects\items\devices\magnetic_lock.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\devices\radio.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\devices\traitor_devices.dm"
+#include "zzzz_modular_occulus\code\game\objects\items\stacks\medical.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\tools\_tools.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\tools\batons.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\toys\balls.dm"

--- a/zzzz_modular_occulus/code/game/objects/items/stacks/medical.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/stacks/medical.dm
@@ -1,0 +1,9 @@
+//Modular Medical stacks folder for Occulus.
+
+/obj/item/stack/medical/bruise_pack
+	amount = 10
+	max_amount = 10
+
+/obj/item/stack/medical/ointment
+	amount = 10
+	max_amount = 10

--- a/zzzz_modular_occulus/code/modules/surgery/organic_damage.dm
+++ b/zzzz_modular_occulus/code/modules/surgery/organic_damage.dm
@@ -7,7 +7,7 @@
 	duration = 80
 
 /datum/surgery_step/fix_brute/can_use(mob/living/user, obj/item/organ/external/organ, obj/item/stack/tool)
-	return BP_IS_ORGANIC(organ) && organ.is_open() && organ.brute_dam >= 15
+	return BP_IS_ORGANIC(organ) && organ.is_open() && organ.brute_dam >= 15 && tool.amount != 0 // Occulus Edit
 
 /datum/surgery_step/fix_brute/begin_step(mob/living/user, obj/item/organ/external/organ, obj/item/stack/tool)
 	user.visible_message(
@@ -20,8 +20,11 @@
 		SPAN_NOTICE("[user] finishes mending [organ.get_surgery_name()]."),
 		SPAN_NOTICE("You finish mending [organ.get_surgery_name()].")
 	)
-	if(tool.use(1))
-		organ.heal_damage(rand(10, 15), 0, 1, 1)
+	if(prob(10 + user.stats.getStat(STAT_BIO))) // Occulus Edit
+		to_chat(user, SPAN_NOTICE("You have managed to waste less of [tool]."))
+	else // Occulus Edit
+		tool.use(1)
+	organ.heal_damage(rand(10, 15), 0, 1, 1)
 
 /datum/surgery_step/fix_brute/fail_step(mob/living/user, obj/item/organ/external/organ, obj/item/stack/tool)
 	user.visible_message(
@@ -45,7 +48,7 @@
 	duration = 80
 
 /datum/surgery_step/fix_burn/can_use(mob/living/user, obj/item/organ/external/organ, obj/item/stack/tool)
-	return BP_IS_ORGANIC(organ) && organ.is_open() && organ.burn_dam >= 15
+	return BP_IS_ORGANIC(organ) && organ.is_open() && organ.burn_dam >= 15 && tool.amount != 0 // Occulus Edit
 
 /datum/surgery_step/fix_burn/begin_step(mob/living/user, obj/item/organ/external/organ, obj/item/stack/tool)
 	user.visible_message(
@@ -58,8 +61,11 @@
 		SPAN_NOTICE("[user] finishes treating [organ.get_surgery_name()]."),
 		SPAN_NOTICE("You finish treating [organ.get_surgery_name()].")
 	)
-	if(tool.use(1))
-		organ.heal_damage(0, rand(10, 15), 1, 1)
+	if(prob(10 + user.stats.getStat(STAT_BIO))) // Occulus Edit
+		to_chat(user, SPAN_NOTICE("You have managed to waste less of [tool]."))
+	else // Occulus Edit
+		tool.use(1)
+	organ.heal_damage(0, rand(10, 15), 1, 1)
 
 /datum/surgery_step/fix_burn/fail_step(mob/living/user, obj/item/organ/external/organ, obj/item/stack/tool)
 	user.visible_message(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Just a few small adjustments to improve the use of certain medical items.

- Gauze and Ointment now have 10 uses instead of 5.
- Advanced brute kits and burn kits now have the same chance to not waste materials during surgery as they do when healing injuries.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This change will give players that have low BIO stats the possibility to share a standard First-Aid kit, rather than using one up entirely on themselves. It will also help doctors with high BIO to save materials on the valuable advanced kits during extensive surgery.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
balance: Roll of Gauze and Ointment increased from 5 to 10 uses.
fix: Advanced kits will now properly apply the chance to not waste materials during surgery mending.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
