### PR TITLE
Litany tweaks

### DIFF
--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -22,7 +22,7 @@
 	power = 50
 	ignore_stuttering = TRUE
 
-/*
+/* Occulus Edit
 /datum/ritual/cruciform/base/relief/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
 	H.add_chemical_effect(CE_PAINKILLER, 10)
 	set_personal_cooldown(H)

--- a/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/code/modules/core_implant/cruciform/rituals/base.dm
@@ -22,11 +22,12 @@
 	power = 50
 	ignore_stuttering = TRUE
 
+/*
 /datum/ritual/cruciform/base/relief/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
 	H.add_chemical_effect(CE_PAINKILLER, 10)
 	set_personal_cooldown(H)
 	return TRUE
-
+*/
 
 /datum/ritual/cruciform/base/soul_hunger
 	name = "Soul Hunger"
@@ -61,6 +62,7 @@
 	set_personal_cooldown(H)
 	return TRUE
 
+/* Occulus Edit: Removal of Reveal
 /datum/ritual/cruciform/occulus/reveal //Occulus Edit, moved to utility
 	name = "Reveal Adversaries"
 	phrase = "Et fumus tormentorum eorum ascendet in saecula saeculorum: nec habent requiem die ac nocte, qui adoraverunt bestiam, et imaginem ejus, et si quis acceperit caracterem nominis ejus."
@@ -100,6 +102,7 @@
 
 	set_personal_cooldown(H)
 	return TRUE
+	End Occulus Edit*/
 
 /datum/ritual/cruciform/occulus/sense_cruciform//Occulus Edit, moved to utility
 	name = "Cruciform sense"
@@ -134,8 +137,8 @@
 	if(!T)
 		fail("No target.", H, C)
 		return FALSE
-	T.hallucination(30,50)	//OCCULUS EDIT - Tweaks to be more in line with mindwipe
-	var/sanity_lost = rand(0,10)	//OCCULUS EDIT - Makes it so that it won't tank someone's sanity, but isn't as powerful
+	T.hallucination(15,30)	//OCCULUS EDIT - Tweaks to be more in line with mindwipe
+	var/sanity_lost = rand(0,25)	//OCCULUS EDIT - Makes it so that it won't tank someone's sanity, but isn't as powerful
 	T.druggy = max(T.druggy, 10)
 	T.sanity.changeLevel(sanity_lost)
 //OCCULUS EDIT START - Add some feedback for the target
@@ -229,7 +232,7 @@
 /datum/ritual/cruciform/base/reincarnation
 	name = "Reincarnation"
 	phrase = "Vetus moritur et onus hoc levaverit"
-	desc = "A reunion of a spirit with it's new body, ritual of activation of a crucifrom, lying on the body. The process requires NeoTheology's special altar on which a body stripped of clothes is to be placed."
+	desc = "This litany calls back the soul of an individual from deep within their cruciform. It must be used after a cruciform is attached."//Occulus Edit
 	var/clone_damage = 60
 
 /datum/ritual/cruciform/base/reincarnation/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
@@ -281,7 +284,7 @@
 /datum/ritual/cruciform/base/install
 	name = "Commitment"
 	phrase = "Unde ipse Dominus dabit vobis signum"
-	desc = "This litany will command cruciform attach to person, so you can perform Reincarnation or Epiphany. Cruciform must lay near them."
+	desc = "This litany attaches a cruciform to a person. The target must be on a Mekhane altar without clothing, and the cruciform must lie on the altar with them."//Occulus Edit
 
 /datum/ritual/cruciform/base/install/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/mob/living/carbon/human/H = get_victim(user)

--- a/code/modules/core_implant/cruciform/rituals/priest.dm
+++ b/code/modules/core_implant/cruciform/rituals/priest.dm
@@ -14,7 +14,7 @@
 /datum/ritual/cruciform/priest/epiphany
 	name = "Epiphany"
 	phrase = "In nomine Patris et Filii et Spiritus sancti"
-	desc = "Mekhane's principal sacrament is a ritual of baptism and merging with the Core Implant. A body, relieved of clothes should be placed on NeoTheology's special altar."
+	desc = "The litany for the activation of a cruciform and baptism of a new church member. The cruciform must be already installed in an individual before use."//Occulus Edit
 
 /datum/ritual/cruciform/priest/epiphany/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/obj/item/weapon/implant/core_implant/cruciform/CI = get_implant_from_victim(user, /obj/item/weapon/implant/core_implant/cruciform, FALSE)
@@ -54,7 +54,7 @@
 /datum/ritual/cruciform/priest/ejection
 	name = "Deprivation"
 	phrase = "Et revertatur pulvis in terram suam unde erat et spiritus redeat ad Deum qui dedit illum"
-	desc = "This litany will command the Core Implant to detach from bearer, if the one bearing it is dead. You will be able to use it in scanner for Resurrection."
+	desc = "This litany will command a cruciform to detach from the target if they are dead."//Occulus Edit
 
 /datum/ritual/cruciform/priest/ejection/perform(mob/living/carbon/human/user, obj/item/weapon/implant/core_implant/C)
 	var/obj/item/weapon/implant/core_implant/cruciform/CI = get_implant_from_victim(user, /obj/item/weapon/implant/core_implant/cruciform, FALSE)

--- a/zzzz_modular_occulus/code/modules/core_implant/cruciform/rituals/base.dm
+++ b/zzzz_modular_occulus/code/modules/core_implant/cruciform/rituals/base.dm
@@ -5,6 +5,13 @@
 /datum/ritual/cruciform/base/relief
 	power = 25
 
+/datum/ritual/cruciform/base/relief/perform(mob/living/carbon/human/H, obj/item/weapon/implant/core_implant/C)
+	var/datum/reagents/R = new /datum/reagents(5, null)
+	R.add_reagent("paracetamol", 5)
+	R.trans_to_mob(H, 5, CHEM_BLOOD)
+	set_personal_cooldown(H)
+	return TRUE
+
 /datum/ritual/cruciform/base/soul_hunger
 	power = 35
 	desc = "Litany of piligrims, helps stave off hunger by generating nutrition at the cost of generating considerable amounts of toxins in the user's bloodstream."
@@ -72,7 +79,9 @@
 		log_and_message_admins("soothed [H]'s pain with the Reprieve litany")
 		to_chat(H, "<span class='info'>A numbing sensation bathes you, soothing your agony.</span>")
 		user.nutrition -= 50
-		H.add_chemical_effect(CE_PAINKILLER, 50)	// Fuggit, lets make it a lot more effective. Basically doesn't do jack otherwise.
+		var/datum/reagents/R = new /datum/reagents(5, null)
+		R.add_reagent("paracetamol", 5)
+		R.trans_to_mob(H, 5, CHEM_BLOOD)
 		return TRUE
 
 /*


### PR DESCRIPTION
## About The Pull Request

Tweaks a few litanies, primarily buffs.
Removed Reveal Adversaries litany

## Why It's Good For The Game

Minor QoL buffs for less useful litanies to make them a bit more desirable. Keeping in-spirit with the goals of the litanies without going overboard.

## Changelog
```changelog
balance: Relief and Relief other now give 5u Paracetamol to the target.
balance: Revelation now restores up to 25 sanity and has half the hallucination duration
balance: Reveal Adversaries removed
tweak: Clarified Reincarnation, Commitment, Epiphany, and Deprivation litany descriptions. 
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
