### PR TITLE
Removes debug world messages from Neuroinducer

### DIFF
--- a/zzzz_modular_occulus/code/game/objects/items/devices/neuroinducer.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/devices/neuroinducer.dm
@@ -22,13 +22,11 @@
 
 /obj/item/device/neuroinducer/proc/halcyon(mob/living/carbon/human/M, mob/user)
 	if(user.incapacitated() || user.get_active_hand() != src)
-		to_world("user is incapacitated")
 		return
 	to_chat(user, SPAN_DANGER("[user] begins to run the [src] over [M]'s Limbic cortex!"))
 	if (do_mob(user, M, 20))
 		if(!cell_use_check(charge_per_use, user))	//I hate this proc -radiantflash
-			update_icon()
-			to_world("updated icon")	//Inducer charge empty
+			update_icon()	//Inducer charge empty
 			return
 		update_icon()
 		var/mob/living/carbon/human/affected = M
@@ -36,7 +34,6 @@
 			B.finished = TRUE
 		if(M.sanity.level < 25)
 			M.sanity.level = 25
-			to_world("sanity level now 25")
 		to_chat(M, SPAN_NOTICE("You have a warm fuzzy feeling, as if you were remembering a pleasant memory."))
 
 		if(M.stats.getPerk(PERK_LOWBORN) && M.sanity.max_level <110)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes Debug world messages on Neuroinducer use (oops)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes my idiocy. Forgot to remove it when I removed it for the traitor variant.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
fix: Fixes debug messages showing up to world.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
