### PR TITLE
Disables the fabric/symbols breakdown

### DIFF
--- a/code/modules/sanity/breakdowns.dm
+++ b/code/modules/sanity/breakdowns.dm
@@ -325,7 +325,8 @@
 	holder.owner.client?.images |= I
 
 /datum/breakdown/negative/fabric/proc/update_client_images()
-	holder.owner.client?.images |= images */ Occulus Removal End
+	holder.owner.client?.images |= images 
+*/ // Occulus Removal End
 
 
 /datum/breakdown/negative/spiral

--- a/code/modules/sanity/breakdowns.dm
+++ b/code/modules/sanity/breakdowns.dm
@@ -285,7 +285,7 @@
 		holder.owner.playsound_local(holder.owner, 'sound/effects/alert.ogg')
 
 
-
+/* Occulus Removal Start - By popular opinion, this is a bad breakdown.
 /datum/breakdown/negative/fabric
 	name = "The Fabric"
 	duration = 3 MINUTES
@@ -325,7 +325,7 @@
 	holder.owner.client?.images |= I
 
 /datum/breakdown/negative/fabric/proc/update_client_images()
-	holder.owner.client?.images |= images
+	holder.owner.client?.images |= images */ Occulus Removal End
 
 
 /datum/breakdown/negative/spiral


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Disables the fabric breakdown. (The one which turns all mobs into symbols, and makes all speech heard/said intelligble.)

## Why It's Good For The Game

It's three minutes of putting a person *completely* out of action/the loop.

## Changelog
```changelog
del: Disabled/commented out the Fabric breakdown. (The one that makes you see people as symbols.)
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
