### PR TITLE
Swaps out NVG ballestics armor helmet for full ballestics armor helmet

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -259,8 +259,8 @@ var/list/all_supply_groups = list("Operations","Security","Hospitality","Enginee
 	name = "IH Ballistic Armor"
 	contains = list(/obj/item/clothing/suit/armor/bulletproof/ironhammer,
 					/obj/item/clothing/suit/armor/bulletproof/ironhammer,
-					/obj/item/clothing/head/armor/bulletproof/ironhammer_nvg,
-					/obj/item/clothing/head/armor/bulletproof/ironhammer_nvg)
+					/obj/item/clothing/head/armor/bulletproof/ironhammer_full,
+					/obj/item/clothing/head/armor/bulletproof/ironhammer_full)
 	cost = 3000
 	containertype = /obj/structure/closet/crate/secure
 	crate_name = "IH Ballistic Armor Pack"

--- a/code/modules/trade/datums/trade_stations_presets/hellcat.dm
+++ b/code/modules/trade/datums/trade_stations_presets/hellcat.dm
@@ -51,11 +51,11 @@
 			/obj/item/clothing/suit/armor/vest/security,
 			/obj/item/clothing/head/armor/helmet,
 			/obj/item/clothing/suit/armor/bulletproof,
-			/obj/item/clothing/head/armor/bulletproof/ironhammer_nvg,
+			/obj/item/clothing/head/armor/bulletproof/ironhammer_full,
 			/obj/item/clothing/suit/armor/laserproof/full,
 			/obj/item/clothing/head/armor/laserproof
 		),
 	)
-	
+
 	offer_types = list(
 	)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Swaps out nvg goggled armor helmets to standard full helmet.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We blacklisted this free NVG from spawning for a reason. It inconsistently doesn't use cells, and can be acquired cheaply in cargo, negating basically every vision issue.
This corrects it by yeeting it from being acquired from cargo, requiring people to use standard light methods.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
tweak: swaps out NVG helmets for Full helmets in cargo code
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
