### PR TITLE
Coin Minting and Premium Vendors 2: Capitalist Boogaloo

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2823,6 +2823,7 @@
 #include "zzzz_modular_occulus\code\datums\datacore.dm"
 #include "zzzz_modular_occulus\code\datums\autolathe\biomatter.dm"
 #include "zzzz_modular_occulus\code\datums\autolathe\circuits.dm"
+#include "zzzz_modular_occulus\code\datums\autolathe\coins.dm" 
 #include "zzzz_modular_occulus\code\datums\autolathe\fabkits.dm"
 #include "zzzz_modular_occulus\code\datums\autolathe\guns.dm"
 #include "zzzz_modular_occulus\code\datums\craft\crafting_items.dm"

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -766,9 +766,11 @@
 			else
 				to_chat(user, SPAN_NOTICE("You weren't able to pull the coin out fast enough, the machine ate it, string and all."))
 				qdel(coin)
+				coin = null    //Occulus Addition, fixing coin cost
 				categories &= ~CAT_COIN
 		else
 			qdel(coin)
+			coin = null    //Occulus Addition, fixing coin cost
 			categories &= ~CAT_COIN
 
 	if(((last_reply + (vend_delay + 200)) <= world.time) && vend_reply)

--- a/code/modules/mining/coins.dm
+++ b/code/modules/mining/coins.dm
@@ -21,43 +21,43 @@
 	name = COIN_GOLD
 	icon_state = "coin_gold"
 	matter = list(MATERIAL_GOLD = 1)	//occulus edit: adding matter value to coins
-	price_tag = 30	//occulus edit: adding pricetag and export to coins
+	price_tag = 75	//occulus edit: adding pricetag and export to coins based on 1.5 the mat value
 
 /obj/item/weapon/coin/silver
 	name = COIN_SILVER
 	icon_state = "coin_silver"
 	matter = list(MATERIAL_SILVER = 1)	//occulus edit: adding matter value to coins
-	price_tag = 15	//occulus edit: adding pricetag and export to coins
+	price_tag = 60	//occulus edit: adding pricetag and export to coins
 
 /obj/item/weapon/coin/diamond
 	name = COIN_DIAMOND
 	icon_state = "coin_diamond"
 	matter = list(MATERIAL_DIAMOND = 1)	//occulus edit: adding matter value to coins
-	price_tag = 40	//occulus edit: adding pricetag and export to coins
+	price_tag = 150	//occulus edit: adding pricetag and export to coins
 
 /obj/item/weapon/coin/iron
 	name = COIN_IRON
 	icon_state = "coin_iron"
 	matter = list(MATERIAL_IRON = 1)	//occulus edit: adding matter value to coins
-	price_tag = 10	//occulus edit: adding pricetag and export to coins
+	price_tag = 10	//occulus edit: adding pricetag and export to coins, special exception to value
 
 /obj/item/weapon/coin/phoron
 	name = COIN_PHORON
 	icon_state = "coin_phoron"
 	matter = list(MATERIAL_PHORON = 1)	//occulus edit: adding matter value to coins
-	price_tag = 30	//occulus edit: adding pricetag and export to coins
+	price_tag = 45	//occulus edit: adding pricetag and export to coins
 
 /obj/item/weapon/coin/uranium
 	name = COIN_URANIUM
 	icon_state = "coin_uranium"
 	matter = list(MATERIAL_URANIUM = 1)	//occulus edit: adding matter value to coins
-	price_tag = 25	//occulus edit: adding pricetag and export to coins
+	price_tag = 75	//occulus edit: adding pricetag and export to coins
 
 /obj/item/weapon/coin/platinum
 	name = COIN_PLATINUM
 	icon_state = "coin_adamantine"
 	matter = list(MATERIAL_PLATINUM = 1)	//occulus edit: adding matter value to coins
-	price_tag = 50	//occulus edit: adding pricetag and export to coins
+	price_tag = 120	//occulus edit: adding pricetag and export to coins
 
 /obj/item/weapon/coin/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/stack/cable_coil))

