### PR TITLE
Fixes an occasional runtime

### DIFF
--- a/zzzz_modular_occulus/code/modules/economy/price_list_fixed.dm
+++ b/zzzz_modular_occulus/code/modules/economy/price_list_fixed.dm
@@ -453,6 +453,8 @@
 
 /obj/item/weapon/reagent_containers/get_item_cost(export)
 	. = ..()
+	if(!reagents)
+		return
 	for(var/datum/reagent/R in reagents.reagent_list)
 		. += R.volume * R.price_tag
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes an occasional runtime which can cause CI to fail.

## Why It's Good For The Game

Less runtimes!

example of the runtime:
```
[19:34:09] Runtime in price_list_fixed.dm,456: Cannot read null.reagent_list
  proc name: get item cost (/obj/item/weapon/reagent_containers/get_item_cost)
  src: the beaker (/obj/item/weapon/reagent_containers/glass/beaker)
  src.loc: the floor (77,83,8) (/turf/simulated/floor/tiled/white/brown_platform)
  call stack:
  the beaker (/obj/item/weapon/reagent_containers/glass/beaker): get item cost(null)
  the mob biome (/obj/landmark/loot_biomes/mob/roach/room): update price()
  the mob biome (/obj/landmark/loot_biomes/mob/roach/room): update()
  the mob biome (/obj/landmark/loot_biomes/mob/roach/room): Initialize(1)
  Atoms (/datum/controller/subsystem/atoms): InitAtom(the mob biome (/obj/landmark/loot_biomes/mob/roach/room), /list (/list))
  Atoms (/datum/controller/subsystem/atoms): InitializeAtoms(/list (/list))
  Deepmaint Template (/datum/map_template/deepmaint_template/room): initTemplateBounds(/list (/list))
  Deep Maint Gen (/obj/procedural/jp_DungeonGenerator/deepmaint): initializeSubmaps()
  Deep Maint Gen (/obj/procedural/jp_DungeonGenerator/deepmaint): generate(null)
  Deep Maint Gen (/obj/procedural/dungenerator/deepmaint): New(the steel wall (88,88,8) (/turf/simulated/wall))
```