### PR TITLE
Anomoly Lab Map Tweak

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -70809,6 +70809,9 @@
 	d2 = 0;
 	icon_state = "16-0"
 	},
+/obj/structure/disposalpipe/up{
+	dir = 4
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
 "dmG" = (
@@ -70830,6 +70833,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
 "dmK" = (
@@ -70846,13 +70852,12 @@
 	dir = 4
 	},
 /obj/spawner/traps/wire_splicing/low_chance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
 "dmL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 1;
-	icon_state = "pipe-c"
-	},
 /obj/structure/catwalk,
 /obj/structure/cable/green{
 	d1 = 4;
@@ -70865,6 +70870,10 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
+/obj/structure/disposalpipe/junction{
+	dir = 1;
+	icon_state = "pipe-y"
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2starboard)
 "dmM" = (
@@ -85505,6 +85514,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
+/obj/structure/disposalpipe/segment{
+	dir = 1;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck1starboard)
 "dWs" = (
@@ -85527,6 +85540,9 @@
 /obj/structure/railing{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck1starboard)
 "dWu" = (
@@ -85537,6 +85553,9 @@
 	d1 = 32;
 	d2 = 8;
 	icon_state = "32-8"
+	},
+/obj/structure/disposalpipe/down{
+	dir = 8
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section2deck1starboard)
@@ -85978,7 +85997,6 @@
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/docking)
 "dXv" = (
-/obj/structure/disposalpipe/junction,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 28
@@ -86004,6 +86022,10 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-y"
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/research)
@@ -89770,6 +89792,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/maintenance/section2deck1starboard)
 "egp" = (
@@ -90812,6 +90835,10 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
 "eiV" = (
@@ -90834,6 +90861,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
 "eiW" = (
@@ -90848,6 +90878,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
@@ -91201,6 +91234,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
 "ejG" = (
@@ -91586,6 +91620,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
 "ekn" = (

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -90091,6 +90091,10 @@
 /obj/structure/bed/chair{
 	dir = 1
 	},
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
 "ehd" = (
@@ -91196,7 +91200,9 @@
 /area/eris/maintenance/section4deck1central)
 "ejA" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
-/obj/machinery/light,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
 "ejB" = (
@@ -91600,15 +91606,20 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section4deck1central)
 "ekk" = (
-/obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/void/hazardsuit/moebius,
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
 "ekl" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/structure/table/rack,
+/obj/item/clothing/suit/space/void/hazardsuit/moebius,
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
 "ekm" = (
@@ -91627,14 +91638,14 @@
 /obj/machinery/camera/network/research{
 	dir = 1
 	},
-/obj/structure/table/rack,
-/obj/item/clothing/suit/space/void/hazardsuit/moebius,
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
 "eko" = (
-/obj/machinery/light,
-/obj/structure/table/rack,
-/obj/item/clothing/suit/space/void/hazardsuit/moebius,
+/obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
 "ekp" = (
@@ -98456,10 +98467,13 @@
 /area/eris/maintenance/section3deck1central)
 "eAm" = (
 /obj/structure/table/standard,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/item/modular_computer/laptop/preset/atmos,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = 27
+	},
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
 "eAn" = (

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -76721,9 +76721,6 @@
 /obj/structure/defibcabinet{
 	pixel_x = 28
 	},
-/obj/structure/defibcabinet{
-	pixel_x = 28
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -88627,6 +88624,7 @@
 /obj/structure/table/standard,
 /obj/item/clothing/glasses/powered/science,
 /obj/item/clothing/glasses/powered/science,
+/obj/item/weapon/inflatable_dispenser,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/eris/rnd/anomal)
 "edI" = (
@@ -91569,6 +91567,10 @@
 /area/eris/maintenance/section4deck1central)
 "ekk" = (
 /obj/structure/reagent_dispensers/fueltank,
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -22
+	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/anomal)
 "ekl" = (


### PR DESCRIPTION
## About The Pull Request

Adds an air alarm to the anomaly lab.
Adds inflatables to the anomaly lab
Removes the duplicate AED cabinet in medical
Added fire extinguishers to the anomoaly lab
Fixed anomoly lab disposal line

![image](https://user-images.githubusercontent.com/1775680/144504071-33b42350-e5d1-4b97-bf7e-3f607787899a.png)


## Why It's Good For The Game

QoL map stuff things

## Changelog
```changelog
tweak: adjusted anomoly lab
fix: Anomoly lab, misc research, xenobotany disposals now work
fix: removed duplicate AED closet
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
