### PR TITLE
Fixes ghost/ClickOn()

### DIFF
--- a/code/_onclick/ghost.dm
+++ b/code/_onclick/ghost.dm
@@ -29,8 +29,8 @@
 
 /mob/observer/ghost/ClickOn(var/atom/A, var/params)
 	var/list/pa = params2list(params)
-	if(check_rights(R_ADMIN)) // Admin click shortcuts
-		if(pa.Find("shift") && pa.Find("ctrl"))
+	if(pa.Find("shift") && pa.Find("ctrl"))//Occulus Edit: Fixes ghostspam
+		if(check_rights(R_ADMIN)) // Admin click shortcuts, fixes ghostspam
 			client.debug_variables(A)
 			return
 


### PR DESCRIPTION
## About The Pull Request

Causes check_rights to only get called if we are actually try to use the VV shortcut, rather than on every single click as a ghost.
Having it the other way causes permission spam in the chat log for non-admins.

## Why It's Good For The Game

Bugfixes good

## Changelog
```changelog
fix: non-admin ghosts no longer get "You are not an admin" spam into chat constantly when clicking on stuff
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
