### PR TITLE
fixes full auto firing when a gun should not be able to fire

### DIFF
--- a/code/datums/datum_click_handlers.dm
+++ b/code/datums/datum_click_handlers.dm
@@ -103,7 +103,12 @@
 /datum/click_handler/fullauto/MouseDown(object,location,control,params)
 	if(!isturf(owner.mob.loc)) // This stops from firing full auto weapons inside closets or in /obj/effect/dummy/chameleon chameleon projector
 		return FALSE
-	
+	if((owner.mob.Adjacent(location) && !(owner.mob.a_intent == "harm"))||owner.mob.in_throw_mode)//Occulus Edit Start
+		return TRUE
+	var/list/click_params = params2list(params)
+	if(!click_params || !click_params["left"])
+		return TRUE //Occulus Edit end
+
 	object = resolve_world_target(object)
 	if (object)
 		target = object

--- a/code/datums/datum_click_handlers.dm
+++ b/code/datums/datum_click_handlers.dm
@@ -103,7 +103,7 @@
 /datum/click_handler/fullauto/MouseDown(object,location,control,params)
 	if(!isturf(owner.mob.loc)) // This stops from firing full auto weapons inside closets or in /obj/effect/dummy/chameleon chameleon projector
 		return FALSE
-	if((owner.mob.Adjacent(location) && !(owner.mob.a_intent == "harm"))||owner.mob.in_throw_mode)//Occulus Edit Start
+	if(owner.mob.in_throw_mode || (owner.mob.Adjacent(location) && owner.mob.a_intent != "harm"))//Occulus Edit Start
 		return TRUE
 	var/list/click_params = params2list(params)
 	if(!click_params || !click_params["left"])


### PR DESCRIPTION
## About The Pull Request

Full auto guns no longer fire when:
1. You click on an adjacent tile (without harm intent)
2. You click any button except lmb
3. You click on yourself
4. You are set to throw something

## Why It's Good For The Game

Full auto was overriding default behavior and making full auto mode guns unwieldy. This fixes that issue.

## Changelog
```changelog
fix: Eris fullauto stupidity.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
