### PR TITLE
Silkcraft fixes

### DIFF
--- a/zzzz_modular_occulus/code/datums/craft/recipes/clothing.dm
+++ b/zzzz_modular_occulus/code/datums/craft/recipes/clothing.dm
@@ -7,7 +7,7 @@
 		list(QUALITY_WIRE_CUTTING, 15, 70)
 	)
 
-/datum/craft_recipe/clothing/webcov
+/datum/craft_recipe/clothing/silkcov
 	name = "silken covers"
 	result = /obj/item/clothing/under/silkwear
 	steps = list(

--- a/zzzz_modular_occulus/code/game/objects/items/silkcraft.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/silkcraft.dm
@@ -20,12 +20,19 @@
 	price_tag = 1
 
 /obj/item/stack/unrefinedsilk/attack_self(mob/user)
+	if((locate(/obj/effect/spider/stickyweb) in get_turf(src)))
+		to_chat(user, SPAN_WARNING("There's already webbing here!"))
+		return
 	if(!(locate(/obj/effect/spider/stickyweb) in get_turf(src)))
 		to_chat(user, SPAN_NOTICE("You start creating a webby mess"))
 		if(do_after(user, 40, src))
+			if((locate(/obj/effect/spider/stickyweb) in get_turf(src)))
+				to_chat(user, SPAN_WARNING("There's already webbing here!"))
+				return
 			new /obj/effect/spider/stickyweb(user.loc)
 			update_openspace()
-			use(3)
+			use(1)
+			return
 
 /obj/item/stack/refinedsilk
 	name = "silk strands"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Silk requirement for webs lowered to 1 (Its going to be a PITA to get enough to really use them if its 3, and so i dont have to fuck around with more checks and questions about "why do you need 3 to make webbing when you're harvesting it all to just 1 glob?") and added more checks for webs to avoid stacking
Silk covers recipe seperated from web covers


## Why It's Good For The Game

Because its a PITA

## Changelog
```changelog
balance: Silk globs have a cost of 1 for making webs now 
fix: web covers aren't over-written
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
