### PR TITLE
Shrinks shotgun ammoboxes

### DIFF
--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -269,7 +269,7 @@
 	name = "ammunition box (slug shell)"
 	icon_state = "shot_hv"
 	matter = list(MATERIAL_STEEL = 24)
-	w_class = ITEM_SIZE_BULKY
+	w_class = ITEM_SIZE_NORMAL	//occulus edit, changing to box size to reverse a slight nerf
 	caliber = CAL_SHOTGUN
 	ammo_type = /obj/item/ammo_casing/shotgun
 	max_ammo = 30


### PR DESCRIPTION

## About The Pull Request

Before.
![image](https://user-images.githubusercontent.com/28457065/134407911-06445074-b0ce-4ea0-a19d-5eafe8a246ad.png)

After
![image](https://user-images.githubusercontent.com/28457065/134407986-59cc8ab9-b7e7-4eb3-81f4-9609554bae89.png)


## Why It's Good For The Game

Puts shotgun ammo boxes to the same size they were before the texture/mechanic change (The same size as a box)

## Changelog
```changelog
balance: puts shotgun ammobox items in the same size as normal boxes
```

