### PR TITLE
Fixes the antag radio not having a sprite

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2873,6 +2873,7 @@
 #include "zzzz_modular_occulus\code\game\objects\items\devices\neuroinducer.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\devices\perscriptionkit.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\devices\radio.dm"
+#include "zzzz_modular_occulus\code\game\objects\items\devices\spy_bug.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\devices\traitor_devices.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\stacks\medical.dm"
 #include "zzzz_modular_occulus\code\game\objects\items\tools\_tools.dm"

--- a/zzzz_modular_occulus/code/game/objects/items/devices/spy_bug.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/devices/spy_bug.dm
@@ -1,0 +1,2 @@
+/obj/item/device/radio/spy
+	icon_state = "xprgrey"


### PR DESCRIPTION
Adds a station bounced radio sprite to the antag SBR uplink.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #781 by changing the icon state of the antag station bounced radio uplink choice. It uses the standard SBR sprite, uncolored.
This is the sprite it uses now. 
![image](https://user-images.githubusercontent.com/84544997/148893135-e1c8bd8c-bd94-4815-93bf-ad84b2dcb383.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This probably shouldn't have been invisible. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
fix: Antagonist's station bounced radio uplink has a sprite now. 
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
