### PR TITLE
Bugfixes

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/stranger.dm
+++ b/code/modules/mob/living/simple_animal/hostile/stranger.dm
@@ -130,6 +130,7 @@
 	suitable_cell = /obj/item/cell/small
 	can_dual = TRUE
 	w_class = ITEM_SIZE_NORMAL
+	spawn_blacklisted = TRUE //Occulus Edit - Boss rewards should not be spawning randomly
 
 	init_firemodes = list(
 		list(mode_name="burn", burst=1, projectile_type=/obj/item/projectile/plasma/light, fire_sound='sound/weapons/Taser.ogg', fire_delay=5, move_delay=null, charge_cost=3, icon="stun", projectile_color = "#0000FF"),

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/storage/pouches.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/storage/pouches.dm
@@ -5,6 +5,7 @@
 /obj/item/storage/pouch/medium_generic
 	desc = "Can hold a fair number of small objects."
 	price_tag = 1000
+	max_w_class = ITEM_SIZE_SMALL
 
 /obj/item/storage/pouch/large_generic
 	price_tag = 1500


### PR DESCRIPTION
## About The Pull Request

Stranger Plasma Gun is now blacklisted from random spawns
Reduced medium pouch maximum w_class from 3 to 2. Fixing #881 

## Why It's Good For The Game

Bugfixes mostly, and removing a boss weapon from the random spawn pool

## Changelog
```changelog
fix: blacklisted stranger plasma gun from lootspawner
fix: reduced medium pouch maximum w_class from 3 to 2.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
