### PR TITLE
Removes mapstart muzzle and straightjacket

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -101572,9 +101572,6 @@
 	pixel_x = 5
 	},
 /obj/item/bodybag/cryobag,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/suit/straight_jacket,
-/obj/item/clothing/mask/muzzle,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = 28


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes the straightjacket and muzzle spawns from medical

## Why It's Good For The Game

These items serve little good purpose in a round, and are mostly used to abuse/prevent players from interacting/RPing by acting as a superior 'handcuff that you cannot escape normally.

Due to abuse, I am recommending outright removal.

## Changelog
```changelog
del: Mapstart straightjackets and muzzles from medical.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
