### PR TITLE
Removal of blatant debug to_worlds

### DIFF
--- a/zzzz_modular_occulus/code/game/gamemodes/events/siren_scan.dm
+++ b/zzzz_modular_occulus/code/game/gamemodes/events/siren_scan.dm
@@ -86,22 +86,15 @@
 	var/list/spawnTypes = pick_n_take(spawnLists)	//picking random mob out of the siren pod list
 	var/attempts = 5	//Number of attempts to pick a tile on selected candidate
 	while(attempts > 0)	//if it still has attempts,
-		to_world("more then 1 attempt")
 		var/turf/picked = get_random_secure_turf_in_range(origin, 10, 7)	//picks initial turf in 10-7 tile range from candidate
-		to_world("picked turf found")
 		if(!(/mob/living/carbon/human in view(6,picked)))						//checks for humans within 6 tiles. Continue if none
-			to_world("Nohuman in view 6 picked")
 			for(var/type in spawnTypes)										//for as long as there is type in spawntypes
 				type = pick_n_take(spawnTypes)								//pick and remove mob from list is now 'type'
-				to_world("picked spawntypes")
 				var/spawnloc = get_random_secure_turf_in_range(picked,3,0)	// second rng'd turf in 3-0 tile range from initial picked turf
-				to_world("spawnloc picked")
 				do_sparks(3,0,spawnloc)										//creates sparks on second slected tile,
 				new type(spawnloc)											//spawn a mob from list of mobs onto second tile.
-				to_world("Actually spawns it")
 			break															//stops proc now that spawntypes no longer has any mobs in it.
 		else																//if human mob within view
-			to_world("there is human in view? :jamero:")
 			attempts--														//reduce attempts number by 1
 
 	if(attempts == 0)														//if out of attempts to find a spawn location,


### PR DESCRIPTION
Forgot about my debug to_worlds...

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I forgot to remove these before my last commit in the PR 😿 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No random to_world messages
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
del: removed to world messages. (oops)
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
