### PR TITLE
Coin Minting + More Vendor Premiums

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2823,6 +2823,7 @@
 #include "zzzz_modular_occulus\code\datums\datacore.dm"
 #include "zzzz_modular_occulus\code\datums\autolathe\biomatter.dm"
 #include "zzzz_modular_occulus\code\datums\autolathe\circuits.dm"
+#include "zzzz_modular_occulus\code\datums\autolathe\coins.dm"
 #include "zzzz_modular_occulus\code\datums\autolathe\fabkits.dm"
 #include "zzzz_modular_occulus\code\datums\autolathe\guns.dm"
 #include "zzzz_modular_occulus\code\datums\craft\crafting_items.dm"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -216,7 +216,7 @@
 
 	if(!user.unEquip(W))
 		return
-		
+
 	var/buying_price = round(R.price * buying_percentage/100,5)
 	if(earnings_account.money < buying_price)
 		to_chat(user, SPAN_WARNING("[src] flashes a message: Account is unable to make this purchase."))
@@ -229,6 +229,7 @@
 	spawn_money(buying_price,loc,usr)
 
 	to_chat(user, SPAN_NOTICE("[src] accepts the sale of [W] and dispenses [buying_price] credits."))
+
 
 	SSnano.update_uis(src)
 

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -216,7 +216,7 @@
 
 	if(!user.unEquip(W))
 		return
-
+		
 	var/buying_price = round(R.price * buying_percentage/100,5)
 	if(earnings_account.money < buying_price)
 		to_chat(user, SPAN_WARNING("[src] flashes a message: Account is unable to make this purchase."))
@@ -229,7 +229,6 @@
 	spawn_money(buying_price,loc,usr)
 
 	to_chat(user, SPAN_NOTICE("[src] accepts the sale of [W] and dispenses [buying_price] credits."))
-
 
 	SSnano.update_uis(src)
 
@@ -766,9 +765,11 @@
 			else
 				to_chat(user, SPAN_NOTICE("You weren't able to pull the coin out fast enough, the machine ate it, string and all."))
 				qdel(coin)
+				coin = null    //Occulus Addition, fixing coin cost
 				categories &= ~CAT_COIN
 		else
 			qdel(coin)
+			coin = null    //Occulus Addition, fixing coin cost
 			categories &= ~CAT_COIN
 
 	if(((last_reply + (vend_delay + 200)) <= world.time) && vend_reply)

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -47531,6 +47531,7 @@
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/devices,
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/misc,
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/medical,
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/coins,
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/nonlethal_ammo,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/quartermaster/storage)

--- a/zzzz_modular_occulus/code/datums/autolathe/coins.dm
+++ b/zzzz_modular_occulus/code/datums/autolathe/coins.dm
@@ -1,0 +1,24 @@
+/datum/design/autolathe/coin
+	name = "iron coin"
+	build_path = /obj/item/weapon/coin/iron
+	materials = list(MATERIAL_IRON = 1)
+
+/datum/design/autolathe/coin/silver
+	name = "silver coin"
+	build_path = /obj/item/weapon/coin/silver
+	materials = list(MATERIAL_SILVER = 1)
+
+/datum/design/autolathe/coin/gold
+	name = "gold coin"
+	build_path = /obj/item/weapon/coin/gold
+	materials = list(MATERIAL_GOLD = 1) 
+
+/datum/design/autolathe/coin/platinum
+	name = "platinum coin"
+	build_path = /obj/item/weapon/coin/platinum
+	materials = list(MATERIAL_PLATINUM = 1)
+
+/datum/design/autolathe/coin/diamond
+	name = "diamond coin"
+	build_path = /obj/item/weapon/coin/diamond
+	materials = list(MATERIAL_DIAMOND = 1)

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/design_disks/_disks.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/design_disks/_disks.dm
@@ -29,7 +29,18 @@
 		/datum/design/autolathe/fabkit/dryrack
 		)
 
