### PR TITLE
Fixes body scanners breaking from shrapnel

### DIFF
--- a/code/game/machinery/adv_med.dm
+++ b/code/game/machinery/adv_med.dm
@@ -382,7 +382,7 @@
 					other_wounds += "[device.get_scanner_name()] implanted"
 				else
 					var/obj/item/weapon/implant/device = I
-					if(!device.scanner_hidden)
+					if(!istype(device) || !device.scanner_hidden) // Occulus Edit - fixes shrapnel breaking body scanners
 						unknown_body = TRUE
 			if(unknown_body)
 				other_wounds += "Unknown body present"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes body scanners work, by checking first if it's an implant - if not an implant but still inside organ, then it counts as an unknown body.

## Why It's Good For The Game

Body scanners working = good.

## Changelog
```changelog
fix: Body scanners no longer break if they're scanning someone with shrapnel.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
