### PR TITLE
Fixes NSA overdosing caused by Ares

### DIFF
--- a/zzzz_modular_occulus/code/modules/reagents/reagent_containers/hypovial.dm
+++ b/zzzz_modular_occulus/code/modules/reagents/reagent_containers/hypovial.dm
@@ -159,4 +159,4 @@
 	icon_state = "hypovial-t"
 	bad_type = /obj/item/weapon/reagent_containers/glass/beaker/hypocartridge/small/combat
 	rarity_value = 100
-	preloaded_reagents = list("synaptizine" = 5, "hyperzine" = 10, "oxycodone" = 10, "trauma_control_system" = 10, "nanosymbiotes" = 10)
+	preloaded_reagents = list("synaptizine" = 5, "hyperzine" = 10, "paracetamol" = 10, "trauma_control_system" = 10, "nanosymbiotes" = 10)


### PR DESCRIPTION
You now can not overdose purely from the ARES. Have fun!

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Too many NSA costing drugs in the Ares caused people to suffer puking and the like.
This PR Swaps oxycodone and paracetamol within the vials
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No longer poisons you for using upper tier gear >..>
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
fix: fixes so that ARES MID nolonger poisons people on use
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
