### PR TITLE
[Modular] Adds Chem heater board to Circuits disk

### DIFF
--- a/zzzz_modular_occulus/code/datums/autolathe/circuits.dm
+++ b/zzzz_modular_occulus/code/datums/autolathe/circuits.dm
@@ -1,3 +1,7 @@
 /datum/design/autolathe/circuit/nanite_reconstitution_apparatus
 	name = "nanite reconstitution apparatus"
 	build_path = /obj/item/electronics/circuitboard/nanite_reconstitution_apparatus
+
+/datum/design/autolathe/circuit/chemheater
+	name = "chem heater"
+	build_path = /obj/item/electronics/circuitboard/chem_heater

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/design_disks/ees.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/design_disks/ees.dm
@@ -30,6 +30,28 @@
 
 /obj/item/computer_hardware/hard_drive/portable/design/circuits
 	disk_name = "EES-ESPO-830 Circuits"
+	designs = list(
+		/datum/design/autolathe/circuit/airlockmodule = 0,
+		/datum/design/autolathe/circuit/airlockmodule/secure,
+		/datum/design/autolathe/circuit/airalarm = 0,
+		/datum/design/autolathe/circuit/firealarm = 0,
+		/datum/design/autolathe/circuit/powermodule = 0,
+		/datum/design/autolathe/circuit/recharger,
+		/datum/design/research/circuit/autolathe,
+		/datum/design/autolathe/circuit/autolathe_disk_cloner = 3,
+		/datum/design/autolathe/circuit/vending,
+		/datum/design/research/circuit/arcade_battle,
+		/datum/design/research/circuit/arcade_orion_trail,
+		/datum/design/research/circuit/teleconsole,
+		/datum/design/research/circuit/operating,
+		/datum/design/autolathe/circuit/helm,
+		/datum/design/autolathe/circuit/nav,
+		/datum/design/autolathe/circuit/centrifuge,
+		/datum/design/autolathe/circuit/electrolyzer,
+		/datum/design/autolathe/circuit/reagentgrinder,
+		/datum/design/autolathe/circuit/industrialgrinder = 2,		
+		/datum/design/autolathe/circuit/chemheater = 2,
+	)
 
 /obj/item/computer_hardware/hard_drive/portable/design/conveyors
 	disk_name = "EES-LAT-018 Logistics"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds Chem Heater board to the Circuits disk at a license cost of 2 (same as industrial grinder) and the same material/chem cost as the other boards

## Why It's Good For The Game

Right, Lets just get this out of the way.
What this PR aims to accomplish: Add the chem heater board to the circuits disk for autolathe printing.

Minor why: So its more inline with the other chem machines so if medical's structure kicks the can and there's no science, they can atleast have access to the chemical heater.

Major why: Look. I'm going to level, Its 100% so vagabond chem has a *Viable* source of chemical cooling.

"Now hold on Zen, There's already instantice, and why are you keywording viable?"

Because, you innocent snowflake, GhettoChem with Instant Ice is a __Nightmare__. 

The minutiae of it is that you have to almost entirely use _large_ beakers or buckets to actually use instant ice, as you have to have the pre-requisite water and empty space to introduce the instantice, Which chills the whole thing and increases the water amount. While this _does_ mean that any chemical that reacts with water at(or above) room temp now suddenly cant be utilized (which, i'm not searching through all the chemical recipes for those edgecases), it also means any large-batch production is going to be severely limited by the required headspace required.

The major problem is what InstantIce is made of. Acetone, Hydrazine, ___SodiumChloride___. Sodium Chloride is made of 2 of the rarest base chems for ghettochemmers, Hydrochloric acid and Sodium. HCLacid has the benefit of atleast being degraded from PolyAcid, which can be farmed from Death Nettles (Which, Mind you, I've ___NEVER___ seen anyone mutate plants in-game outside of DNA confuckery with the 3 machines), But Sodium... Sodium has the benefit of being found in beakers, practically all over the station, if you search enough, But it isn't _reliable_. Neither ingredients for Sodium Chloride are reliable to get, But it itself can be obtained in a 40u batch by.. getting the salt shakers from the bar. 20u of each of the ingredients, And its expected to be wasted to chill chems if needed.

The requirement to waste these resources on a simple function, quite honestly, is an affront to the already difficult process of ghetto chem. Even with the grinder, centrifuge and electrolyzer, Which require silicon to print and usually means getting it through.. _whatever means_ (usually electrolyzing dylovene), Something as simple as _cooling down the chems_ is limited behind resources that are not always onhand or viable to even get, and as is, is severely hampered if anyone else just.. Nabs the table salt in the bar tables. Spending _god knows how long_ trying to mutate death nettles is going to take forever to do, and even then you're relying on _Sodium_, which any medical "good samaritan" can pick up, drop off at chem's desk with a smile, unknowing of _just what_ potential they've done.

"y'know this is a lot of poetic waxing over shit when you can just steal a chem dispenser board and then just be a maintenance chemist"

Yes. it is. But at the same time, Stealing a chem board kills the spirit of ghettochem. It kills the work arounds needed to find the ingredients to make This or That chem since you can just sit down and print silicon, or sodium, or tungsten (which.. does it even have a use?) or what has you. And while i am _literally_ advocating for the heater to be added so the rare reagents of sodium and hclacid aren't wasted on such a basic function, its not because i'm wanting to just make it _easier_. You still need the disk, the silicon, and all 2 parts to make the heater. You still need the room to put the machines, and you're still open to someone coming in, saying "the fucks all this shit m8, yous makin drugs so nows we gottsa arrest ye" (dont ask what accent i was trying to immitate, i dont even know. british maybe?). and most importantly, Its still not true ghettochem, no machines are.

also like tbh the point of stealing a chem dispenser board is just... very asinine to point out. Like yeah they have *two* but like, they dont recharge the fastest so god knows they need both of them (maybe more, but thats why there's science)

Is it _good_ for the game? Debatable. I dont think i can truly justify this as 'good', but i couldn't have justified many of my PR's as good.

Is it _bad_ for the game? IMO, No. It doesn't kill the true spirit of ghettochem, and it never will as ghettochem is about _specifically_ not using machines. If someone decides to make a maint chem lab, i dont see why something as simple as a chem heater would be so hard limited. 

Do i plan on making a ghetto-chem tool to cool down items so ghettochem can still not waste sodiumchloride on a simple function? ye. I just need to figure out how to do it, and this just feels like a step i wanted to take, accepted or denied, because quite frankly its a shame that... There just isn't that much reason to do ghettochem. There's drugs, or antag specific things, But you're limited out of a handful of niche items (that tbh you probably wouldn't use anyways) due to rare/non-renewable base chems and a few small functions. 

Do i plan on adding the chem master? god fuck no. Just chug your happy juice or use rusty needles. 

Did i spend way too much time waxing on about stupid shit only a select handful are going to argue against? Probably. I just feel its kinda odd to draw the line of machines at the chem heater, and not include a ghetto cooling device.

Is it te- Yes its tested. 

## Changelog
```changelog
tweak: adds chem heater board to circuit disk
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
