### PR TITLE
Mech Manual Maintenance Mode External Extravaganza 

### DIFF
--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -330,7 +330,7 @@
 		if(do_mob(user, src, 30) && coil.use(5))
 			mc.repair_burn_damage(15)
 
-	var/list/usable_qualities = list(QUALITY_PULSING, QUALITY_BOLT_TURNING, QUALITY_WELDING)
+	var/list/usable_qualities = list(QUALITY_PULSING, QUALITY_BOLT_TURNING, QUALITY_WELDING, QUALITY_SCREW_DRIVING) //Occulus Edit, added screwdriving
 
 	var/tool_type = I.get_tool_type(user, usable_qualities, src)
 	switch(tool_type)
@@ -379,6 +379,19 @@
 				visible_message(SPAN_WARNING("\The [mc] has been repaired by [user]!"),"You hear welding.")
 				mc.repair_brute_damage(15)
 				return TRUE
+		//Occulus Edit Start
+		if(QUALITY_SCREW_DRIVING)
+			if(length(pilots))
+				to_chat(user, SPAN_WARNING("You cant press the maintenance button with the pilot inside!"))
+				return TRUE
+			if(!pilots)
+				to_chat(user, SPAN_NOTICE("You carefully start to wedge the screwdriver bit in to activate maintenance mode"))
+				if(!do_mob(user, src, 60))
+					return TRUE
+				to_chat(user, SPAN_NOTICE("You successfully press the emergency maintenance button as the bolt covers retract"))
+				maintenance_protocols = 1
+				return TRUE
+		//Occulus Edit End
 
 		if(ABORT_CHECK)
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows screwdrivers to put mechs into maint mode aslong as there isn't a pilot and after a bit of time.

## Why It's Good For The Game

Allows people to put mechs into maintenance mode without entering them. If you've played with mechs you'll probably understand why this is good for the game.

## Changelog
```changelog
add: Can use a screwdriver to force a mech into maintenance mode
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
