### PR TITLE
Medical supply balances

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -73284,10 +73284,7 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/medical/chemstor)
 "dsK" = (
-/obj/spawner/medical/low_chance,
-/obj/spawner/medical/low_chance,
 /obj/structure/table/rack/shelf,
-/obj/item/weapon/storage/box/monkeycubes,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -73299,6 +73296,22 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/hypospray/mkii,
+/obj/item/hypospray/mkii,
+/obj/item/hypospray/mkii,
+/obj/item/hypospray/mkii,
+/obj/item/weapon/reagent_containers/glass/beaker/hypocartridge/small,
+/obj/item/weapon/reagent_containers/glass/beaker/hypocartridge/small,
+/obj/item/weapon/reagent_containers/glass/beaker/hypocartridge/small,
+/obj/item/weapon/reagent_containers/glass/beaker/hypocartridge/small,
+/obj/item/weapon/reagent_containers/glass/beaker/hypocartridge/small,
+/obj/item/weapon/reagent_containers/glass/beaker/hypocartridge/small,
+/obj/item/weapon/reagent_containers/glass/beaker/hypocartridge/small,
+/obj/item/weapon/reagent_containers/glass/beaker/hypocartridge/small,
+/obj/item/weapon/reagent_containers/glass/beaker/hypocartridge/small,
+/obj/item/weapon/reagent_containers/glass/beaker/hypocartridge/small,
+/obj/item/weapon/reagent_containers/glass/beaker/hypocartridge/small,
+/obj/item/weapon/reagent_containers/glass/beaker/hypocartridge/small,
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/medical/chemstor)
 "dsL" = (
@@ -76348,21 +76361,6 @@
 /area/occulus/medical/equipment)
 "dAD" = (
 /obj/structure/table/standard,
-/obj/item/weapon/storage/hypospraykit/fire{
-	pixel_x = -1;
-	pixel_y = -1
-	},
-/obj/item/weapon/storage/hypospraykit/o2,
-/obj/item/weapon/storage/hypospraykit/toxin{
-	pixel_x = 1;
-	pixel_y = 1
-	},
-/obj/item/hypospray/mkii,
-/obj/item/hypospray/mkii{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/weapon/storage/hypospraykit/regular,
 /obj/machinery/firealarm{
 	pixel_y = 28
 	},
@@ -77629,10 +77627,6 @@
 /obj/item/weapon/storage/firstaid/fire{
 	pixel_x = 2;
 	pixel_y = 6
-	},
-/obj/item/weapon/storage/firstaid/fire{
-	pixel_x = -2;
-	pixel_y = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
@@ -102124,7 +102118,7 @@
 /obj/item/weapon/autopsy_scanner,
 /obj/item/weapon/soulmanip,
 /obj/item/rig_module/cape/cmo,
-/obj/structure/closet/secure_closet/reinforced/CMO,
+/obj/structure/closet/secure_closet/reinforced/CMOcculus,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/command/mbo)
 "fUN" = (
@@ -103063,10 +103057,6 @@
 /obj/item/weapon/storage/firstaid/o2{
 	pixel_x = 2;
 	pixel_y = 6
-	},
-/obj/item/weapon/storage/firstaid/o2{
-	pixel_x = -2;
-	pixel_y = 4
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -104158,10 +104148,6 @@
 /obj/item/weapon/storage/firstaid/o2{
 	pixel_x = 2;
 	pixel_y = 6
-	},
-/obj/item/weapon/storage/firstaid/o2{
-	pixel_x = -2;
-	pixel_y = 4
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/occulus/medical/equipment)
@@ -107223,10 +107209,6 @@
 /obj/item/weapon/storage/firstaid/fire{
 	pixel_x = 2;
 	pixel_y = 6
-	},
-/obj/item/weapon/storage/firstaid/fire{
-	pixel_x = -2;
-	pixel_y = 4
 	},
 /obj/machinery/camera/network/medbay{
 	dir = 1

--- a/zzzz_modular_occulus/code/modules/economy/vending.dm
+++ b/zzzz_modular_occulus/code/modules/economy/vending.dm
@@ -142,8 +142,6 @@
 					/obj/item/weapon/storage/hypospraykit/brute = 1,
 					/obj/item/weapon/storage/hypospraykit/toxin = 1,
 					/obj/item/weapon/storage/hypospraykit/o2 = 1,
-					/obj/item/hypospray/mkii = 4,
-					/obj/item/weapon/reagent_containers/glass/beaker/hypocartridge/small = 9
 					)
 
 	contraband = list(


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Balance talked about in discord coding channels:
Drops standard kit amount for oxy and fire kits to 2.
Removes Hypokits from table, leaves them within the vendor.
Removes individual hypos and cartridges from vendors, Moves them to chemistry storage.
Also replaces CMO locker with CMOcculus locker
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
balance. Wasn't my idea, but it's a suitable compromise.
## Changelog
```changelog
del: Removes 2x fire&oxy medkits from map
del: Removes hypokits from table in medical storage,
tweak: moves Apollo and Apollo cartridges from vendor to chemistry
fix: Replaces CMO locker with the correct CMOcculus locker.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
