### PR TITLE
Allows players to holster hammers onto their suits.

### DIFF
--- a/zzzz_modular_occulus/code/game/objects/items/weapons/storage/pouches.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/storage/pouches.dm
@@ -41,6 +41,7 @@
 		/obj/item/device/radio,
 		/obj/item/clothing/mask,
 		/obj/item/tool/sword/katana,
+		/obj/item/tool/hammer,
 		/obj/item/tool/sword/improvised,
 		/obj/item/storage/sheath)
 


### PR DESCRIPTION
+## About The Pull Request

Does as says: allows you to holster hammers on your suit. includes homewrecker, charge hammer, maces, everything under the hammer/ string.

## Why It's Good For The Game

Lets people wears hammers on their armor! Wow!

## Changelog
```changelog
add: can now wear hammer on armor.
``