--- a/code/modules/mining/coins.dm
+++ b/code/modules/mining/coins.dm
@@ -20,30 +20,44 @@
 /obj/item/weapon/coin/gold
 	name = COIN_GOLD
 	icon_state = "coin_gold"
+	matter = list(MATERIAL_GOLD = 1)	//occulus edit: adding matter value to coins
+	price_tag = 30	//occulus edit: adding pricetag and export to coins
 
 /obj/item/weapon/coin/silver
 	name = COIN_SILVER
 	icon_state = "coin_silver"
+	matter = list(MATERIAL_SILVER = 1)	//occulus edit: adding matter value to coins
+	price_tag = 15	//occulus edit: adding pricetag and export to coins
 
 /obj/item/weapon/coin/diamond
 	name = COIN_DIAMOND
 	icon_state = "coin_diamond"
+	matter = list(MATERIAL_DIAMOND = 1)	//occulus edit: adding matter value to coins
+	price_tag = 40	//occulus edit: adding pricetag and export to coins
 
 /obj/item/weapon/coin/iron
 	name = COIN_IRON
 	icon_state = "coin_iron"
+	matter = list(MATERIAL_IRON = 1)	//occulus edit: adding matter value to coins
+	price_tag = 10	//occulus edit: adding pricetag and export to coins
 
 /obj/item/weapon/coin/phoron
 	name = COIN_PHORON
 	icon_state = "coin_phoron"
+	matter = list(MATERIAL_PHORON = 1)	//occulus edit: adding matter value to coins
+	price_tag = 30	//occulus edit: adding pricetag and export to coins
 
 /obj/item/weapon/coin/uranium
 	name = COIN_URANIUM
 	icon_state = "coin_uranium"
+	matter = list(MATERIAL_URANIUM = 1)	//occulus edit: adding matter value to coins
+	price_tag = 25	//occulus edit: adding pricetag and export to coins
 
 /obj/item/weapon/coin/platinum
 	name = COIN_PLATINUM
 	icon_state = "coin_adamantine"
+	matter = list(MATERIAL_PLATINUM = 1)	//occulus edit: adding matter value to coins
+	price_tag = 50	//occulus edit: adding pricetag and export to coins
 
 /obj/item/weapon/coin/attackby(obj/item/weapon/W as obj, mob/user as mob)
 	if(istype(W,/obj/item/stack/cable_coil))

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -47524,6 +47524,7 @@
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/misc,
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/medical,
 /obj/item/weapon/computer_hardware/hard_drive/portable/design/nonlethal_ammo,
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/coins,
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/quartermaster/storage)
 "cia" = (

--- a/zzzz_modular_occulus/code/datums/autolathe/coins.dm
+++ b/zzzz_modular_occulus/code/datums/autolathe/coins.dm
@@ -1,0 +1,24 @@
+/datum/design/autolathe/coin
+	name = "iron coin"
+	build_path = /obj/item/weapon/coin/iron
+	materials = list(MATERIAL_IRON = 1)
+
+/datum/design/autolathe/coin/silver
+	name = "silver coin"
+	build_path = /obj/item/weapon/coin/silver
+	materials = list(MATERIAL_SILVER = 1)
+
+/datum/design/autolathe/coin/gold
+	name = "gold coin"
+	build_path = /obj/item/weapon/coin/gold
+	materials = list(MATERIAL_GOLD = 1) 
+
+/datum/design/autolathe/coin/platinum
+	name = "platinum coin"
+	build_path = /obj/item/weapon/coin/platinum
+	materials = list(MATERIAL_PLATINUM = 1)
+
+/datum/design/autolathe/coin/diamond
+	name = "diamond coin"
+	build_path = /obj/item/weapon/coin/diamond
+	materials = list(MATERIAL_DIAMOND = 1)

--- a/zzzz_modular_occulus/code/game/machinery/vending.dm
+++ b/zzzz_modular_occulus/code/game/machinery/vending.dm
@@ -120,6 +120,14 @@
 					/obj/item/weapon/storage/box/smokes = 3,
 					/obj/item/clothing/head/armor/helmet = 2,
 					/obj/item/clothing/suit/armor/vest = 2)
