### PR TITLE
Skremfix, Barricade fix

### DIFF
--- a/zzzz_modular_occulus/code/modules/mob/living/simple_animal/hostile/siren/composer.dm
+++ b/zzzz_modular_occulus/code/modules/mob/living/simple_animal/hostile/siren/composer.dm
@@ -28,9 +28,10 @@
 
 /mob/living/simple_animal/hostile/siren/composer/Life()
 	. = ..()
-	soundloop()
-	if(target_mob)
-		skremloop()
+	if(health >=15)
+		soundloop()
+		if(target_mob)
+			skremloop()
 
 /mob/living/simple_animal/hostile/siren/composer/proc/skremloop()
 	if(skremdelay == 0)

--- a/zzzz_modular_occulus/code/modules/mob/living/simple_animal/hostile/siren/conservator.dm
+++ b/zzzz_modular_occulus/code/modules/mob/living/simple_animal/hostile/siren/conservator.dm
@@ -129,6 +129,32 @@
 
 /obj/structure/sirencade/attackby(obj/item/W as obj, mob/user as mob)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	if(QUALITY_BOLT_TURNING in W.tool_qualities)
+		if(stage == 0)
+			user.visible_message(
+			SPAN_DANGER("[user] struggles to unbolt the cover of \the [src]."),
+			SPAN_DANGER("You struggles to unbolt the cover of \the [src]."))
+			if(do_after(user,2 SECONDS))
+				stage = 1
+				user.visible_message(
+					SPAN_DANGER("[user] to unbolts the cover of \the [src]."))
+				return
+		if(stage == 1)
+			to_chat(user, "<span class='notice'>The cover of \the [src] has already been removed</span>")
+
+	if(QUALITY_PULSING in W.tool_qualities)
+		if(stage == 0)
+			to_chat(user, "<span class='notice'>You're unable to deactivate \the [src] with it's cover in place.</span>")
+		if(stage == 1)
+			user.visible_message(
+				SPAN_DANGER("[user] starts to carefully shutdown \the [src]."),
+				SPAN_DANGER("You begin to carefully shutdown \the [src]."))
+			if(do_after(user,5 SECONDS))
+				qdel(src)
+				user.visible_message(
+					SPAN_DANGER("[user] has shutdown \the [src]."),
+					SPAN_DANGER("You have shutdown \the [src]!"))
+				return
 	switch(W.damtype)
 		if("fire")
 			health -= W.force * 1
@@ -147,28 +173,6 @@
 		return
 	..()
 
-/obj/structure/sirencade/attackby(obj/item/W as obj, mob/user as mob)
-	if(QUALITY_PULSING in W.tool_qualities)
-		if(stage == 0)
-			to_chat(user, "<span class='notice'>You're unable to deactivate \the [src] with it's cover in place.</span>")
-		if(stage == 1)
-			user.visible_message(
-				SPAN_DANGER("[user] starts to carefully shutdown \the [src]."),
-				SPAN_DANGER("You begin to carefully shutdown \the [src]."))
-			if(do_after(user,5 SECONDS))
-				qdel(src)
-				user.visible_message(
-					SPAN_DANGER("[user] has shutdown \the [src]."),
-					SPAN_DANGER("You have shutdown \the [src]!"))
-	if(QUALITY_BOLT_TURNING in W.tool_qualities)
-		if(stage == 0)
-			user.visible_message(
-			SPAN_DANGER("[user] struggles to unbolt the cover of \the [src]."),
-			SPAN_DANGER("You struggles to unbolt the cover of \the [src]."))
-			if(do_after(user,2 SECONDS))
-				stage = 1
-		if(stage == 1)
-			to_chat(user, "<span class='notice'>The cover of \the [src] has already been removed</span>")
 /obj/structure/sirencade/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	if(air_group || (height==0))
 		return 1


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes barricades actually bashable now. (I think a byond update broke it, or my shoddy coding was only working part of the time.)
Composers will no longer skrem indefinitely. At low health, and when dead they will shuttheheckup
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes bugs
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
fix: Siren Composers no longer skrem forever and always
fix:Sirenbarricades are now destroyable once more.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
