### PR TITLE
Readjusts artwork oddity stats as they were still coming up jank

### DIFF
--- a/code/game/machinery/autolathe/artist_bench.dm
+++ b/code/game/machinery/autolathe/artist_bench.dm
@@ -243,16 +243,16 @@
 	else if(full_artwork == "artwork_oddity")
 		var/obj/item/weapon/oddity/artwork/O = new(src)
 		var/list/oddity_stats = list(STAT_MEC = rand(0,1), STAT_COG = rand(0,1), STAT_BIO = rand(0,1), STAT_ROB = rand(0,1), STAT_TGH = rand(0,1), STAT_VIG = rand(0,1))//May not be nessecary
-		var/stats_amt = 3
+		var/stats_amt = 1//Occulus Edit - Stat nerf
 		if(ins_used >= 85)//Arbitrary values
-			stats_amt += 3
+			stats_amt += 1//Occulus Edit - Stat Nerf
 		if(ins_used >= 70)
-			stats_amt += 3
+			stats_amt += 1//Occulus Edit - Stat Nerf
 		if(ins_used >= 55)
-			stats_amt += 3//max = 3*4*2+6 = 30 points, min 3*4+6 = 18
+			stats_amt += 1//max = 3*4*2+6 = 30 points, min 3*4+6 = 18 Occulus Edit - Stat Nerf
 		for(var/i in 1 to stats_amt)
 			var/stat = pick(ALL_STATS)
-			oddity_stats[stat] = round(min(MAX_STAT_VALUE, oddity_stats[stat]+ 1)/3,1) //Occulus Edit - Nerfing Artist oddity stats a bit!
+			oddity_stats[stat] = min(MAX_STAT_VALUE, oddity_stats[stat]+ 1) //Occulus Edit - Nerfing Artist oddity stats a bit!
 
 		O.oddity_stats = oddity_stats
 		O.AddComponent(/datum/component/inspiration, O.oddity_stats, O.perk)

--- a/code/game/objects/items/devices/techno_tribalism.dm
+++ b/code/game/objects/items/devices/techno_tribalism.dm
@@ -63,7 +63,7 @@
 				for(var/quality in W.tool_qualities)
 
 					if(W.tool_qualities[quality] >= 30)//Occulus Edit
-						var/stat_cost = round(W.tool_qualities[quality] / 25)//Occulus Edit
+						var/stat_cost = W.tool_qualities[quality] / 25//Occulus Edit
 						if(quality == QUALITY_BOLT_TURNING || quality == QUALITY_SCREW_DRIVING || quality == QUALITY_CUTTING)
 							oddity_stats[STAT_COG] += stat_cost
 							useful = TRUE


### PR DESCRIPTION
## About The Pull Request

Adjusts how Artist and cube oddities are generated

## Why It's Good For The Game

Due to how I was doing this nerf before on the art oddities, we were losing points we should not have. That has been adjusted

Update!

Adjusted cube calculations to only round off fractional stats at the end of stat gen, instead of flooring both when calculating tool input stats as well as dividing by three. This should result in two power tools with 60 power generating a medium stat instead of a weak stat. ( For the final calculation we go from 4/3 (round to nearest int) to 4.8/3. Going from 1.33 round to nearest int (1) to 1.6 round to nearest int (2))

This brings cube oddities back in line to what they provided before (Medium oddity power with two power tools instead of weak)

## Changelog
```changelog
tweak: Artist oddities.
tweak: Cube oddities
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
