### PR TITLE
Fixes a bug that corrupts a crafting step

### DIFF
--- a/code/datums/craft/step.dm
+++ b/code/datums/craft/step.dm
@@ -152,6 +152,10 @@
 			return
 
 	else if(reqed_quality)
+		if (!(istype(I, /obj/item)))//Occulus Edit Sanity checking for a bug. If we get a turf passed in here, just exit cleanly
+			to_chat(user, SPAN_WARNING("Something bad happened, Work aborted"))
+			building = FALSE
+			return//End Occulus Edit
 		var/q = I.get_tool_quality(reqed_quality)
 		if(!q)
 			to_chat(user, SPAN_WARNING("Wrong type of tool. You need a tool with [reqed_quality] quality"))


### PR DESCRIPTION
## About The Pull Request

I need to test this PR yet. Please do not merge it.

This should fix an obscure bug where a tool flying away while you are doing a crafting step causes a turf to get passed to the crafting step. Corrupting that step for every single craft of an item for the remainder of the round.

This should provide some sanity checking to prevent that

## Why It's Good For The Game

Bugs bad

## Changelog
```changelog
fix: Crafting steps getting irrevocably corrupted
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
