### PR TITLE
Fixes only being able to examine your own pupil reaction

### DIFF
--- a/code/game/objects/items/devices/lighting/toggleable/flashlight.dm
+++ b/code/game/objects/items/devices/lighting/toggleable/flashlight.dm
@@ -255,7 +255,7 @@
 
 			user.visible_message(SPAN_NOTICE("\The [user] directs [src] to [M]'s eyes."), \
 							 	 SPAN_NOTICE("You direct [src] to [M]'s eyes."))
-			if(H == user)	//can't look into your own eyes buster
+			if(H != user)	//can't look into your own eyes buster // OCCULUS Edit - Fixes looking at pupil dilation
 				if(M.stat == DEAD || M.blinded)	//mob is dead or fully blind
 					to_chat(user, SPAN_WARNING("\The [M]'s pupils do not react to the light!"))
 					return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
title, also unable to exam own eyes

## Why It's Good For The Game

fixes bug

## Changelog
```changelog
fix: Fixed not being able to check others' pupils with flashlight/penlight.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
