### PR TITLE
Medical Tweaks

### DIFF
--- a/code/modules/organs/internal/internal_organ_processes.dm
+++ b/code/modules/organs/internal/internal_organ_processes.dm
@@ -26,7 +26,7 @@
 		for(var/organ in process_list)
 			var/obj/item/organ/internal/I = organ
 			effective_efficiency += I.get_process_eficiency(process_define)
-		
+
 	return effective_efficiency ? effective_efficiency : 1
 
 /mob/living/carbon/human/get_specific_organ_efficiency(process_define, parent_organ_tag)
@@ -41,7 +41,7 @@
 			var/obj/item/organ/internal/I = organ
 			if(process_define in I.organ_efficiency)
 				effective_efficiency += I.get_process_eficiency(process_define)
-	
+
 	return effective_efficiency ? effective_efficiency : 1
 
 /mob/living/carbon/human/proc/eye_process()
@@ -143,19 +143,24 @@
 	var/blood_bad = total_blood_req + BLOOD_VOLUME_BAD_MODIFIER
 
 	if(blood_volume < total_blood_req)
+		eye_blurry = max(eye_blurry,24)//Occulus Edit: Blurry vision stays
+		adjustOxyLoss(8) //Occulus Edit: At this point you should pretty much mcfuckingdie
 		status_flags |= BLEEDOUT
 		if(prob(15))
 			to_chat(src, SPAN_WARNING("Your organs feel extremely heavy"))
 
 	else if(blood_volume < blood_bad)
-		adjustOxyLoss(2)
-		adjustToxLoss(1)
+		eye_blurry = max(eye_blurry,12)//Occulus Edit: Blurry vision stays
+		adjustOxyLoss(5) //Occulus Edit: Bloodloss uncaps here
+		adjustBrainLoss(1)//Occulus Edit: You start getting brain damage here.
+		//Occulus Edit: Toxin damage is handled in bleedout now. adjustToxLoss(1)
 		if(prob(15))
 			to_chat(src, SPAN_WARNING("You feel extremely [pick("dizzy","woosey","faint")]"))
 
 	else if(blood_volume < blood_okay)
 		eye_blurry = max(eye_blurry,6)
-		adjustOxyLoss(1)
+		if(getOxyLoss() < 50)//Occulus Edit
+			adjustOxyLoss(3)//Occulus Edit: Bumping up over automatic oxyloss recovery
 		if(prob(15))
 			Paralyse(rand(1,3))
 			to_chat(src, SPAN_WARNING("You feel extremely [pick("dizzy","woosey","faint")]"))
@@ -164,9 +169,9 @@
 		if(prob(1))
 			to_chat(src, SPAN_WARNING("You feel [pick("dizzy","woosey","faint")]"))
 		if(getOxyLoss() < 10)
-			adjustOxyLoss(1)
+			adjustOxyLoss(3)//Occulus Edit: Bumping up over automatic oxyloss recovery
 
-	if(blood_volume > total_blood_req)	
+	if(blood_volume > total_blood_req)
 		status_flags &= ~BLEEDOUT
 
 	//Blood regeneration if there is some space

--- a/code/modules/reagents/reagents/nanites.dm
+++ b/code/modules/reagents/reagents/nanites.dm
@@ -1,5 +1,9 @@
-// Nanobots blood drain per unit
+/* This file has been completely restructured for Occulus*/
+
 #define NANOBOTS_BLOOD_DRAIN 0.003
+// Nanobots blood drain per unit
+
+/*Basic Nanite Defines*/
 
 /datum/reagent/nanites
 	name = ""
@@ -83,6 +87,8 @@
 		return FALSE
 	return TRUE
 
+/*Medical Nanites*/
+/*ARAD - Removes Radiation*/
 /datum/reagent/nanites/arad
 	name = "A-rad"
 	id = "arad nanites"
@@ -92,52 +98,11 @@
 	if(..() && M.radiation)
 		return TRUE
 
-
 /datum/reagent/nanites/arad/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(..())
 		M.radiation = max(M.radiation - (5 + M.radiation * 0.10) * effect_multiplier, 0)
 
