### PR TITLE
Composers no longer do audio loops while dead

### DIFF
--- a/zzzz_modular_occulus/code/modules/mob/living/simple_animal/hostile/siren/composer.dm
+++ b/zzzz_modular_occulus/code/modules/mob/living/simple_animal/hostile/siren/composer.dm
@@ -27,7 +27,9 @@
 
 
 /mob/living/simple_animal/hostile/siren/composer/Life()
-	..()
+	. = ..()
+	if(!.)
+		return
 	soundloop()
 	if(target_mob)
 		skremloop()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Life() doesn't actually stop when something is dead, but it does return FALSE

## Why It's Good For The Game

Typically, things can't scream when they're dead.

## Changelog
```changelog
fix: The Siren Composer no longer screams while dead
```