-
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/coins
+	disk_name = "FTU Coinpress Disk"
+	icon_state = "guild"
+	rarity_value = 264
+	designs = list(
+		/datum/design/autolathe/coin,
+		/datum/design/autolathe/coin/silver,
+		/datum/design/autolathe/coin/gold,
+		/datum/design/autolathe/coin/platinum,
+		/datum/design/autolathe/coin/diamond
+	)
+ 
 /*
 CHURCH DISKS
 */

--- a/zzzz_modular_occulus/code/modules/economy/vending.dm
+++ b/zzzz_modular_occulus/code/modules/economy/vending.dm
@@ -36,7 +36,7 @@
 	contraband = list(/obj/item/clothing/mask/smokable/cigarette/cigar = 4, /obj/item/weapon/flame/lighter/zippo = 4, /obj/item/clothing/mask/vape/pipe = 3,/obj/item/clothing/mask/vape = 5, /obj/item/weapon/reagent_containers/glass/beaker/vial/vape/nicotine = 5,/obj/item/weapon/reagent_containers/glass/beaker/vial/vape/berry = 10,/obj/item/weapon/reagent_containers/glass/beaker/vial/vape/lemon = 10,/obj/item/weapon/reagent_containers/glass/beaker/vial/vape/banana = 10,)
 	premium = list(/obj/item/weapon/storage/fancy/cigar = 5,/obj/item/weapon/storage/fancy/cigarettes/killthroat = 5,/obj/item/weapon/storage/fancy/cigarettes/homeless = 3 )
 	prices = list(/obj/item/clothing/mask/smokable/cigarette/cigar = 200, /obj/item/weapon/storage/fancy/cigarettes = 100,/obj/item/weapon/storage/fancy/cigcartons = 800,/obj/item/weapon/storage/fancy/cigarettes/dromedaryco = 100,/obj/item/weapon/storage/fancy/cigcartons/dromedaryco = 800,/obj/item/weapon/storage/box/matches = 30,/obj/item/weapon/flame/lighter/random = 30,
-				/obj/item/weapon/flame/lighter/zippo = 250, /obj/item/clothing/mask/vape/pipe = 500, /obj/item/clothing/mask/vape = 300, /obj/item/weapon/reagent_containers/glass/beaker/vial/vape/nicotine = 150,/obj/item/weapon/reagent_containers/glass/beaker/vial/vape/berry = 100,/obj/item/weapon/reagent_containers/glass/beaker/vial/vape/lemon = 100,/obj/item/weapon/reagent_containers/glass/beaker/vial/vape/banana = 100,)
+				/obj/item/weapon/flame/lighter/zippo = 250, /obj/item/clothing/mask/vape/pipe = 500, /obj/item/clothing/mask/vape = 300, /obj/item/weapon/reagent_containers/glass/beaker/vial/vape/nicotine = 150,/obj/item/weapon/reagent_containers/glass/beaker/vial/vape/berry = 100,/obj/item/weapon/reagent_containers/glass/beaker/vial/vape/lemon = 100,/obj/item/weapon/reagent_containers/glass/beaker/vial/vape/banana = 100, /obj/item/weapon/storage/fancy/cigar = 50,/obj/item/weapon/storage/fancy/cigarettes/killthroat = 50, /obj/item/weapon/storage/fancy/cigarettes/homeless = 50)
 
 /obj/machinery/vending/boozeomat
 	req_access = list(access_bar)
@@ -91,6 +91,12 @@
 					/obj/item/weapon/storage/deferred/crate/clown_crime/hoxton = 2,
 					/obj/item/weapon/storage/deferred/crate/clown_crime/chains = 2
 					)
