### PR TITLE
compile cl action now uses PAT

### DIFF
--- a/.github/workflows/compile_changelogs.yml
+++ b/.github/workflows/compile_changelogs.yml
@@ -50,4 +50,5 @@ jobs:
         if: steps.value_holder.outputs.CL_ENABLED
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          #github_token: ${{ secrets.GITHUB_TOKEN }} Occulus Edit - Allows this action to directly merge to master (with next line)
+          github_token: ${{ secrets.CL_TOKEN }}    # Occulus Edit ^


### PR DESCRIPTION
Bypasses the approval requirement for merging directly to master (for the compile changelogs workflow), via use of a PAT held in a repo secret.