### PR TITLE
Fixes slimepeople missing stomachs

### DIFF
--- a/zzzz_modular_occulus/code/modules/mob/living/carbon/human/species/station.dm
+++ b/zzzz_modular_occulus/code/modules/mob/living/carbon/human/species/station.dm
@@ -70,7 +70,7 @@
 	total_health = 125 //Unathi level
 	brute_mod = 1.1 //Normalized to .1 delta
 	burn_mod = 0.9 // ditto
-	spawn_flags = CAN_JOIN //duh
+	spawn_flags = CAN_JOIN | NO_SLIP //duh
 	siemens_coefficient = 3 //conductive | left untouched from regular slimes
 	darksight = 3
 	blood_volume = SPECIES_BLOOD_DEFAULT * 1.25
@@ -92,7 +92,8 @@
 	has_process = list(
 		OP_HEART =    /obj/item/organ/internal/heart/slime,
 		BP_BRAIN = /obj/item/organ/internal/brain/slime,
-		OP_EYES =     /obj/item/organ/internal/eyes/slime
+		OP_EYES =     /obj/item/organ/internal/eyes/slime,
+		OP_STOMACH = /obj/item/organ/internal/stomach/slime
 		)
 
 	has_limbs = list(
@@ -122,6 +123,10 @@
 /obj/item/organ/internal/eyes/slime
 	name = "slime photoreceptors"
 	desc = "A pulsating complex of jelly-like orbs."
+
+/obj/item/organ/internal/stomach/slime
+	name = "slime digestive sack"
+	desc = "a pulsating sack that contains especially heavy acids and sand."
 
 /datum/species // Instead of using snowflake slime sprites, we just tweak their alpha down
 	var/body_alpha = 255


### PR DESCRIPTION
## About The Pull Request

Slime-people can now eat normally.
Readded NO_SLIP tag to slimepeople

## Why It's Good For The Game

Despite "Only able to drink nutriment" being kind of cool, it's very un-intuitive and a bit unfair to newcomers that slimepeople can't eat anything but liquid nutriment.

Additionally, in retrospect, gibbing on death is a nasty penalty. Readding NO_SLIP gives slimepeople a small benefit for the very heavy disadvantage of having no body on death.

## Changelog
```changelog
fix: Slimepeople now have stomachs
tweak: Slimepeople now have NO_SLIP
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
