### PR TITLE
New Medbay Map Hotfix

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -84948,7 +84948,7 @@
 "dUN" = (
 /obj/structure/catwalk,
 /obj/spawner/pack/gun_loot/low_chance,
-/turf/simulated/open,
+/turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck1starboard)
 "dUO" = (
 /obj/spawner/flora/low_chance,
@@ -107996,6 +107996,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/fitness)
+"pha" = (
+/obj/machinery/door/airlock/maintenance_common{
+	name = "Service Maintenance";
+	req_access = list(12)
+	},
+/turf/simulated/floor/plating/under,
+/area/eris/maintenance/section2deck1starboard)
 "phd" = (
 /obj/structure/railing{
 	dir = 8
@@ -108423,6 +108430,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/techmaint_cargo,
 /area/eris/crew_quarters/bar)
+"pYZ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/lattice,
+/turf/simulated/open,
+/area/eris/maintenance/section2deck1starboard)
 "pZm" = (
 /obj/spawner/mob/spiders/cluster/low_chance,
 /turf/simulated/floor/tiled/steel/gray_perforated,
@@ -291441,12 +291455,12 @@ aaa
 alb
 dAF
 anQ
-dWB
+pha
 dUW
 dUW
 dUW
-dUW
-dUW
+xZK
+xZK
 dUW
 amc
 dGs
@@ -291650,7 +291664,7 @@ dUW
 foW
 alG
 fzH
-aof
+rAj
 wZT
 aof
 anQ
@@ -291848,11 +291862,11 @@ alb
 yda
 gtp
 ora
-dUW
+xZK
 foW
 alG
-xZK
-dQr
+dUW
+anQ
 anQ
 anQ
 anQ
@@ -292053,8 +292067,8 @@ jDO
 dUW
 nEC
 alG
-xZK
-xuA
+dUW
+xLX
 xuA
 dUW
 ijA
@@ -292255,10 +292269,10 @@ jDO
 dUW
 fWo
 alG
-xZK
+dUW
 dUN
-uYg
-uYg
+ate
+ate
 alG
 aor
 dUW
@@ -292457,9 +292471,9 @@ qEM
 dUW
 iTB
 alG
-xZK
-xuA
-xuA
+dUW
+pYZ
+xLX
 dUW
 dUW
 xZK
@@ -292654,15 +292668,15 @@ dWB
 alC
 eWP
 eDD
-uYg
-uYg
+ate
+ate
 dUW
-dUW
+xZK
 fzH
 dUW
 dUN
-uYg
-uYg
+ate
+ate
 egQ
 kmV
 dVD
@@ -292856,14 +292870,14 @@ dWB
 ala
 ala
 ala
-uYg
-uYg
-uYg
-uYg
-uYg
-eDL
-xuA
+ate
+ate
+ate
+ate
+ate
+dUW
 xLX
+xuA
 xLX
 dUW
 dUW
@@ -293062,10 +293076,10 @@ irC
 dUW
 dUW
 dUW
-uYg
+ate
 ala
 dUW
-xZK
+dUW
 dUW
 dUW
 qcr

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -106065,11 +106065,10 @@
 /turf/simulated/floor/tiled/white,
 /area/eris/hallway/main/section2)
 "mAL" = (
-/obj/structure/lattice,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/open,
+/turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck1port)
 "mAW" = (
 /obj/structure/bed/chair{
@@ -109027,6 +109026,10 @@
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck1port)
+"qXA" = (
+/obj/structure/lattice,
+/turf/simulated/wall,
+/area/eris/maintenance/section2deck1port)
 "qZr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -110630,6 +110633,9 @@
 /area/eris/command/bridge)
 "tLo" = (
 /obj/spawner/structures/common/low_chance,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck1port)
 "tLp" = (
@@ -290242,10 +290248,10 @@ aaa
 abF
 abF
 alb
-vgv
-vgv
 dAF
-vgv
+qXA
+dAF
+qXA
 mNY
 anQ
 amc
@@ -290649,7 +290655,7 @@ anQ
 anQ
 mAL
 dAF
-vgv
+qXA
 rAj
 anQ
 tth
@@ -290849,7 +290855,7 @@ alb
 pcM
 dAF
 anQ
-vgv
+anQ
 dAF
 rAj
 dAF
@@ -291053,7 +291059,7 @@ dAF
 anQ
 tLo
 dAF
-vgv
+qXA
 dAF
 amO
 dAF
@@ -291257,8 +291263,8 @@ gQl
 dAF
 mNY
 anQ
-vgv
-vgv
+anQ
+tDD
 anQ
 jQY
 anQ
@@ -291459,9 +291465,9 @@ pha
 dUW
 dUW
 dUW
+iTB
+alG
 xZK
-xZK
-dUW
 amc
 dGs
 amc

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -20164,12 +20164,13 @@
 /turf/simulated/floor/tiled/dark/techfloor_grid,
 /area/eris/engineering/wastingroom)
 "aWN" = (
-/obj/structure/multiz/stairs/active/bottom{
-	dir = 4
+/obj/machinery/door/airlock/glass_medical{
+	id_tag = "MedbayFoyer";
+	name = "Upper Medical Hall";
+	req_access = list(5)
 	},
-/obj/structure/railing/grey,
-/turf/simulated/floor/tiled/steel,
-/area/eris/hallway/side/morguehallway)
+/turf/simulated/floor/tiled/techmaint,
+/area/eris/maintenance/section2deck4port)
 "aWO" = (
 /obj/machinery/camera/network/fist_section,
 /turf/simulated/floor/tiled/techmaint,
@@ -20593,6 +20594,11 @@
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/hallway/side/morguehallway)
@@ -24633,6 +24639,11 @@
 /area/eris/maintenance/section2deck4starboard)
 "bgm" = (
 /obj/machinery/hologram/holopad,
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/hallway/side/morguehallway)
 "bgn" = (
@@ -25536,8 +25547,8 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
 	},
 /obj/spawner/junk/low_chance,
 /turf/simulated/floor/plating/under,