+	premium = list(
+					/obj/item/weapon/gun/projectile/automatic/wintermute = 3,
+					/obj/item/weapon/gun/projectile/automatic/sol = 3,
+					/obj/item/weapon/gun/projectile/automatic/straylight = 3,
+					/obj/item/weapon/gun/projectile/paco = 3,
+					/obj/item/weapon/gun/projectile/revolver/deckard = 3,
+					/obj/item/weapon/gun/projectile/shotgun/pump/regulator = 3,
+					/obj/item/weapon/gun/energy/gun/gemini = 3)
 	prices = list(
 					/obj/item/weapon/reagent_containers/spray/pepper = 200,
 					/obj/item/weapon/gun/projectile/revolver/havelock = 600,
@@ -135,7 +143,14 @@
 					/obj/item/clothing/head/armor/helmet = 1000,
 					/obj/item/clothing/suit/armor/vest = 1500,
 					/obj/item/weapon/tool/knife/tacknife = 600,
-					/obj/item/weapon/storage/box/smokes = 200)
+					/obj/item/weapon/storage/box/smokes = 200,
+					/obj/item/weapon/gun/projectile/automatic/wintermute = 3500,
+					/obj/item/weapon/gun/projectile/automatic/sol = 2300,
+					/obj/item/weapon/gun/projectile/automatic/straylight = 1400,
+					/obj/item/weapon/gun/projectile/paco = 1500,
+					/obj/item/weapon/gun/projectile/revolver/deckard = 3100,
+					/obj/item/weapon/gun/projectile/shotgun/pump/regulator = 1500,
+					/obj/item/weapon/gun/energy/gun/gemini = 2100)
 
 /obj/machinery/vending/serbomat
 	name = "BulletHeaven"
@@ -162,6 +177,12 @@
 					/obj/item/weapon/cell/small/high = 10,
 					/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_cheap_guns/generic = 2
 					)
+	premium = list(
+					/obj/item/weapon/storage/pouch/ammo = 5,
+					/obj/item/ammo_magazine/ammobox/clrifle/rubber = 3,
+					/obj/item/ammo_magazine/ammobox/lrifle/rubber = 3,
+					/obj/item/ammo_magazine/ammobox/srifle/rubber = 3
+					)
 	prices = list(
 					/obj/item/ammo_magazine/slpistol/rubber = 90,
 					/obj/item/ammo_magazine/pistol/rubber = 200,
@@ -178,7 +199,11 @@
 					/obj/item/ammo_magazine/ammobox/shotgun/beanbags = 575,
 					/obj/item/ammo_magazine/ammobox/shotgun/rubbershot = 575,
 					/obj/item/weapon/cell/small/high = 500,
-					/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_cheap_guns/generic = 2500
+					/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/fs_cheap_guns/generic = 2500,
+					/obj/item/weapon/storage/pouch/ammo = 750,
+					/obj/item/ammo_magazine/ammobox/clrifle/rubber = 1500,
+					/obj/item/ammo_magazine/ammobox/lrifle/rubber = 1500,
+					/obj/item/ammo_magazine/ammobox/srifle/rubber = 1500
 					)
 	idle_power_usage = 211
 	auto_price = FALSE
@@ -236,6 +261,30 @@
 		/obj/item/weapon/implanter = 2,
 		/obj/item/stack/nanopaste = 1
 		)
+	premium = list(
+		/obj/item/weapon/storage/firstaid/regular = 5,
+		/obj/item/weapon/storage/firstaid/adv = 3
+		)
+	prices = list(
+		/obj/item/device/scanner/health = 50,
+		/obj/item/stack/medical/bruise_pack = 100,
+		/obj/item/stack/medical/ointment = 100,
+		/obj/item/stack/medical/advanced/bruise_pack = 200,
+		/obj/item/stack/medical/advanced/ointment = 200,
+		/obj/item/stack/nanopaste = 1000,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/antitoxin = 100, 
+		/obj/item/weapon/reagent_containers/syringe/antitoxin = 200,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/tricordrazine = 150, 
+		/obj/item/weapon/reagent_containers/syringe/tricordrazine = 300,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/spaceacillin = 100, 
+		/obj/item/weapon/reagent_containers/syringe/spaceacillin = 200,
+		/obj/item/weapon/implantcase/death_alarm = 500,
+		/obj/item/weapon/implanter = 50,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/hyperzine = 500,
+		/obj/item/weapon/reagent_containers/hypospray/autoinjector/drugs = 500,
+		/obj/item/weapon/storage/firstaid/regular = 400,
+		/obj/item/weapon/storage/firstaid/adv = 800,
+		)
 
 //Seed Vendors
 
