### PR TITLE
Bugfixes - Water, Slimes, and Defibs

### DIFF
--- a/code/modules/mob/living/carbon/slime/powers.dm
+++ b/code/modules/mob/living/carbon/slime/powers.dm
@@ -21,7 +21,7 @@
 		return "I cannot feed on other slimes..."
 	if (!Adjacent(M))
 		return "This subject is too far away..."
-	if (iscarbon(M) && M.getFireLoss() >= M.maxHealth * 1.5 || isanimal(M) && M.stat == DEAD)
+	if (iscarbon(M) && M.getCloneLoss() >= M.maxHealth - HEALTH_THRESHOLD_DEAD || isanimal(M) && M.stat == DEAD)
 		return "This subject does not have an edible life energy..."
 	for(var/mob/living/carbon/slime/met in view())
 		if(met.Victim == M && met != src)
@@ -43,7 +43,7 @@
 			UpdateFeed(M)
 
 			if(iscarbon(M))
-				Victim.adjustFireLoss(rand(5,6))
+				Victim.adjustCloneLoss(rand(5,6))
 				Victim.adjustToxLoss(rand(1,2))
 				if(Victim.health <= 0)
 					Victim.adjustToxLoss(rand(2,4))
@@ -66,10 +66,7 @@
 					if (!(C.species && (C.species.flags & NO_PAIN)))
 						to_chat(M, SPAN_DANGER("[painMes]"))
 
-			if(Victim.isMonkey()) //eclipse edit
-				gain_nutrition(rand(20,25)) //eclipse edit
-			else
-				gain_nutrition(rand(20,25) * 0.1) //eclipse edit
+			gain_nutrition(rand(20,25))
 
 			adjustOxyLoss(-8) //Heal yourself
 			adjustBruteLoss(-8)
@@ -120,7 +117,7 @@
 	if(!is_adult)
 		if(amount_grown >= 10)
 			is_adult = 1
-			maxHealth = 80 //eclipse edit, used to be 150
+			maxHealth = 150
 			amount_grown = 0
 			regenerate_icons()
 			name = text("[colour] [is_adult ? "adult" : "baby"] slime ([number])")

--- a/code/modules/mob/living/carbon/slime/slime.dm
+++ b/code/modules/mob/living/carbon/slime/slime.dm
@@ -7,8 +7,8 @@
 	speak_emote = list("chirps")
 
 	layer = 5
