### PR TITLE
Fixes synthetics sending soulcrypts to the shadow realm

### DIFF
--- a/code/modules/core_implant/cruciform/machinery/cloning.dm
+++ b/code/modules/core_implant/cruciform/machinery/cloning.dm
@@ -502,10 +502,10 @@
 		return
 
 	if(reading)
-		to_chat(user, SPAN_WARNING("You try to pull the [implant], but it does not move."))
+		to_chat(user, SPAN_WARNING("You try to eject the [implant], but it does not move.")) //Occulus Edit: Synthetics no longer delete crypts
 		return
 
-	user.put_in_active_hand(implant)
+	implant.forceMove(loc) //Occulus Edit: Synthetics no longer delete crypts
 	implant = null
 
 	src.add_fingerprint(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The soulcrypt reader in NT cloning now drops the crypt on the floor instead of your hand.

## Why It's Good For The Game

This prevents synthetics from sending the core implant into the shadow realm. (an inaccessible part of the core implant reader)

## Changelog
```changelog
fix: Core implant readers no longer make soulcrypts inaccessible if a synthetic touches the device.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
