### PR TITLE
ensign tweaks

### DIFF
--- a/zzzz_modular_occulus/code/game/jobs/job/captain.dm
+++ b/zzzz_modular_occulus/code/game/jobs/job/captain.dm
@@ -28,7 +28,7 @@
 	supervisors = "the first officer and captain"
 	selection_color = "#ddddff"
 	wage = WAGE_LABOUR
-	alt_titles = list("Helmsman", "Communications Officer")
+	alt_titles = list("Helmsman", "Communications Officer","UTSM Observer")
 	perks = list(/datum/perk/sommelier)
 	ideal_character_age = 30
 
@@ -61,7 +61,7 @@ Should the worst occur, defend your ship, post, and commanders with your life."
 
 	access = list(
 		access_maint_tunnels, access_heads, access_RC_announce, access_sec_doors, access_tcomsat,
-		access_moebius, access_tech_storage, access_teleporter
+		access_moebius, access_tech_storage, access_teleporter, access_bar, access_kitchen, access_engine
 	)
 
 	stat_modifiers = list(


### PR DESCRIPTION
## About The Pull Request

Adds new lore-title, UTSM Observer
Adds club and basic engineering access to ensigns

## Why It's Good For The Game

Tweaks for the job for various lore and mechanical reasons.

## Changelog
```changelog
tweak: Ensign job
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
