### PR TITLE
hotfix for ghost examines

### DIFF
--- a/zzzz_modular_occulus/code/modules/mob/living/carbon/human/examine.dm
+++ b/zzzz_modular_occulus/code/modules/mob/living/carbon/human/examine.dm
@@ -277,13 +277,14 @@
 		for(var/obj/item/organ/internal/blood_vessel/BV in temp.internal_organs)//Occulus Edit: Ruptured Blood Vessel
 			if(BV.damage > 4)//occulus Edit: Ruptured blood vessel that is above the self-heal threshold
 				wound_flavor_text["[temp.name]"] += "<span class='warning'>[T.His] [temp.name] swollen and discolored!</span><br>"//Occulus Edit: Ruptured Blood vessel
-	if(user.stats.getPerk(PERK_EMPATH))
-		if(sanity.level <= 40 && sanity.level > 20)
-			msg += "[T.He] looks stressed out.\n"
-		else if(sanity.level <= 20 && sanity.level > 0)
-			msg += "<span class='warning'>[T.He] looks ready to do something rash!</span>\n"
-		else if(sanity.level == 0)
-			msg += "<span class ='danger'>[T.He] needs help! Now! Something is wrong!\n"
+	if(user.stats)
+		if(user.stats.getPerk(PERK_EMPATH))
+			if(sanity.level <= 40 && sanity.level > 20)
+				msg += "[T.He] looks stressed out.\n"
+			else if(sanity.level <= 20 && sanity.level > 0)
+				msg += "<span class='warning'>[T.He] looks ready to do something rash!</span>\n"
+			else if(sanity.level == 0)
+				msg += "<span class ='danger'>[T.He] needs help! Now! Something is wrong!\n"
 
 
 


### PR DESCRIPTION
## About The Pull Request

Ghosts examining people will no longer runtime

## Why It's Good For The Game

whoops!

## Changelog
```changelog
fix: Ghosts examining people will no longer runtime
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
