### PR TITLE
Caseless Ammo Fix

### DIFF
--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -56,6 +56,7 @@
 		new_casing.icon_state = src.icon_state
 		new_casing.spent_icon = src.spent_icon
 		new_casing.maxamount = src.maxamount
+		new_casing.is_caseless = src.is_caseless
 		if(ispath(new_casing.projectile_type) && src.BB)
 			new_casing.BB = new new_casing.projectile_type(new_casing)
 		else
@@ -293,6 +294,7 @@
 		inserted_casing.icon_state = C.icon_state
 		inserted_casing.spent_icon = C.spent_icon
 		inserted_casing.maxamount = C.maxamount
+		inserted_casing.is_caseless = C.is_caseless
 		if(ispath(inserted_casing.projectile_type) && C.BB)
 			inserted_casing.BB = new inserted_casing.projectile_type(inserted_casing)
 		C.update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes caseless ammo not drop casings when the ammo was previously pulled out of a magazine/ammo box and put back into a magazine.

## Why It's Good For The Game

Not having those casing errors everywhere.

## Changelog
tweak: made the function for taking ammo out of a magazine/putting it in copy over the "is_caseless" variable to the new bullets.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
