### PR TITLE
Finally re-dose narcolepsy spiderling

### DIFF
--- a/zzzz_modular_occulus/code/game/objects/items/weapons/implant/implants/carrion/sleep_spider.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/implant/implants/carrion/sleep_spider.dm
@@ -8,7 +8,7 @@
 /obj/item/weapon/implant/carrion_spider/sleeping/activate()
 	..()
 	if(wearer)
-		wearer.reagents.add_reagent("stoxin", 5)
+		wearer.reagents.add_reagent("stoxin", 10)
 		to_chat(wearer, SPAN_NOTICE("You feel tired and drop into a sleep"))
 		die()
 	else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So, this doubles the narcolepsy spider's chem count to 10. This is **What it should have been** on release, because apparently i balanced it for 25 chem cost.

## Why It's Good For The Game

Makes the narcolepsy spider worth its price for carrion, the dreadfully broken antag.

## Changelog
```changelog
balance: doubles narcolepsy/sleep-spiderling's stoxin 
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
