### PR TITLE
Updates changelog workflows to only run on the main repo 

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -8,6 +8,7 @@ jobs:
   compile:
     name: "Compile changelogs"
     runs-on: ubuntu-20.04
+    if: github.repository == 'Occulus-Server/Occulus-Eris' # Occulus Edit - stops workflow from running on forks
     steps:
       - name: "Check for CHANGELOG_ENABLER secret and pass true to output if it exists to be checked by later steps"
         id: value_holder

--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   MakeCL:
     runs-on: ubuntu-latest
-    if: github.repository == 'discordia-space/CEV-Eris'
+    if: github.repository == 'Occulus-Server/Occulus-Eris' # Occulus Edit - We want this to run
     steps:
       - name: Checkout
         uses: actions/checkout@v1


### PR DESCRIPTION
## About The Pull Request

Changelog actions shouldn't run on forks. Also lets the make_changelogs action actually run (as it was set to only run on Eris' repo)