### PR TITLE
Makes stingers require chems

### DIFF
--- a/zzzz_modular_occulus/code/game/objects/items/weapons/grenades/stinger.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/grenades/stinger.dm
@@ -13,6 +13,7 @@
 	fragment_damage = 1
 
 	matter = list(MATERIAL_PLASTIC = 3, MATERIAL_STEEL = 2)
+	matter_reagents = list("ammonium_nitrate" = 5)
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 1)
 
 /obj/item/storage/box/frag/rubber

--- a/zzzz_modular_occulus/code/modules/reagents/reagents/other.dm
+++ b/zzzz_modular_occulus/code/modules/reagents/reagents/other.dm
@@ -50,6 +50,12 @@ datum/reagent/nitrate
 	reagent_state = LIQUID
 	color = "#E1CFE3"
 
+/datum/reagent/ammonium_nitrate
+	id = "ammonium_nitrate"
+	name = "Ammonium Nitrate"
+	description = "Ammonium Nitrate, even more interesting!"
+	reagent_state = LIQUID
+	color = "#d0bcd2"
 
 /datum/reagent/babelizine
 	id = "babelizine"

--- a/zzzz_modular_occulus/code/modules/reagents/recipes.dm
+++ b/zzzz_modular_occulus/code/modules/reagents/recipes.dm
@@ -52,6 +52,11 @@
 	required_reagents = list("aluminum" = 1, "nitrate" = 3)
 	result_amount = 4
 
+/datum/chemical_reaction/ammonium_nitrate
+	result = "ammonium_nitrate"
+	required_reagents = list("ammonia" = 1, "nitrate" = 3)
+	result_amount = 4
+
 /datum/chemical_reaction/tartrate
 	result = "tartrate"
 	required_reagents = list("nitrogen" = 1, "hydrazine" = 1)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes funny rubber grenades require ammonium nitrate, requiring more work to make them. It also adds in ammonium nitrate for future use. 
![Itworkwoe)](https://user-images.githubusercontent.com/53068506/167054043-173b0c05-d991-4af4-af73-417c11acd107.png)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Less OP balls of hurt 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
add: Added Ammonium Nitrate
tweak: Stingers now require ammonium nitrate
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
