### PR TITLE
Fixes Trays

### DIFF
--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -14,10 +14,15 @@
 	flags = CONDUCT
 	matter = list(MATERIAL_STEEL = 3)
 	var/list/carrying = list() // List of things on the tray. - Doohl
-	var/max_carry = 10
+	var/max_carry = 15
+	var/cleanpickup = FALSE
+
+/obj/item/tray/AltClick(mob/living/carbon/user)
+	cleanpickup = TRUE
+	pickup(mob/user)
 
 /obj/item/tray/attack(mob/living/carbon/M, mob/living/carbon/user)
-
+	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)	//Occulus Edit- NO INSTANT MURDERING PEOPLE WITH A RAPID TRAY SPAM
 	// Drop all the things. All of them.
 	cut_overlays()
 	for(var/obj/item/I in carrying)
@@ -28,6 +33,8 @@
 				for(var/i = 1, i <= rand(1,2), i++)
 					if(I)
 						step(I, pick(NORTH,SOUTH,EAST,WEST))
+						for(var/mob/O in viewers(M, null))
+							O.show_message(SPAN_DANGER("[I] flies off the tray!"), 1)
 						sleep(rand(2,4))
 
 
@@ -169,8 +176,11 @@
 
 	return val
 
-/obj/item/tray/pre_pickup(mob/user)
+/obj/item/tray/pickup(mob/user)	//occulus edit: Prepickup just returns True in the code. I don't know how it works, but it certainly /doesn't/ work here. Reverted to using standard pickup.
 	if(!isturf(loc))
+		return ..()
+	if(cleanpickup == TRUE)
+		cleanpickup = FALSE
 		return ..()
 
 	for(var/obj/item/I in loc)

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -14,7 +14,7 @@
 	flags = CONDUCT
 	matter = list(MATERIAL_STEEL = 3)
 	var/list/carrying = list() // List of things on the tray. - Doohl
-	var/max_carry = 15
+	var/max_carry = 15	//Occulus Edit: Changed to 15 to allow for a drink as well as food on tray
 
 /obj/item/tray/attack(mob/living/carbon/M, mob/living/carbon/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)	//Occulus Edit- NO INSTANT MURDERING PEOPLE WITH A RAPID TRAY SPAM
@@ -28,8 +28,8 @@
 				for(var/i = 1, i <= rand(1,2), i++)
 					if(I)
 						step(I, pick(NORTH,SOUTH,EAST,WEST))
-						for(var/mob/O in viewers(M, null))
-							O.show_message(SPAN_DANGER("[I] flies off the tray!"), 1)
+						for(var/mob/O in viewers(M, null))	//Occulus edit start: adds a bit of flavor to obj's flying off the tray with a message
+							O.show_message(SPAN_DANGER("[I] flies off the tray!"), 1)	//occulus edit end
 						sleep(rand(2,4))
 
 
@@ -171,7 +171,7 @@
 
 	return val
 
-/obj/item/tray/pickup(mob/user)	//occulus edit: Prepickup just returns True in the code. I don't know how it works, but it certainly /doesn't/ work here. Reverted to using standard pickup.
+/obj/item/tray/pickup(mob/user)	//Occulus Edit: Prepickup just returns True in the code. I don't know how it works, but it certainly /doesn't/ work here. Reverted to using standard pickup.
 	if(!isturf(loc))
 		return ..()
 

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -15,11 +15,6 @@
 	matter = list(MATERIAL_STEEL = 3)
 	var/list/carrying = list() // List of things on the tray. - Doohl
 	var/max_carry = 15
-	var/cleanpickup = FALSE
-
-/obj/item/tray/AltClick(mob/living/carbon/user)
-	cleanpickup = TRUE
-	pickup(mob/user)
 
 /obj/item/tray/attack(mob/living/carbon/M, mob/living/carbon/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)	//Occulus Edit- NO INSTANT MURDERING PEOPLE WITH A RAPID TRAY SPAM
@@ -178,9 +173,6 @@
 
 /obj/item/tray/pickup(mob/user)	//occulus edit: Prepickup just returns True in the code. I don't know how it works, but it certainly /doesn't/ work here. Reverted to using standard pickup.
 	if(!isturf(loc))
-		return ..()
-	if(cleanpickup == TRUE)
-		cleanpickup = FALSE
 		return ..()
 
 	for(var/obj/item/I in loc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes trays to actually pick things up, 
increases tray holding capacity
adds an attack cool down to trays so you can't murder someone in 5 seconds flat.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I demand a burger, fries, and a soda all fit on one tray properly.
Also being able to use trays is actually kinda nice.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
fix: fixes trays not picking items up (Bad pickup proc replaced)
tweak: increases holding capacity of trays
balance: Adds a cooldown to attacks with a trays so you can't instantly kill someone with rapid mouse clickage
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
