### PR TITLE
Fixes assisted kidneys

### DIFF
--- a/code/modules/organs/body_modifications.dm
+++ b/code/modules/organs/body_modifications.dm
@@ -36,7 +36,7 @@ var/global/list/modifications_types = list(
 	var/list/body_parts = list(				// For sorting'n'selection optimization.
 		BP_CHEST, "chest2", BP_HEAD, BP_GROIN, BP_L_ARM, BP_R_ARM, BP_L_HAND, BP_R_HAND, BP_L_LEG, BP_R_LEG,\
 		BP_L_FOOT, BP_R_FOOT,\
-		OP_HEART, OP_LUNGS, OP_LIVER, BP_BRAIN, OP_EYES)
+		OP_HEART, OP_LUNGS, OP_LIVER, BP_BRAIN, OP_EYES, OP_STOMACH, OP_KIDNEYS) //Occulus Edit: Allowing unmodified stomaches and kidneys
 	var/list/allowed_species = list("Human")// Species restriction.
 	var/replace_limb = null					// To draw usual limb or not.
 	var/mob_icon = ""


### PR DESCRIPTION
## About The Pull Request

You can now remove robotic and assisted Kidneys and Stomachs

## Why It's Good For The Game

This was an oversight that has been corrected

## Changelog
```changelog
fix: You can now make kidneys and stomaches unmodified in body augmentation.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
