### PR TITLE
Fixed a lot of sanity and insight items.

### DIFF
--- a/code/game/machinery/autolathe/artist_bench.dm
+++ b/code/game/machinery/autolathe/artist_bench.dm
@@ -252,7 +252,7 @@
 			stats_amt += 3//max = 3*4*2+6 = 30 points, min 3*4+6 = 18
 		for(var/i in 1 to stats_amt)
 			var/stat = pick(ALL_STATS)
-			oddity_stats[stat] = round(min(MAX_STAT_VALUE, oddity_stats[stat]+ 1)/3) //Occulus Edit - Nerfing Artist oddity stats a bit!
+			oddity_stats[stat] = round(min(MAX_STAT_VALUE, oddity_stats[stat]+ 1)/3,1) //Occulus Edit - Nerfing Artist oddity stats a bit!
 
 		O.oddity_stats = oddity_stats
 		O.AddComponent(/datum/component/inspiration, O.oddity_stats, O.perk)

--- a/code/game/objects/items/devices/techno_tribalism.dm
+++ b/code/game/objects/items/devices/techno_tribalism.dm
@@ -150,7 +150,7 @@
 				var/obj/item/weapon/oddity/techno/T = new /obj/item/weapon/oddity/techno(src)
 				T.oddity_stats = src.oddity_stats
 				for(var/stat in T.oddity_stats)//Occulus Stat nerf
-					stat = round(stat/3)//Occulus Stat nerf
+					T.oddity_stats[stat] = round(T.oddity_stats[stat]/3,1)
 				T.AddComponent(/datum/component/inspiration, T.oddity_stats, T.perk)
 				items_count = 0
 				oddity_stats = list(STAT_MEC = 0, STAT_COG = 0, STAT_BIO = 0, STAT_ROB = 0, STAT_TGH = 0, STAT_VIG = 0)

--- a/code/modules/client/preference_setup/background/06_training.dm
+++ b/code/modules/client/preference_setup/background/06_training.dm
@@ -70,7 +70,7 @@
 
 	else if(href_list["cogmod"])
 		var/new_cog = 0
-		new_cog = input(user, "Enter a value between -10 and 15 for your cognition. (Cognition 50% the cost of other stats).", CHARACTER_PREFERENCE_INPUT_TITLE, pref.COGMOD) as num
+		new_cog = input(user, "Enter a value between -10 and 15 for your cognition. (COG is half the cost of other stats).", CHARACTER_PREFERENCE_INPUT_TITLE, pref.COGMOD) as num
 		if(CanUseTopic(user))
 			var/old_cog = pref.COGMOD
 			pref.COGMOD = max(min(round(new_cog),15),-10)

--- a/zzzz_modular_occulus/code/game/machinery/jukebox.dm
+++ b/zzzz_modular_occulus/code/game/machinery/jukebox.dm
@@ -1,5 +1,5 @@
 /obj/machinery/media/jukebox/Process()
 	if(playing)
-		for(var/mob/living/carbon/human/listener in range)
-			listener.sanity.onMusic()
-
+		for(var/mob/living/carbon/human/listener in range(7, get_turf(src)))
+			listener.sanity.onMusic(0.5)
+	..()

--- a/zzzz_modular_occulus/code/game/objects/items/toys/balls.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/toys/balls.dm
@@ -26,7 +26,7 @@
 /obj/item/toy/tennis/throw_impact()
 	if(istype(thrower, /mob/living/carbon/human))
 		var/mob/living/carbon/human/tosser = thrower
-		tosser.sanity.onExercise(0.4)
+		tosser.sanity.onExercise(8)
 
 /obj/item/toy/tennis/attack_self(mob/user as mob) //Hjonk
 	if (spam_flag == 0)

--- a/zzzz_modular_occulus/code/game/objects/structures/fitness.dm
+++ b/zzzz_modular_occulus/code/game/objects/structures/fitness.dm
@@ -23,7 +23,7 @@
 			user.do_attack_animation(src)
 			// user.nutrition = user.nutrition - 5
 			to_chat(user, "<span class='warning'>You [pick(hit_message)] \the [src].</span>")
-			user.sanity.onExercise(0.4)
+			user.sanity.onExercise(1)
 
 /obj/structure/fitness/weightlifter
 	name = "weightlifting machine"
@@ -60,7 +60,7 @@
 			playsound(src, 'sound/effects/weightdrop.ogg', 25, 1)
 			to_chat(user, "<span class='notice'>You lift the weights [qualifiers[weight]].</span>")
 			being_used = 0
-			user.sanity.onExercise(4)
+			user.sanity.onExercise(8)
 		else
 			to_chat(user, "<span class='notice'>Against your previous judgement, perhaps working out is not for you.</span>")
 			being_used = 0

--- a/zzzz_modular_occulus/code/modules/sanity/sanity_mob.dm
+++ b/zzzz_modular_occulus/code/modules/sanity/sanity_mob.dm
@@ -1,5 +1,8 @@
-/datum/sanity/proc/onMusic()
-	changeLevel(SANITY_GAIN_MUSIC)
+/datum/sanity/proc/onMusic(var/rate)
+	if(!rate)
+		changeLevel(SANITY_GAIN_MUSIC)
+	else
+		changeLevel(rate)
 	if(resting)
 		add_rest(INSIGHT_DESIRE_MUSIC, 0.4)
 


### PR DESCRIPTION
## About The Pull Request

Fixed the Cube from runtiming instead of generating oddities.
Fixed art oddities potentially having no aspects
Fixed jukebox sanity gain and music not occurring
Increased exercise insight gain.

## Why It's Good For The Game

Just some fixes to sanity related things.

## Changelog
```changelog
fix: The Cube no longer runtimes
fix: Art oddities now round to the nearest number instead of down when calculating reduced stat output
fix: The jukebox now properly grants sanity and music insight
balance: Increased exercise sanity and insight gain.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
