### PR TITLE
Disables Bounty Hunter/Marshall

### DIFF
--- a/code/game/gamemodes/roleset/simple.dm
+++ b/code/game/gamemodes/roleset/simple.dm
@@ -85,7 +85,7 @@
 	role_id = ROLE_MALFUNCTION
 	req_crew = 15
 
-
+/* OCCULUS EDIT - We don't have the playerbase to support this
 /datum/storyevent/roleset/marshal
 	id = "marshal"
 	name = "marshal"
@@ -117,7 +117,7 @@
 		return 0 //Can't spawn without at least one antag
 
 	return new_weight * max(a_count, 1)
-
+*/
 
 /datum/storyevent/roleset/carrion
 	id = "carrion"


### PR DESCRIPTION
## About The Pull Request

Spicy validhunters have proven to not be a good match for the level of RP we're going for, so it's getting disabled from the storyteller pools. They can still be adminspawned in just fine.

## Why It's Good For The Game

Less salt, less hypertension, healthier playerbase.

## Changelog
```changelog Toriate
del: Removed storyteller bounty hunters
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
