### PR TITLE
Fragmentation can now hit roaches

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -3045,6 +3045,7 @@
 #include "zzzz_modular_occulus\code\modules\mob\living\carbon\human\inventory.dm"
 #include "zzzz_modular_occulus\code\modules\mob\living\carbon\human\species\species.dm"
 #include "zzzz_modular_occulus\code\modules\mob\living\carbon\human\species\station.dm"
+#include "zzzz_modular_occulus\code\modules\mob\living\carbon\superior_animal\defense.dm"
 #include "zzzz_modular_occulus\code\modules\mob\living\carbon\superior_animal\giant_spider\giant_spider.dm"
 #include "zzzz_modular_occulus\code\modules\mob\living\carbon\superior_animal\roach\blattedin.dm"
 #include "zzzz_modular_occulus\code\modules\mob\living\carbon\superior_animal\roach\kaiserin.dm"

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/grenades/stinger.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/grenades/stinger.dm
@@ -10,7 +10,7 @@
 
 	fragment_type = /obj/item/projectile/bullet/pellet/fragment/rubber/stinger
 	num_fragments = 100  //total number of fragments produced by the grenade
-	fragment_damage = 2
+	fragment_damage = 1
 
 	matter = list(MATERIAL_PLASTIC = 3, MATERIAL_STEEL = 2)
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 1)

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/grenades/stinger.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/grenades/stinger.dm
@@ -8,7 +8,7 @@
 	item_state = "frggrenade"
 	loadable = TRUE
 
-	fragment_type = /obj/item/projectile/bullet/pellet/shotgun/rubber/stinger
+	fragment_type = /obj/item/projectile/bullet/pellet/fragment/rubber/stinger
 	num_fragments = 100  //total number of fragments produced by the grenade
 	fragment_damage = 0
 

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/grenades/stinger.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/grenades/stinger.dm
@@ -10,7 +10,7 @@
 
 	fragment_type = /obj/item/projectile/bullet/pellet/fragment/rubber/stinger
 	num_fragments = 100  //total number of fragments produced by the grenade
-	fragment_damage = 0
+	fragment_damage = 2
 
 	matter = list(MATERIAL_PLASTIC = 3, MATERIAL_STEEL = 2)
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 1)

--- a/zzzz_modular_occulus/code/modules/mob/living/carbon/superior_animal/defense.dm
+++ b/zzzz_modular_occulus/code/modules/mob/living/carbon/superior_animal/defense.dm
@@ -1,0 +1,7 @@
+/mob/living/carbon/superior_animal/CanPass(var/atom/mover)
+
+	if (istype(mover, /obj/item/projectile/bullet/pellet/fragment)) // Doesn't allow fragments to pass through
+		return FALSE
+
+	//But mobs can walk over the nondense ones.
+	return ..()

--- a/zzzz_modular_occulus/code/modules/projectiles/projectile/bullettypes.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/projectile/bullettypes.dm
@@ -15,16 +15,15 @@
 	name = "rubber pellet"
 	icon_state = "birdshot-1"
 	damage_types = list(BRUTE = 2)
-	agony = 18
-	pellets = 4
+	agony = 10
 	armor_penetration = 0
 	knockback = 0
 	embed = FALSE
 	sharp = FALSE
 
 /obj/item/projectile/bullet/pellet/fragment/rubber/stinger/weak
-	agony = 10
-	pellets = 2
+	damage_types = list(BRUTE = 1)
+	agony = 5
 
 //Rubberizing rubber rounds
 

--- a/zzzz_modular_occulus/code/modules/projectiles/projectile/bullettypes.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/projectile/bullettypes.dm
@@ -14,8 +14,8 @@
 /obj/item/projectile/bullet/pellet/fragment/rubber/stinger	//used for the stinger grenade
 	name = "rubber pellet"
 	icon_state = "birdshot-1"
-	damage_types = list(BRUTE = 2)
-	agony = 10
+	damage_types = list(BRUTE = 1)
+	agony = 17
 	armor_penetration = 0
 	knockback = 0
 	embed = FALSE

--- a/zzzz_modular_occulus/code/modules/projectiles/projectile/bullettypes.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/projectile/bullettypes.dm
@@ -1,8 +1,8 @@
 /obj/item/projectile/bullet/pellet/shotgun/rubber
 	name = "rubber pellet"
 	icon_state = "birdshot-1"
-	damage_types = list(BRUTE = 1) //No more crew skeeting without medkits!
-	agony = 9 //Whoever the hell had this at 15 is going to suffer multiple shots to the groin.
+	damage_types = list(BRUTE = 2) //No more crew skeeting without medkits!
+	agony = 8 //Whoever the hell had this at 15 is going to suffer multiple shots to the groin.
 	pellets = 8
 	range_step = 2
 	spread_step = 10
@@ -52,10 +52,6 @@
 /obj/item/projectile/bullet/pistol/rubber
 	damage_types = list(BRUTE = 6)
 	agony = 22
-
-/obj/item/projectile/bullet/pellet/shotgun/rubber
-	damage_types = list(BRUTE = 2) //The official consensus is that getting PB'd by rubbers should be an owie.
-	agony = 8 //Whoever the hell had this at 15 is going to suffer multiple shots to the groin.
 
 // nanite bullet types
 

--- a/zzzz_modular_occulus/code/modules/projectiles/projectile/bullettypes.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/projectile/bullettypes.dm
@@ -11,15 +11,20 @@
 	embed = FALSE
 	sharp = FALSE
 
-/obj/item/projectile/bullet/pellet/shotgun/rubber/stinger	//used for the stinger grenade
+/obj/item/projectile/bullet/pellet/fragment/rubber/stinger	//used for the stinger grenade
+	name = "rubber pellet"
+	icon_state = "birdshot-1"
 	damage_types = list(BRUTE = 2)
 	agony = 18
 	pellets = 4
-	base_spread = 0 //causes it to be treated as a shrapnel explosion instead of cone
-	spread_step = 20
-	silenced = 1 //embedding messages are still produced so it's kind of weird when enabled.
-	no_attack_log = 1
-	muzzle_type = null
+	armor_penetration = 0
+	knockback = 0
+	embed = FALSE
+	sharp = FALSE
+
+/obj/item/projectile/bullet/pellet/fragment/rubber/stinger/weak
+	agony = 10
+	pellets = 2
 
 //Rubberizing rubber rounds
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As the title says, a modular change to allow fragments from Pommes and Stingers now can hit roaches and actually hurt them instead of being useless.
![Fragment](https://user-images.githubusercontent.com/53068506/163300166-6f410ee0-8777-4bc9-bdee-d8317144e7ea.png)

Yes, I know code freeze still 


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes fragment grenades actually useful against roaches. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
tweak: Roaches are now hit by fragmentation 
balance: Stingers do a minor amount of brute; they're projectiles being shot at you, they should. They've also been toned down agony wise.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