+	premium = list(
+					/obj/item/weapon/storage/pouch/ammo = 5,
+					/obj/item/ammo_magazine/ammobox/clrifle/rubber = 3,
+					/obj/item/ammo_magazine/ammobox/lrifle/rubber = 3,
+					/obj/item/ammo_magazine/ammobox/srifle/rubber = 3
+	)
 	prices = list(
 					/obj/item/ammo_magazine/slpistol/rubber = 90,
 					/obj/item/ammo_magazine/pistol/rubber = 200,
@@ -111,7 +117,11 @@
 					/obj/item/weapon/storage/deferred/crate/clown_crime = 1800,
 					/obj/item/weapon/storage/deferred/crate/clown_crime/wolf = 1800,
 					/obj/item/weapon/storage/deferred/crate/clown_crime/hoxton = 1800,
-					/obj/item/weapon/storage/deferred/crate/clown_crime/chains = 1800
+					/obj/item/weapon/storage/deferred/crate/clown_crime/chains = 1800,
+					/obj/item/weapon/storage/pouch/ammo = 750,
+					/obj/item/ammo_magazine/ammobox/clrifle/rubber = 1500,
+					/obj/item/ammo_magazine/ammobox/lrifle/rubber = 1500,
+					/obj/item/ammo_magazine/ammobox/srifle/rubber = 1500
 					)
 	idle_power_usage = 211
 	auto_price = FALSE
@@ -154,6 +164,9 @@
 	auto_price = FALSE
 
 /obj/machinery/vending/wallmed/lobby
+	premium = list(/obj/item/weapon/storage/firstaid/regular = 5,
+					/obj/item/weapon/storage/firstaid/adv = 3
+	)
 	products = list(
 		/obj/item/device/scanner/health = 5,
 		/obj/item/stack/medical/bruise_pack = 5,
@@ -168,7 +181,36 @@
 		/obj/item/stack/nanopaste = 1
 		)
 
+	prices = list(
+		/obj/item/device/scanner/health = 50,
+
+		/obj/item/stack/medical/bruise_pack = 100, /obj/item/stack/medical/ointment = 100,
+		/obj/item/stack/medical/advanced/bruise_pack = 200, /obj/item/stack/medical/advanced/ointment = 200,
+		/obj/item/stack/nanopaste = 1000,
+
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/antitoxin = 100, /obj/item/weapon/reagent_containers/syringe/antitoxin = 200,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/tricordrazine = 150, /obj/item/weapon/reagent_containers/syringe/tricordrazine = 300,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/spaceacillin = 100, /obj/item/weapon/reagent_containers/syringe/spaceacillin = 200,
+
+		/obj/item/weapon/implantcase/death_alarm = 500,
+		/obj/item/weapon/implanter = 50,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/hyperzine = 500,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/drugs = 500,
+
+		/obj/item/weapon/storage/firstaid/regular = 500,
+		/obj/item/weapon/storage/firstaid/adv = 1000
+		)
+
 /obj/machinery/vending/weapon_machine
+	premium = list(
+					/obj/item/weapon/gun/projectile/automatic/wintermute = 3,
+					/obj/item/weapon/gun/projectile/automatic/sol = 3,
+					/obj/item/weapon/gun/projectile/automatic/straylight = 3,
+					/obj/item/weapon/gun/projectile/paco = 3,
+					/obj/item/weapon/gun/projectile/revolver/deckard = 3,
+					/obj/item/weapon/gun/projectile/shotgun/pump/regulator = 3,
+					/obj/item/weapon/gun/energy/gun/gemini = 3
+	)
 	prices = list(
 
 					/obj/item/weapon/gun/projectile/revolver/havelock = 600,
@@ -185,7 +227,14 @@
 					/obj/item/clothing/suit/armor/vest = 1500,
 					/obj/item/weapon/gun/projectile/automatic/slaught_o_matic = 300,//Occulus Edit: Ahahaha what? No
 					/obj/item/weapon/tool/knife/tacknife = 600,//Occulus Edit: We have a bullet vendor
-					/obj/item/weapon/storage/box/smokes = 200)
+					/obj/item/weapon/storage/box/smokes = 200,
+					/obj/item/weapon/gun/projectile/automatic/wintermute = 3500,
+					/obj/item/weapon/gun/projectile/automatic/sol = 2300,
+					/obj/item/weapon/gun/projectile/automatic/straylight = 1400,
+					/obj/item/weapon/gun/projectile/paco = 1500,
+					/obj/item/weapon/gun/projectile/revolver/deckard = 3100,
+					/obj/item/weapon/gun/projectile/shotgun/pump/regulator = 1500,
+					/obj/item/weapon/gun/energy/gun/gemini = 2100)
 
 //all these are just to update the bill validator lights
 /obj/machinery/vending/serbomat/New()