@@ -26075,33 +26086,28 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4starboard)
 "bjI" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/camera/network/second_section{
 	dir = 4
 	},
-/turf/simulated/floor/plating/under,
-/area/eris/maintenance/section2deck4central)
+/turf/simulated/floor/tiled/dark,
+/area/eris/hallway/side/morguehallway)
 "bjJ" = (
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/railing{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck4central)
@@ -28198,6 +28204,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/light{
 	dir = 1
+	},
+/obj/machinery/alarm{
+	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/maintenance/section2deck4port)
@@ -47328,7 +47337,7 @@
 "chz" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Medical Stairwell";
-	req_access = list(5)
+	req_access = list(5,66)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -48894,7 +48903,7 @@
 	pixel_x = -22
 	},
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "clN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
@@ -49347,7 +49356,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "cmV" = (
 /obj/machinery/seed_extractor,
 /turf/simulated/floor/wood,
@@ -50047,18 +50056,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white/cargo,
 /area/eris/command/mbo)
-"coC" = (
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
-	},
-/obj/machinery/power/apc{
-	dir = 1;
-	name = "North APC";
-	pixel_y = 28
-	},
-/turf/simulated/floor/tiled/dark,
-/area/eris/hallway/side/morguehallway)
 "coD" = (
 /obj/structure/cable/cyan,
 /obj/machinery/power/emitter/anchored{
@@ -58215,11 +58212,13 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section3deck4starboard)
 "cHW" = (
-/obj/structure/multiz/stairs/enter/bottom{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/railing/grey,
-/turf/simulated/floor/tiled/steel,
+/turf/simulated/floor/tiled/dark,
 /area/eris/hallway/side/morguehallway)
 "cHX" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -58417,10 +58416,10 @@
 /turf/simulated/wall,
 /area/eris/medical/patient_wing)
 "cIy" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/door/airlock/glass_medical{
+	id_tag = "MedbayFoyer";
+	name = "Lower Medical Hall";
+	req_access = list(5,66)
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/hallway/side/morguehallway)
@@ -65628,7 +65627,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
 	name = "Medbay E.V.A.";
-	req_access = list(5)
+	req_access = list(5,66)
 	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -67455,7 +67454,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "deZ" = (
 /obj/structure/table/woodentable,
 /obj/item/weapon/paper_bin,
@@ -69042,19 +69041,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/eris/hallway/side/bridgehallway)
 "dir" = (
-/obj/machinery/camera/network/second_section{
-	dir = 4
+/obj/machinery/door/airlock/glass_medical{
+	id_tag = "MedbayFoyer";
+	name = "Morgue";
+	req_access = list(6)
 	},
-/obj/structure/sign/department/virology{
-	pixel_x = -32
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/eris/hallway/side/morguehallway)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/white,
+/area/eris/maintenance/section2deck4port)
 "dis" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -69511,6 +69505,15 @@
 /obj/structure/closet/l3closet/general,
 /obj/machinery/camera/network/medbay{
 	dir = 8
+	},
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "East APC";
+	pixel_x = 28
+	},
+/obj/structure/cable/green{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/hallway/side/morguehallway)
@@ -70983,7 +70986,7 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "dmO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4;
@@ -71466,7 +71469,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "dnM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel/orangecorner,
@@ -72263,7 +72266,7 @@
 	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "dqb" = (
 /obj/machinery/vending/cigarette,
 /obj/machinery/camera/network/medbay{
@@ -72508,7 +72511,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "dqz" = (
 /obj/machinery/light{
 	dir = 4
@@ -72778,7 +72781,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "drm" = (
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
@@ -72857,7 +72860,7 @@
 	dir = 9
 	},
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "drB" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -72873,10 +72876,9 @@
 	pixel_x = -24;
 	req_access = list(38)
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/structure/sign/department/virology{
+	pixel_x = -32;
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/hallway/side/morguehallway)
@@ -73019,7 +73021,7 @@
 "drX" = (
 /obj/structure/multiz/stairs/active,
 /turf/simulated/open,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "drZ" = (
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
@@ -73818,21 +73820,6 @@
 /turf/simulated/floor/tiled/white/panels,
 /area/eris/medical/virology)
 "dui" = (
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
@@ -73842,6 +73829,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/hallway/side/morguehallway)
@@ -74078,7 +74075,6 @@
 /turf/simulated/floor/plating,
 /area/eris/engineering/engine_room)
 "duL" = (
-/obj/machinery/door/airlock/glass_medical,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -74086,6 +74082,11 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/glass_medical{
+	id_tag = null;
+	name = "Chemistry Lab";
+	req_access = list(33)
 	},
 /turf/simulated/floor/tiled/white/cargo,
 /area/eris/medical/chemistry)
@@ -74653,7 +74654,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
 	name = "Morgue";
-	req_access = list(6)
+	req_access = list(6,5)
 	},
 /obj/structure/cable/green{
 	d1 = 1;
@@ -76801,7 +76802,7 @@
 "dBH" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Medical Surgery Hallway";
-	req_access = list(5)
+	req_access = list(5,66)
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -77049,7 +77050,7 @@
 "dCr" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Medical Stairwell";
-	req_access = list(5)
+	req_access = list(5,66)
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/cargo,
@@ -85520,12 +85521,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -85536,12 +85531,6 @@
 /area/eris/maintenance/section2deck1starboard)
 "dWm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
 /obj/structure/cable/green{
@@ -85556,21 +85545,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/catwalk,
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck1starboard)
 "dWo" = (
@@ -85615,10 +85598,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -85629,6 +85608,10 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck1starboard)
@@ -102230,7 +102213,7 @@
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "ggr" = (
 /obj/item/modular_computer/console/preset/medical/records{
 	dir = 8
@@ -102507,7 +102490,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "gBw" = (
 /obj/structure/lattice,
 /obj/structure/railing{
@@ -103454,7 +103437,7 @@
 /obj/item/weapon/reagent_containers/syringe/spaceacillin,
 /obj/item/weapon/reagent_containers/syringe/spaceacillin,
 /turf/simulated/floor/tiled/dark,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "ieC" = (
 /obj/structure/table/marble,
 /obj/item/seeds/potatoseed,
@@ -103659,7 +103642,7 @@
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "ivn" = (
 /obj/structure/table/rack,
 /obj/item/weapon/holochip/security/tough,
@@ -104154,7 +104137,7 @@
 "jdK" = (
 /obj/structure/multiz/stairs/enter,
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "jfx" = (
 /obj/spawner/junk/low_chance,
 /obj/machinery/light/small{
@@ -104533,7 +104516,7 @@
 	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "jMK" = (
 /obj/structure/catwalk,
 /obj/spawner/traps/wire_splicing/low_chance,
@@ -105205,7 +105188,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "leL" = (
 /obj/machinery/door/blast/shutters/glass{
 	id = "random_radio"
@@ -105240,7 +105223,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "lgz" = (
 /obj/machinery/light{
 	dir = 8
@@ -105267,7 +105250,7 @@
 	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "ljf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -105637,6 +105620,18 @@
 	pixel_y = 28
 	},
 /turf/simulated/floor/tiled/white,
+/area/eris/medical/chemistry)
+"lUl" = (
+/obj/structure/table/standard,
+/obj/item/weapon/reagent_containers/dropper{
+	pixel_y = -4
+	},
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -26
+	},
+/turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/medical/chemistry)
 "lUr" = (
 /obj/structure/disposalpipe/segment{
@@ -106068,7 +106063,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "mAL" = (
 /obj/structure/lattice,
 /obj/machinery/light/small{
@@ -106206,7 +106201,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "mLx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
@@ -106844,8 +106839,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_medical{
 	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access = newlist()
+	name = "Upper Medical Hall";
+	req_access = list(5)
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -108693,10 +108688,6 @@
 /area/eris/medical/medbay/uppercor)
 "quT" = (
 /obj/machinery/chem_master,
-/obj/machinery/alarm{
-	dir = 1;
-	pixel_y = -22
-	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/medical/chemistry)
 "qvL" = (
@@ -108941,7 +108932,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/dark,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "qLU" = (
 /obj/structure/railing{
 	dir = 8
@@ -109484,7 +109475,7 @@
 	pixel_y = 26
 	},
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "rQn" = (
 /obj/machinery/button/remote/airlock{
 	desc = "A remote control switch.";
@@ -109884,7 +109875,7 @@
 	icon_state = "pipe-j2"
 	},
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "sEx" = (
 /obj/structure/ore_box,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -110423,7 +110414,7 @@
 "tqT" = (
 /obj/machinery/door/airlock/glass_medical{
 	name = "Medical Stairwell";
-	req_access = list(5)
+	req_access = list(5,66)
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -110665,7 +110656,7 @@
 	pixel_x = -32
 	},
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "tNW" = (
 /obj/machinery/chem_master,
 /turf/simulated/floor/tiled/techmaint,
@@ -111054,6 +111045,9 @@
 	},
 /turf/simulated/floor/tiled/white/cargo,
 /area/occulus/medical/cryo)
+"uqY" = (
+/turf/simulated/floor/tiled/white,
+/area/eris/hallway/main/section2)
 "uqZ" = (
 /obj/machinery/door/airlock/maintenance_common{
 	name = "Central Maintenance"
@@ -111341,6 +111335,17 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/medical/medbay/uppercor)
+"uVW" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/white,
+/area/eris/hallway/main/section2)
 "uWd" = (
 /obj/spawner/scrap/dense,
 /turf/simulated/floor/carpet/bcarpet,
@@ -111990,8 +111995,8 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_medical{
 	id_tag = "MedbayFoyer";
-	name = "Medbay";
-	req_access = newlist()
+	name = "Upper Medical Hall";
+	req_access = list(5)
 	},
 /turf/simulated/floor/tiled/white/cargo,
 /area/eris/medical/medbay/uppercor)
@@ -112336,7 +112341,7 @@
 	},
 /obj/machinery/light,
 /turf/simulated/floor/tiled/white,
-/area/eris/medical/medbay/uppercor)
+/area/eris/hallway/main/section2)
 "wNz" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/oddity/instructional/common/mec/pamphlet,
@@ -112483,13 +112488,22 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section2deck1port)
 "xcM" = (
-/obj/structure/bed/padded,
-/obj/item/weapon/bedsheet/medical,
-/obj/machinery/firealarm{
-	pixel_y = 28
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/white/brown_perforated,
-/area/eris/medical/ward)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/white,
+/area/eris/hallway/main/section2)
 "xeR" = (
 /obj/structure/closet/crate/secure/hydrosec/prelocked,
 /obj/item/weapon/reagent_containers/glass/bottle/mutagen,
@@ -170027,7 +170041,7 @@ cOq
 bsw
 cIS
 aWH
-aWN
+aWH
 bhL
 bsM
 duh
@@ -170229,7 +170243,7 @@ bmZ
 cOq
 cIS
 col
-cHW
+col
 bhL
 iSq
 biO
@@ -170430,9 +170444,9 @@ aCc
 aCc
 aCc
 cIS
-coC
 cIy
-dir
+cIy
+bcH
 drC
 dui
 mTY
@@ -170634,8 +170648,8 @@ beu
 cIS
 bfp
 cJL
-cJL
-cJL
+bjI
+cHW
 aXL
 aYw
 wIp
@@ -170831,7 +170845,7 @@ aaa
 cJK
 awz
 aWT
-cOq
+aWN
 cOq
 ccT
 beA
@@ -171656,7 +171670,7 @@ blQ
 etB
 ixm
 bkq
-dAL
+dir
 cIS
 cIS
 aad
@@ -172054,7 +172068,7 @@ bgQ
 bhA
 bhN
 biu
-bjI
+brm
 bkq
 boK
 bpX
@@ -213456,7 +213470,7 @@ rma
 hgv
 cYV
 gJE
-xcM
+gJE
 dgo
 dzc
 crD
@@ -246386,12 +246400,12 @@ bdL
 bdL
 bdL
 bdL
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+abF
+abF
+abF
+abF
+abF
+abF
 aaa
 aaa
 aaa
@@ -246591,9 +246605,9 @@ bdL
 bdL
 bdL
 bdL
-aaa
-aaa
-aaa
+abF
+abF
+abF
 aaa
 aaa
 aaa
@@ -247183,8 +247197,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+abF
+abF
 bdL
 dcQ
 qaA
@@ -247384,9 +247398,9 @@ abF
 abF
 abF
 abF
-aaa
-aaa
-aaa
+abF
+abF
+abF
 bdL
 gyw
 dcQ
@@ -251448,7 +251462,7 @@ rSs
 dFc
 dtb
 dtz
-kVC
+lUl
 dtO
 ozX
 aaa
@@ -252841,8 +252855,8 @@ bPe
 bPe
 aaa
 aaa
-aaa
-aaa
+abF
+abF
 dxt
 fYr
 dEP
@@ -253043,7 +253057,7 @@ bPe
 aaa
 aaa
 aaa
-aaa
+abF
 qss
 dxt
 dzL
@@ -253058,7 +253072,7 @@ qvL
 utr
 qLL
 liQ
-ofp
+uqY
 ozX
 wSR
 euV
@@ -253067,7 +253081,7 @@ dty
 kVC
 pbb
 ozX
-aaa
+abF
 dqI
 dOQ
 dOQ
@@ -253260,7 +253274,7 @@ dzM
 dzO
 idh
 deY
-dta
+uVW
 pSY
 hIK
 vei
@@ -253269,7 +253283,7 @@ evv
 evv
 wpb
 dte
-aaa
+abF
 dqI
 dOQ
 dPf
@@ -253461,8 +253475,8 @@ ija
 dcd
 utr
 rPY
-dfo
-ofp
+xcM
+uqY
 wEJ
 rHt
 evv
@@ -253471,7 +253485,7 @@ evv
 dpF
 eTm
 dte
-aaa
+abF
 dqI
 dOQ
 dPP
@@ -253851,7 +253865,7 @@ aad
 aaa
 aaa
 aaa
-aaa
+abF
 qss
 ggr
 aog
@@ -253866,7 +253880,7 @@ dmN
 dqa
 dqa
 drl
-ofp
+uqY
 jdK
 drX
 bZc
@@ -254069,8 +254083,8 @@ sEr
 dqy
 drA
 jMx
-dBj
-dBj
+bZc
+bZc
 bZc
 dth
 dth
@@ -290613,7 +290627,7 @@ dHe
 dIG
 doD
 abF
-aaa
+abF
 aaa
 alb
 kuY
@@ -290815,7 +290829,7 @@ doD
 doD
 doD
 abF
-aaa
+abF
 aaa
 alb
 pcM
@@ -292835,7 +292849,7 @@ doM
 doD
 doD
 doD
-aaa
+abF
 aaa
 ala
 dWB
@@ -293037,7 +293051,7 @@ doM
 dGI
 doM
 doD
-aaa
+abF
 aaa
 ala
 dWB
@@ -293239,7 +293253,7 @@ doQ
 doD
 doE
 doD
-aaa
+abF
 aaa
 ala
 ala
@@ -293441,7 +293455,7 @@ doM
 doD
 doD
 doD
-aaa
+abF
 aaa
 ala
 dNn


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Fixes a bunch of exposed roofing stuff found by Sydrec,
Fixes fire alarm in recovery ward,
Fixes door access issues coming up from morgue
Fixes door access into chemistry,
Fixes door access in stairwell
Fixes door access in upper medical hallway,
Areas adjusted to extend hallway into the upstairs balcony to reduce area conflict,
Door added to morgue entry to prevent venting from maintenance hall venting all of secondary main hall.
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Map Hotfixes
## Changelog
```changelog
fix: Fixed missing roofing in certain rooms of medbay.
fix: Fixed fire alarm in the Recovery Ward.
fix: Fixed door access on multiple medbay airlocks.
tweak: Areas adjusted to extend hallway into the upstairs balcony to reduce area conflict
tweak: Door added to morgue entry to prevent venting from maintenance.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
