### PR TITLE
Halves sopo, adds delayed chloral inject

### DIFF
--- a/zzzz_modular_occulus/code/game/objects/items/weapons/implant/implants/carrion/sleep_spider.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/implant/implants/carrion/sleep_spider.dm
@@ -8,8 +8,10 @@
 /obj/item/weapon/implant/carrion_spider/sleeping/activate()
 	..()
 	if(wearer)
-		wearer.reagents.add_reagent("stoxin", 10)
+		wearer.reagents.add_reagent("stoxin", 5)
 		to_chat(wearer, SPAN_NOTICE("You feel tired and drop into a sleep"))
+		sleep(20)
+		wearer.reagents.add_reagent("chloralhydrate", 3)
 		die()
 	else
 		to_chat(owner_mob, SPAN_WARNING("[src] doesn't have a host"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Re-adjusts Narco spiders to be more reliable for sleep, but much shorter in time.

## Why It's Good For The Game

... Bumping narco spiders to 10u was a mistake and i am kinda still angry i did it and had to experience the absolute shit it did

## Changelog
```changelog
balance: halves the stoxin injection of narcolepsy spiderlings, adds a 3u chloral injection after 20ticks (or, IIRC 2 seconds?)
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
