### PR TITLE
All belts can now hold bounce radios

### DIFF
--- a/zzzz_modular_occulus/code/game/objects/items/weapons/storage/belt.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/storage/belt.dm
@@ -23,7 +23,7 @@
 		/obj/item/weapon/tool/crowbar,
 		/obj/item/device/lighting/toggleable/flashlight,
 		/obj/item/weapon/extinguisher/mini,
-		/obj/item/roller/adv,
+		/obj/item/roller/adv
 	)
 
 /obj/item/weapon/storage/belt/tactical//adds stun baton to belt! Whoop!

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/storage/belt.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/storage/belt.dm
@@ -4,7 +4,7 @@
 	can_hold = list(
 		/obj/item/device/scanner/health,
 		/obj/item/weapon/dnainjector,
-		/obj/item/device/radio/headset,
+		/obj/item/device/radio,
 		/obj/item/weapon/reagent_containers/dropper,
 		/obj/item/weapon/reagent_containers/glass/beaker,
 		/obj/item/weapon/reagent_containers/glass/bottle,
@@ -23,7 +23,7 @@
 		/obj/item/weapon/tool/crowbar,
 		/obj/item/device/lighting/toggleable/flashlight,
 		/obj/item/weapon/extinguisher/mini,
-		/obj/item/roller/adv
+		/obj/item/roller/adv,
 	)
 
 /obj/item/weapon/storage/belt/tactical//adds stun baton to belt! Whoop!
@@ -44,7 +44,7 @@
 		/obj/item/weapon/flame/lighter,
 		/obj/item/device/lighting/toggleable/flashlight,
 		/obj/item/modular_computer/pda,
-		/obj/item/device/radio/headset,
+		/obj/item/device/radio,
 		/obj/item/device/hailer,
 		/obj/item/device/megaphone,
 		/obj/item/weapon/melee,
@@ -53,3 +53,4 @@
 		/obj/item/weapon/gun/energy/gun/martin,
 		/obj/item/taperoll
 	)
+


### PR DESCRIPTION
## About The Pull Request

All belts can now hold bounce radios, instead of just utility belts

## Why It's Good For The Game

Because it makes no sense otherwise.

## Changelog
```changelog
tweak: Handheld radios now fit on medical and tactical belts.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