-	maxHealth = 40 //eclipse edit, used to be 80
-	health = 40 //eclipse edit ditto
+	maxHealth = 80
+	health = 80
 	gender = NEUTER
 
 	update_icon = 0

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -223,7 +223,7 @@ default behaviour is:
 /mob/living/proc/adjustBruteLoss(var/amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
-	bruteloss = min(max(bruteloss + amount, 0),(maxHealth*2))
+	bruteloss = min(max(bruteloss + amount, 0),(maxHealth-HEALTH_THRESHOLD_DEAD))//Occulus Edit - Fixes immortal monkies
 
 /mob/living/proc/getOxyLoss()
 	return oxyloss
@@ -231,7 +231,7 @@ default behaviour is:
 /mob/living/proc/adjustOxyLoss(var/amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
-	oxyloss = min(max(oxyloss + amount, 0),(maxHealth*2))
+	oxyloss = min(max(oxyloss + amount, 0),(maxHealth-HEALTH_THRESHOLD_DEAD))//Occulus Edit - Fixes immortal monkies
 
 /mob/living/proc/setOxyLoss(var/amount)
 	if(status_flags & GODMODE)
@@ -244,7 +244,7 @@ default behaviour is:
 /mob/living/proc/adjustToxLoss(var/amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
-	toxloss = min(max(toxloss + amount, 0),(maxHealth*2))
+	toxloss = min(max(toxloss + amount, 0),(maxHealth-HEALTH_THRESHOLD_DEAD))//Occulus Edit - Fixes immortal monkies
 
 /mob/living/proc/setToxLoss(var/amount)
 	if(status_flags & GODMODE)
@@ -257,7 +257,7 @@ default behaviour is:
 /mob/living/proc/adjustFireLoss(var/amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
-	fireloss = min(max(fireloss + amount, 0),(maxHealth*2))
+	fireloss = min(max(fireloss + amount, 0),(maxHealth-HEALTH_THRESHOLD_DEAD))//Occulus Edit - Fixes immortal monkies
 
 /mob/living/proc/getCloneLoss()
 	return cloneloss
@@ -265,7 +265,7 @@ default behaviour is:
 /mob/living/proc/adjustCloneLoss(var/amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
-	cloneloss = min(max(cloneloss + amount, 0),(maxHealth*2))
+	cloneloss = min(max(cloneloss + amount, 0),(maxHealth-HEALTH_THRESHOLD_DEAD))//Occulus Edit - Fixes immortal monkies
 
 /mob/living/proc/setCloneLoss(var/amount)
 	if(status_flags & GODMODE)
@@ -278,7 +278,7 @@ default behaviour is:
 /mob/living/proc/adjustBrainLoss(var/amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
-	brainloss = min(max(brainloss + amount, 0),(maxHealth*2))
+	brainloss = min(max(brainloss + amount, 0),(maxHealth-HEALTH_THRESHOLD_DEAD))//Occulus Edit - Fixes immortal monkies. Even if this doesn't really matter
 
 /mob/living/proc/setBrainLoss(var/amount)
 	if(status_flags & GODMODE)
@@ -291,7 +291,7 @@ default behaviour is:
 /mob/living/proc/adjustHalLoss(var/amount)
 	if(status_flags & GODMODE)
 		return FALSE	//godmode
-	halloss = min(max(halloss + amount, 0),(maxHealth*2))
+	halloss = min(max(halloss + amount, 0),(maxHealth-HEALTH_THRESHOLD_DEAD))//Occulus Edit - Fixes immortal monkies. Just doing this for good measure
 
 /mob/living/proc/setHalLoss(var/amount)
 	if(status_flags & GODMODE)

--- a/code/modules/reagents/reagents/other.dm
+++ b/code/modules/reagents/reagents/other.dm
@@ -208,10 +208,10 @@
 /datum/reagent/adrenaline/withdrawal_act(mob/living/carbon/M)
 	M.adjustOxyLoss(15)
 
-/datum/reagent/water/holywater/touch_turf(turf/T)
-	if(volume >= 5)
-		T.holy = 1
-	return TRUE
+///datum/reagent/water/holywater/touch_turf(turf/T) Occulus Edit - This doesn't actually exist
+//	if(volume >= 5)
+//		T.holy = 1
+//	return TRUE Occulus Edit- This doesn't actually exist
 
 /datum/reagent/other/diethylamine
 	name = "Diethylamine"

--- a/code/modules/reagents/reagents/random.dm
+++ b/code/modules/reagents/reagents/random.dm
@@ -4,7 +4,7 @@
 GLOBAL_LIST_INIT(random_chem_interaction_blacklist, list(
 	/datum/reagent/adminordrazine,
 	/datum/reagent/nanites,
-	/datum/reagent/water/holywater,
+	// /datum/reagent/water/holywater,This doesn't exist. Occulus Edit
 	/datum/reagent/chloralhydrate/beer2,
 	/datum/reagent/tobacco,
 	/datum/reagent/drink,

--- a/zzzz_modular_occulus/code/modules/defib.dm
+++ b/zzzz_modular_occulus/code/modules/defib.dm
@@ -482,7 +482,7 @@
 			O = H.random_organ_by_process(organ_tag)
 			if(!O)
 				return "buzzes, \"Resuscitation failed - Patient is missing vital organ ([name]). Further attempts futile.\""
-			if(O.damage > O.max_damage)
+			if(O.damage >= (O.max_damage * 0.75))//Organs can't go past max_damage in erismed3. If an organ has less than 25% health left, this step now fails.
 				return "buzzes, \"Resuscitation failed - Excessive damage to vital organ ([name]). Further attempts futile.\""
 	return null
 


### PR DESCRIPTION
## About The Pull Request

A handful of small fixes for various things around the ship

## Why It's Good For The Game

Bugfixes good.

## Changelog
```changelog
fix: Slimes are once again able to kill their victims.
fix: Slimes once again deal cloneloss
fix: Slime health restored to original values from eclipse edit
fix: Adjusted the adjustXLoss formulas to respect mobs with below 100 maxhealth
fix: Removed depreciated holywater references
fix: Fixed a bad area in research.
fix: Defibs no longer revive people with vital organs below 25% health. much of this code is a holdover from oldbay medical and wasn't accounted for in ErisMed3 as they don't have defibs.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
