### PR TITLE
Tools and RPEDs no longer can be blended by grinders.

### DIFF
--- a/code/modules/reagents/machinery/grinder.dm
+++ b/code/modules/reagents/machinery/grinder.dm
@@ -19,6 +19,8 @@
 /obj/machinery/reagentgrinder/MouseDrop_T(atom/movable/I, mob/user, src_location, over_location, src_control, over_control, params)
 	if(!Adjacent(user) || !I.Adjacent(user) || user.incapacitated())
 		return ..()
+	if(istype(I,/obj/item/tool) || istype(I,/obj/item/storage/part_replacer)) //Occulus edit: Grinders no longer attempt to grind tools
+		return ..() //Occulus Edit: Grinders no longer attempt to grind tools
 	insert(I, user)
 	. = ..()
 
@@ -26,9 +28,11 @@
 	if(default_deconstruction(I, user))
 		return
 	//Useability tweak for borgs
-	if (istype(I,/obj/item/gripper))
+	if (istype(I,/obj/item/gripper) && istype(I,/obj/item/storage/part_replacer))
 		ui_interact(user)
 		return
+	if(istype(I,/obj/item/tool) || istype(I,/obj/item/storage/part_replacer)) //Occulus edit: Grinders no longer attempt to grind tools
+		return  //Occulus Edit: Grinders no longer attempt to grind tools
 	return insert(I, user)
 
 /obj/machinery/reagentgrinder/proc/insert(obj/item/I, mob/user)

--- a/code/modules/reagents/machinery/grinder.dm
+++ b/code/modules/reagents/machinery/grinder.dm
@@ -28,7 +28,7 @@
 	if(default_deconstruction(I, user))
 		return
 	//Useability tweak for borgs
-	if (istype(I,/obj/item/gripper) && istype(I,/obj/item/storage/part_replacer))
+	if (istype(I,/obj/item/gripper))
 		ui_interact(user)
 		return
 	if(istype(I,/obj/item/tool) || istype(I,/obj/item/storage/part_replacer)) //Occulus edit: Grinders no longer attempt to grind tools


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Prevents grinders from attempting to grind tools and RPEDs

## Why It's Good For The Game

No more accidentally recycling your welder.
No more "This probably won't blend" from trying to upgrade the parts in a grinder

## Changelog
```changelog
fix: Grinders now have a few sanity checks to prevent them from eating tools
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
