### PR TITLE
Lethal Spiderlings Warning (Ready for Review)

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2911,6 +2911,7 @@
 #include "zzzz_modular_occulus\code\game\objects\items\weapons\design_disks\nanotrasen.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\weapons\grenades\chem_grenade.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\weapons\grenades\stinger.dm"
+#include "zzzz_modular_occulus\code\game\objects\items\weapons\implant\implants\carrion\carrion_spiders.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\weapons\implant\implants\carrion\cleaner_spider.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\weapons\implant\implants\carrion\disruptor_spider.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\weapons\implant\implants\carrion\friend_spider.dm"

--- a/code/modules/sanity/sanity_lists.dm
+++ b/code/modules/sanity/sanity_lists.dm
@@ -133,7 +133,10 @@
 		"The fungus dreams.",
 		"Eternity lies ahead of you, and behind. Have you drunk your fill?",
 		"Your blood is precious and must never be seen by the greedy.",
-		"You hear the distant, unmistakable sound of the drum roll from singer-songerwiter Phil Collin's original 1981 release of In The Air Tonight. ...Who the hell is Phil Collins?"
+		"You hear the distant, unmistakable sound of the drum roll from singer-songerwiter Phil Collin's original 1981 release of In The Air Tonight. ...Who the hell is Phil Collins?",
+		"You hear chittering and broken whispers scratch at your mind",  //Occulus Edit
+		"You feel a sharp stabbing pain that slowly fades.",  //Occulus Edit
+		"You feel a sharp stabbing pain followed by an odd electric tingle."  //Occulus Edit
 		
 	)
 	return pick(sanity_quotes_40)

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
@@ -1,27 +1,27 @@
 /obj/item/weapon/implant/carrion_spider/explosive/install()
 	..()
 	spawn(600) //This is a 1 minute warning. I am varying these quite a lot
-	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades"))
+	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades."))
 
 /obj/item/weapon/implant/carrion_spider/flashbang/install()
 	..()
 	spawn(3000) //5 minute warning
-	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades"))
+	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades."))
 
 /obj/item/weapon/implant/carrion_spider/infection/install()
 	..()
 	spawn(50) //5 second warning, This one is kinda important to have feedback   
-	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades"))
+	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades."))
 
 /obj/item/weapon/implant/carrion_spider/breeding/install()
 	..()
 	spawn(6000) //10 minute warning, It can only activate when a person is dead, so its not high priority
-	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades"))
+	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades."))
 
 /obj/item/weapon/implant/carrion_spider/toxicbomb/install()
 	..()
 	spawn(600) //1 minute warning, potentially more deadly than an explosive spider, but unreliable
-	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades"))
+	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades."))
 
 /obj/item/weapon/implant/carrion_spider/disruptor/install()
 	..()

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
@@ -1,0 +1,29 @@
+/obj/item/weapon/implant/carrion_spider/explosive/install()
+	..()
+	sleep(600) //This is a 1 minute warning. I am varying these quite a lot
+	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades"))
+
+/obj/item/weapon/implant/carrion_spider/flashbang/install()
+	..()
+	sleep(3000) //5 minute warning
+	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades"))
+
+/obj/item/weapon/implant/carrion_spider/infection/install()
+	..()
+	sleep(50) //5 second warning, This one is kinda important to have feedback   
+	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades"))
+
+/obj/item/weapon/implant/carrion_spider/breeding/install()
+	..()
+	sleep(6000) //10 minute warning, It can only activate when a person is dead, so its not high priority
+	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades"))
+
+/obj/item/weapon/implant/carrion_spider/toxicbomb/install()
+	..()
+	sleep(600) //1 minute warning, potentially more deadly than an explosive spider, but unreliable
+	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades"))
+
+/obj/item/weapon/implant/carrion_spider/disruptor/install()
+	..()
+	sleep(3000) //5 minute warning.
+	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain followed by an odd electric tingle."))

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
@@ -29,8 +29,6 @@
 	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain followed by an odd electric tingle."))
 
 /obj/item/weapon/implant/carrion_spider/mindboil/Process()
-	..()
-
 	if(active)
 		if(wearer)
 			attack_from = wearer

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/implant/implants/carrion/carrion_spiders.dm
@@ -1,29 +1,50 @@
 /obj/item/weapon/implant/carrion_spider/explosive/install()
 	..()
-	sleep(600) //This is a 1 minute warning. I am varying these quite a lot
+	spawn(600) //This is a 1 minute warning. I am varying these quite a lot
 	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades"))
 
 /obj/item/weapon/implant/carrion_spider/flashbang/install()
 	..()
-	sleep(3000) //5 minute warning
+	spawn(3000) //5 minute warning
 	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades"))
 
 /obj/item/weapon/implant/carrion_spider/infection/install()
 	..()
-	sleep(50) //5 second warning, This one is kinda important to have feedback   
+	spawn(50) //5 second warning, This one is kinda important to have feedback   
 	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades"))
 
 /obj/item/weapon/implant/carrion_spider/breeding/install()
 	..()
-	sleep(6000) //10 minute warning, It can only activate when a person is dead, so its not high priority
+	spawn(6000) //10 minute warning, It can only activate when a person is dead, so its not high priority
 	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades"))
 
 /obj/item/weapon/implant/carrion_spider/toxicbomb/install()
 	..()
-	sleep(600) //1 minute warning, potentially more deadly than an explosive spider, but unreliable
+	spawn(600) //1 minute warning, potentially more deadly than an explosive spider, but unreliable
 	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain that slowly fades"))
 
 /obj/item/weapon/implant/carrion_spider/disruptor/install()
 	..()
-	sleep(3000) //5 minute warning.
+	spawn(3000) //5 minute warning.
 	to_chat(wearer, SPAN_WARNING("You feel a sharp stabbing pain followed by an odd electric tingle."))
+
+/obj/item/weapon/implant/carrion_spider/mindboil/Process()
+	..()
+
+	if(active)
+		if(wearer)
+			attack_from = wearer
+		else
+			attack_from = src
+		for(var/mob/living/carbon/human/H in view(5, attack_from))
+			if(!H.mind || (H in victims) || (H == owner_mob)) //Occulus Edit
+				continue
+			H.sanity.onPsyDamage(1) //Half the ammount of mind fryer, can be mass produced
+			var/chance_multi = 1
+			if(H.stats.getPerk(PERK_EAR_OF_QUICKSILVER))
+				chance_multi = 4
+			if(prob(5*chance_multi))
+				to_chat(H, SPAN_DANGER("You hear chittering and broken whispers scratch at your mind"))
+		// Pick up a new contract if there is none
+		if(owner_mob && !contract)
+			find_contract()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds a very simple delayed warning system to combat oriented spiderlings and a random chance while in the mindboiler spider's field that gets higher when you have ear of quicksilver.

## Why It's Good For The Game

Its... Debatable if it is good
But it DOES make it so carrions have to plan much more carefully with their violent spiderlings, Along with giving some.. Fun potential :^) 

## Changelog
```changelog
add: Spiderling warnings (And sanity message mirrors for the warnings)
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