-
-/datum/reagent/nanites/implant_medics
-	name = "Implantoids"
-	id = "implant nanites"
-	description = "Microscopic construction robots programmed to repair implants."
-
-
-/datum/reagent/nanites/implant_medics/will_occur(mob/living/carbon/M, alien, var/location)
-	if(..() && ishuman(M))
-		var/mob/living/carbon/human/H = M
-		constant_metabolism = FALSE
-		metabolism = initial(metabolism)
-		for(var/obj/item/organ/organ in H.organs) //Grab the organ holding the implant.
-			if((organ.damage > 0) && BP_IS_ROBOTIC(organ)) //only robotic organs
-				return TRUE
-			if(istype(organ, /obj/item/organ/external))
-				var/obj/item/organ/external/E = organ
-				for(var/obj/item/implant/I in E.implants)
-					if(I.malfunction)
-						metabolism = 1
-						constant_metabolism = TRUE
-						return TRUE
-
-
-/datum/reagent/nanites/implant_medics/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
-	if(..() && ishuman(M))
-		var/mob/living/carbon/human/H = M
-		for(var/obj/item/organ/organ in H.organs) //Grab the organ holding the implant.
-			if(metabolism == 1 && istype(organ, /obj/item/organ/external)) // if metabolism == 1 then broken implant is found see implant_medics/will_occur()
-				var/obj/item/organ/external/E = organ
-				for(var/obj/item/implant/I in E.implants)
-					if(I.malfunction)
-						I.restore()
-						return
-			else if (istype(organ, /obj/item/organ/external) && organ.damage > 0 && BP_IS_ROBOTIC(organ))
-				organ.heal_damage((2 + organ.damage * 0.05)* effect_multiplier, (2 + organ.damage * 0.05)* effect_multiplier, 1, 1)
-				return
-			else if (istype(organ, /obj/item/organ/internal) && organ.damage > 0 && BP_IS_ROBOTIC(organ))
-				organ.heal_damage((2 + organ.damage * 0.05)* effect_multiplier)
-				return
-
+/*Nantidotes - Removes foreign substances from the blood stream*/
 
 /datum/reagent/nanites/nantidotes
 	name = "Nantidotes"
@@ -158,10 +123,12 @@
 				if(!istype(current, /datum/reagent/nanites))
 					R.remove_self(effect_multiplier * 1)
 
+/*Nanosymbiotes - General purpose restoration nanites for raw damage. Regardless of limb type*/
+
 /datum/reagent/nanites/nanosymbiotes
 	name = "Nanosymbiotes"
 	id = "nanosymbiotes"
-	description = "Microscopic construction robots programmed to heal body cells."
+	description = "Microscopic construction robots programmed to heal organic and synthetic cells. Useless for internal damage"
 
 /datum/reagent/nanites/nanosymbiotes/will_occur(mob/living/carbon/M, alien, var/location)
 	if(..() && (M.getBruteLoss() || M.getFireLoss() || M.getToxLoss() || M.getCloneLoss() || M.getBrainLoss()))
@@ -173,6 +140,8 @@
 		M.adjustToxLoss(-((1 + (M.getToxLoss() * 0.03)) * effect_multiplier))
 		M.adjustCloneLoss(-(1 + (M.getCloneLoss() * 0.03)) * effect_multiplier)
 		M.adjustBrainLoss(-(1 + (M.getBrainLoss() * 0.03)) * effect_multiplier)
+
+/*Oxyrush - Removes oxygen damage from the target*/
 
 /datum/reagent/nanites/oxyrush
 	name = "Oxyrush"
@@ -188,6 +157,8 @@
 		M.adjustOxyLoss(-30 * effect_multiplier)
 		M.add_chemical_effect(CE_OXYGENATED, 2)
 
+/*Trauma Control System - Repairs internal organ damage for user*/
+
 /datum/reagent/nanites/trauma_control_system
 	name = "Trauma Control System"
 	id = "trauma_control_system"
@@ -196,24 +167,40 @@
 /datum/reagent/nanites/trauma_control_system/will_occur(mob/living/carbon/M, alien, var/location)
 	if(..() && ishuman(M))
 		var/mob/living/carbon/human/H = M
-		for(var/obj/item/organ/organ in H.organs) //Grab the organ holding the implant.
-			if(organ.damage > 0 && !BP_IS_ROBOTIC(organ))
-				return TRUE
-		for(var/obj/item/organ/organ in H.internal_organs) //SYZYGY Edit
-			if(organ.damage > 0 && !BP_IS_ROBOTIC(organ)) //SYZYGY Edit
+		for(var/obj/item/organ/organ in H.internal_organs) //Occulus Edit
+			if(organ.damage > 0 && !BP_IS_ROBOTIC(organ)) //Occulus Edit
 				return TRUE // SYZYGY Edit
 
 /datum/reagent/nanites/trauma_control_system/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(..() && ishuman(M))
 		var/mob/living/carbon/human/H = M
