### PR TITLE
Corrects ADMS disk teleporation and feedback

### DIFF
--- a/zzzz_modular_occulus/code/modules/maint_expeditions/ADMS.dm
+++ b/zzzz_modular_occulus/code/modules/maint_expeditions/ADMS.dm
@@ -237,14 +237,29 @@
 
 	update_icon()
 
-/obj/machinery/exploration/ADMS/verb/eject_disk()
+//Handles ejecting the data disk, when able, will place and hand
+/obj/machinery/exploration/adms/proc/eject_disk_action(mob/living/user)
+	if(!inserted_disk)
+		to_chat(usr, SPAN_NOTICE("No disk is inside."))
+		return
+
+	if(inserted_disk)
+		inserted_disk.forceMove(drop_location())
+		component_parts -= inserted_disk
+		to_chat(usr, SPAN_NOTICE("You remove \the [inserted_disk] from \the [src]."))
+
+	inserted_disk = null
+	inserted_disk_file = null
+
+/obj/machinery/exploration/adms/verb/eject_disk()
 	set name = "Eject Disk"
 	set category = "Object"
 	set src in view(1)
 	if(inserted_disk)
-		inserted_disk.loc = get_turf(src)
-		inserted_disk = null
-		inserted_disk_file = null
+		eject_disk_action()
+	else
+		to_chat(usr, SPAN_NOTICE("No disk is inside."))
+
 /obj/machinery/exploration/ADMS/update_icon()
 	if(active)
 		icon_state = "ADMS-on"

--- a/zzzz_modular_occulus/code/modules/maint_expeditions/ADMS.dm
+++ b/zzzz_modular_occulus/code/modules/maint_expeditions/ADMS.dm
@@ -243,10 +243,9 @@
 		to_chat(usr, SPAN_NOTICE("No disk is inside."))
 		return
 
-	if(inserted_disk)
-		inserted_disk.forceMove(drop_location())
-		component_parts -= inserted_disk
-		to_chat(usr, SPAN_NOTICE("You remove \the [inserted_disk] from \the [src]."))
+	inserted_disk.forceMove(drop_location())
+	component_parts -= inserted_disk
+	to_chat(usr, SPAN_NOTICE("You remove \the [inserted_disk] from \the [src]."))
 
 	inserted_disk = null
 	inserted_disk_file = null

--- a/zzzz_modular_occulus/code/modules/maint_expeditions/ADMS.dm
+++ b/zzzz_modular_occulus/code/modules/maint_expeditions/ADMS.dm
@@ -238,7 +238,7 @@
 	update_icon()
 
 //Handles ejecting the data disk, when able, will place and hand
-/obj/machinery/exploration/adms/proc/eject_disk_action(mob/living/user)
+/obj/machinery/exploration/ADMS/proc/eject_disk_action(mob/living/user)
 	if(!inserted_disk)
 		to_chat(usr, SPAN_NOTICE("No disk is inside."))
 		return
@@ -251,7 +251,7 @@
 	inserted_disk = null
 	inserted_disk_file = null
 
-/obj/machinery/exploration/adms/verb/eject_disk()
+/obj/machinery/exploration/ADMS/verb/eject_disk()
 	set name = "Eject Disk"
 	set category = "Object"
 	set src in view(1)


### PR DESCRIPTION
## About The Pull Request
ADMS now gives messages when a disk is not is-side well ejecting
Ejecting a disk now removes it form its lists preventing it form teleporting to were you deconstruct it
![image](https://user-images.githubusercontent.com/30435998/132144200-e17d48b6-8b16-40f8-b796-cd78b5a1f432.png)

Dont mind the fire
## Why It's Good For The Game
fix: Corrects the ADMS disk teleportation bug when decontructed
