### PR TITLE
Fixes default instructionals spawning.

### DIFF
--- a/zzzz_modular_occulus/code/game/objects/items/instructional.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/instructional.dm
@@ -30,6 +30,7 @@
 	icon_state = "instructional_debug"
 	oddity_stats = list(STAT_BIO = 1)
 	spawn_tags = SPAWN_TAG_INSTRUCTIONAL_BIO
+	spawn_blacklisted = TRUE
 
 /obj/item/weapon/oddity/instructional/common/bio/pamphlet
 	name = "Medical Instructional Pamphlet"
@@ -54,6 +55,7 @@
 	icon_state = "instructional_debug"
 	oddity_stats = list(STAT_COG = 1)
 	spawn_tags = SPAWN_TAG_INSTRUCTIONAL_COG
+	spawn_blacklisted = TRUE
 
 /obj/item/weapon/oddity/instructional/common/cog/book
 	name = "Theorems on Entrope and Rhinemann Manifolds in Non-Euclidian Space"
@@ -78,6 +80,7 @@
 	icon_state = "instructional_debug"
 	oddity_stats = list(STAT_MEC = 1)
 	spawn_tags = SPAWN_TAG_INSTRUCTIONAL_MEC
+	spawn_blacklisted = TRUE
 
 /obj/item/weapon/oddity/instructional/common/mec/pamphlet
 	name = "Screwdriving Monthly"
@@ -107,6 +110,7 @@
 	icon_state = "instructional_debug"
 	oddity_stats = list(STAT_ROB = 1)
 	spawn_tags = SPAWN_TAG_INSTRUCTIONAL_ROB
+	spawn_blacklisted = TRUE
 
 /obj/item/weapon/oddity/instructional/common/rob/aegis
 	name = "Aegis Hand-to-Hand Combat Manual"
@@ -131,6 +135,7 @@
 	icon_state = "instructional_debug"
 	oddity_stats = list(STAT_TGH = 1)
 	spawn_tags = SPAWN_TAG_INSTRUCTIONAL_TGH
+	spawn_blacklisted = TRUE
 
 /obj/item/weapon/oddity/instructional/common/tgh/slip
 	name = "Steadying Yourself"
@@ -155,6 +160,7 @@
 	icon_state = "instructional_debug"
 	oddity_stats = list(STAT_VIG = 1)
 	spawn_tags = SPAWN_TAG_INSTRUCTIONAL_VIG
+	spawn_blacklisted = TRUE
 
 /obj/item/weapon/oddity/instructional/common/vig/ross
 	name = "Happy Little Accidents"
@@ -170,8 +176,6 @@
 	name = "Holding Fast: Body and Soul"
 	desc = "Some lesser known Mekhane preacher somehow got this book on mental and physical health published."
 	icon_state = "instructional_vig_mek"
-
-/datum/component/inspiration/instructional
 
 /datum/component/inspiration/instructional/ //making a new component so the examine text can be different.
 

--- a/zzzz_modular_occulus/code/game/objects/items/instructional.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/instructional.dm
@@ -30,7 +30,7 @@
 	icon_state = "instructional_debug"
 	oddity_stats = list(STAT_BIO = 1)
 	spawn_tags = SPAWN_TAG_INSTRUCTIONAL_BIO
-	spawn_blacklisted = TRUE
+	bad_type = /obj/item/weapon/oddity/instructional/common/bio
 
 /obj/item/weapon/oddity/instructional/common/bio/pamphlet
 	name = "Medical Instructional Pamphlet"
@@ -55,7 +55,7 @@
 	icon_state = "instructional_debug"
 	oddity_stats = list(STAT_COG = 1)
 	spawn_tags = SPAWN_TAG_INSTRUCTIONAL_COG
-	spawn_blacklisted = TRUE
+	bad_type = /obj/item/weapon/oddity/instructional/common/cog
 
 /obj/item/weapon/oddity/instructional/common/cog/book
 	name = "Theorems on Entrope and Rhinemann Manifolds in Non-Euclidian Space"
@@ -80,7 +80,7 @@
 	icon_state = "instructional_debug"
 	oddity_stats = list(STAT_MEC = 1)
 	spawn_tags = SPAWN_TAG_INSTRUCTIONAL_MEC
-	spawn_blacklisted = TRUE
+	bad_type = /obj/item/weapon/oddity/instructional/common/mec
 
 /obj/item/weapon/oddity/instructional/common/mec/pamphlet
 	name = "Screwdriving Monthly"
@@ -110,7 +110,7 @@
 	icon_state = "instructional_debug"
 	oddity_stats = list(STAT_ROB = 1)
 	spawn_tags = SPAWN_TAG_INSTRUCTIONAL_ROB
-	spawn_blacklisted = TRUE
+	bad_type = /obj/item/weapon/oddity/instructional/common/rob
 
 /obj/item/weapon/oddity/instructional/common/rob/aegis
 	name = "Aegis Hand-to-Hand Combat Manual"
@@ -135,7 +135,7 @@
 	icon_state = "instructional_debug"
 	oddity_stats = list(STAT_TGH = 1)
 	spawn_tags = SPAWN_TAG_INSTRUCTIONAL_TGH
-	spawn_blacklisted = TRUE
+	bad_type = /obj/item/weapon/oddity/instructional/common/tgh
 
 /obj/item/weapon/oddity/instructional/common/tgh/slip
 	name = "Steadying Yourself"
@@ -160,7 +160,7 @@
 	icon_state = "instructional_debug"
 	oddity_stats = list(STAT_VIG = 1)
 	spawn_tags = SPAWN_TAG_INSTRUCTIONAL_VIG
-	spawn_blacklisted = TRUE
+	bad_type = /obj/item/weapon/oddity/instructional/common/vig
 
 /obj/item/weapon/oddity/instructional/common/vig/ross
 	name = "Happy Little Accidents"


### PR DESCRIPTION
Adding a spawn_blacklisted = TRUE tag to the base instructionals. I still don't understand how the spawners are working, they shouldn't be, nothing makes sense anymore.

Anyway this should stop them from spawning randomly. I hope. BYONDcode is witchcraft.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adding a badtype tag to the base instructionals. I still don't understand how the spawners are working, they shouldn't be, nothing makes sense anymore.

Anyway this should stop them from spawning randomly. I hope. BYONDcode is witchcraft.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Default instructionals should not spawn. This fixes that. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
tweak: Default instrucitonals should no longer spawn. 
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