-		for(var/obj/item/organ/organ in H.organs) //Grab the organ holding the implant.
-			if (istype(organ, /obj/item/organ/external) && organ.damage > 0 && !BP_IS_ROBOTIC(organ))
-				organ.heal_damage((2 + organ.damage * 0.03)* effect_multiplier, (2 + organ.damage * 0.03)* effect_multiplier)
-			//else if (istype(organ, /obj/item/organ/internal) && organ.damage > 0 && !BP_IS_ROBOTIC(organ)) - SYZYGY Edit: Fix internal organs
-			//	organ.heal_damage((2 + organ.damage * 0.03)* effect_multiplier) - SYZY EDIT : Fix internal organs
-		for(var/obj/item/organ/organ in H.internal_organs) //SYZYGY EDIT - Grab Internal Organs
-			if((organ.damage > 0) && !BP_IS_ROBOTIC(organ)) //SYZYGY Edit
-				organ.heal_damage(((0.2 + organ.damage * 0.03) * effect_multiplier), FALSE) //SYZYGY Edit
+		for(var/obj/item/organ/organ in H.internal_organs) //Occulus EDIT - Grab Internal Organs
+			if((organ.damage > 0) && !BP_IS_ROBOTIC(organ)) //Occulus Edit
+				organ.heal_damage(((0.2 + organ.damage * 0.03) * effect_multiplier), FALSE) //Occulus Edit
+
+/*Implantoids - Repairs synthetic organ damage*/
+
+/datum/reagent/nanites/implant_medics
+	name = "Implantoids"
+	id = "implant nanites"
+	description = "Microscopic construction robots programmed to repair prosthetics."
+
+/datum/reagent/nanites/implant_medics/will_occur(mob/living/carbon/M, alien, var/location)//Occulus Edit Start
+	if(..() && ishuman(M))
+		var/mob/living/carbon/human/H = M
+		for(var/obj/item/organ/organ in H.internal_organs) //Check Internal Organs
+			if(organ.damage > 0 && BP_IS_ROBOTIC(organ))
+				return TRUE//Occulus Edit
+
+/datum/reagent/nanites/implant_medics/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
+	if(..() && ishuman(M))
+		var/mob/living/carbon/human/H = M
+		for(var/obj/item/organ/organ in H.internal_organs) //The location of internal organs changed
+			if((organ.damage > 0) && BP_IS_ROBOTIC(organ))
+				organ.heal_damage(((0.2 + organ.damage * 0.03) * effect_multiplier), FALSE)
+
+/*Purgers - Purges nanites from the bloodstream, except themselves*/
+
 /datum/reagent/nanites/purgers
 	name = "Purgers"
 	id = "nanopurgers"
@@ -293,3 +280,4 @@
 /datum/reagent/nanites/uncapped/dynamic_handprints/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	if(..())
 		M.add_chemical_effect(CE_DYNAMICFINGERS, uni_identity)
+/*End Occulus Edit*/

--- a/zzzz_modular_occulus/code/datums/autolathe/biomatter.dm
+++ b/zzzz_modular_occulus/code/datums/autolathe/biomatter.dm
@@ -31,3 +31,6 @@
 /datum/design/bioprinter/carpet/oracarpet
 	name = "orange carpet"
 	build_path = /obj/item/stack/tile/carpet/oracarpet
+
+/datum/design/bioprinter/medical/advanced
+	materials = list(MATERIAL_BIOMATTER = 35)

--- a/zzzz_modular_occulus/code/game/objects/items/stacks/medical.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/stacks/medical.dm
@@ -7,3 +7,6 @@
 /obj/item/stack/medical/ointment
 	amount = 10
 	max_amount = 10
+
+/obj/item/stack/medical
+	matter = list(MATERIAL_BIOMATTER = 2)


### PR DESCRIPTION
## About The Pull Request

Adjusts bleeding to be less trivial for a person bleeding.
Reduces the cost of Ointment and Bandages in the bioprinter
Adjusts nanite chems to be a bit cleaner/simpler and  above all...functional


### Bloodloss Effects
Note, all mobs recover 2 oxygen damage per organ tick by default

85%-75% Blood - 3 Oxygen Damage per organ tick, capped at 10 damage.
75%-60% Blood - 3 Oxygen Damage per organ tick, capped at 50 damage. Vision Blurriness
60%-40% Blood - 5 Oxygen Damage per organ tick, 1 Brain damage per organ tick. Even more bluriness
40% Blood or less- 8 Oxygen Damage per organ tick and rapid organ failure as per previously.

### Medical Supply Costs
All medical supply costs have been reduced to 2 biomatter
Advanced medical supply costs recipes have been increased to compensate for the base cost reduction.
Ointment and Bandages are now 30 biomatter to make in total.
Advanced kits are now 45 biomatter to make in total.

### Nanite Tweaks
Removed nonfunctional code with Trauma Control System. TCS now only focuses on internal organ damage for biological organs.
Reworked Implantedoid code. Removed nonfuncitonal implant restore code. Implantedoids now only focus on fixing internal organ damage for prosthetics.
Nanosymbiotes unchanged.
Tweaked file to be slightly easier to understand. Marked entire nanite file as an Occulus Edit

## Why It's Good For The Game

QoL Adjustments for medical

## Changelog
```changelog
balance: Bloodloss effects Tweaked
balance: basic medical supply cost reduced to 2 biomatter from 5
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