@@ -282,6 +331,38 @@
 		/obj/item/device/electronics/integrated/integrated_circuit_printer = 3000
 	)
 	vendor_department = DEPARTMENT_ENGINEERING
+
+/obj/machinery/vending/powermat
+	premium = list(/obj/item/weapon/cell/large/hyper = 3,
+					/obj/item/weapon/cell/medium/hyper = 3,
+					/obj/item/weapon/cell/small/hyper = 3
+					)
+	prices = list(/obj/item/weapon/cell/large = 500, 
+					/obj/item/weapon/cell/large/high = 700, 
+					/obj/item/weapon/cell/medium = 300, 
+					/obj/item/weapon/cell/medium/high = 400, 
+					/obj/item/weapon/cell/small = 100, 
+					/obj/item/weapon/cell/small/high = 200,
+					/obj/item/weapon/cell/large/super = 1200, 
+					/obj/item/weapon/cell/medium/super = 700, 
+					/obj/item/weapon/cell/small/super = 350, 
+					/obj/item/weapon/cell/large/hyper = 1700, 
+					/obj/item/weapon/cell/medium/hyper = 1000, 
+					/obj/item/weapon/cell/small/hyper = 500
+					)
+
+//Mekhane Theomat
+
+/obj/machinery/vending/theomat
+	premium = list(
+					/obj/item/weapon/storage/belt/utility/neotheology = 3,
+					/obj/item/weapon/storage/belt/tactical/neotheology = 3)
+	prices = list(/obj/item/weapon/book/ritual/cruciform = 500, 
+					/obj/item/weapon/storage/fancy/candle_box = 200, 
+					/obj/item/weapon/reagent_containers/food/drinks/bottle/ntcahors = 250,
+					/obj/item/weapon/implant/core_implant/cruciform = 1000,
+					/obj/item/weapon/storage/belt/utility/neotheology = 150,
+					/obj/item/weapon/storage/belt/tactical/neotheology = 150)
 
 //all these are just to update the bill validator lights
 /obj/machinery/vending/serbomat/New()

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/design_disks/_disks.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/design_disks/_disks.dm
@@ -29,6 +29,18 @@
 		/datum/design/autolathe/fabkit/dryrack
 		)
 
+/obj/item/weapon/computer_hardware/hard_drive/portable/design/coins
+	disk_name = "FTU Coinpress Disk"
+	icon_state = "guild"
+	rarity_value = 247
+	designs = list(
+		/datum/design/autolathe/coin,
+		/datum/design/autolathe/coin/silver,
+		/datum/design/autolathe/coin/gold,
+		/datum/design/autolathe/coin/platinum,
+		/datum/design/autolathe/coin/diamond
+	)
+
 
 /*
 CHURCH DISKS


### PR DESCRIPTION
## About The Pull Request

This PR adds a coinpress disk (I was not going to make a whole-ass machine like TG just for this) And, more importantly, Changes premium selection in vendors and adds more.

Vendor premiums *NOW* consume their coin. This is both to justify the coin minting disk, and so its not just a key that you put in, take out.. Specially since you can string coins. (Another good reason to fix it)

Ontop of this, Bullethavens, FS Gun vendor, Theomats, Powermats, and the Medical Wall Vendor now has premium options.

## Why It's Good For The Game

Fixes something Eris didn't impliment correctly and adds more uses for the system

## Changelog
```changelog
add: Added new "Premium" Selections for Bullethavens, FS gun vendors, Theomats, powermats, and medical wall vendors, all requiring a coin and their cost.
fix: fixed coins not being consumed on vending.
```