@@ -250,3 +299,32 @@
 					/obj/item/weapon/reagent_containers/food/snacks/sosjerky = 75,/obj/item/weapon/reagent_containers/food/snacks/no_raisin = 80,/obj/item/weapon/reagent_containers/food/snacks/spacetwinkie = 60,
 					/obj/item/weapon/reagent_containers/food/snacks/cheesiehonkers = 90, /obj/item/weapon/reagent_containers/food/snacks/tastybread = 100,
 					/obj/item/weapon/reagent_containers/food/snacks/syndicake = 80, /obj/item/weapon/storage/ration_pack = 500)
+
+/obj/machinery/vending/powermat
+	premium = list(/obj/item/weapon/cell/large/hyper = 3,
+					/obj/item/weapon/cell/medium/hyper = 3,
+					/obj/item/weapon/cell/small/hyper = 3)
+	prices = list(/obj/item/weapon/cell/large = 500, 
+					/obj/item/weapon/cell/large/high = 700, 
+					/obj/item/weapon/cell/medium = 300, 
+					/obj/item/weapon/cell/medium/high = 400, 
+					/obj/item/weapon/cell/small = 100, 
+					/obj/item/weapon/cell/small/high = 200,
+					/obj/item/weapon/cell/large/super = 1200, 
+					/obj/item/weapon/cell/medium/super = 700, 
+					/obj/item/weapon/cell/small/super = 350, 
+					/obj/item/weapon/cell/large/hyper = 1700, 
+					/obj/item/weapon/cell/medium/hyper = 1000, 
+					/obj/item/weapon/cell/small/hyper = 500)
+
+/obj/machinery/vending/theomat
+	premium = list(
+					/obj/item/weapon/storage/belt/utility/neotheology = 3,
+					/obj/item/weapon/storage/belt/tactical/neotheology = 3
+	)
+	prices = list(/obj/item/weapon/book/ritual/cruciform = 500, 
+					/obj/item/weapon/storage/fancy/candle_box = 200, 
+					/obj/item/weapon/reagent_containers/food/drinks/bottle/ntcahors = 250,
+					/obj/item/weapon/implant/core_implant/cruciform = 1000,
+					/obj/item/weapon/storage/belt/utility/neotheology = 150,
+					/obj/item/weapon/storage/belt/tactical/neotheology = 150)


### PR DESCRIPTION

## About The Pull Request

This PR adds a coinpress disk (I was not going to make a whole-ass machine like TG just for this) And, more importantly, Changes premium selection in vendors and adds more.

Vendor premiums *NOW* consume their coin. This is both to justify the coin minting disk, and so its not just a key that you put in, take out.. Specially since you can string coins. (Another good reason to fix it)

Ontop of this, Bullethavens, FS Gun vendor, Theomats, Powermats, and the Medical Wall Vendor now has premium options.

## Why It's Good For The Game

Fixes something Eris didn't impliment correctly and adds more uses for the system

## Changelog
```changelog
add: Added new "Premium" Selections for Bullethavens, FS gun vendors, Theomats, powermats, and medical wall vendors, all requiring a coin and their cost.
fix: fixed coins not being consumed on vending.
```
