### PR TITLE
Fix fishing hats runtime (maybe)

### DIFF
--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -9,8 +9,7 @@
 	all_vars = duplicate_vars(parent)
 	if(isitem(parent))
 		var/obj/item/I = parent
-		if(!istype(I, /obj/item/clothing/head/fishing)) //Occulus edit: if not fish hat, put in armor list
-			armor = I.armor.getList()
+		armor = I.armor.getList()
 
 /datum/component/oldficator/proc/make_young()
 	for(var/V in all_vars)
@@ -208,7 +207,7 @@
 	if(.)
 		if(prob(30))
 			slowdown += pick(0.5, 0.5, 1, 1.5)
-		if(prob(40) && (islist(armor)))/* //Occulus edit: if not armor, don't do this (only applies to fishing hats)
+		if(prob(40))/*
 			if(islist(armor)) //Possible to run before the initialize proc, thus having to modify the armor list
 				var/list/armorList = armor	// Typecasting to a list from datum
 				for(var/i in armorList)

--- a/code/modules/scrap/oldificator.dm
+++ b/code/modules/scrap/oldificator.dm
@@ -9,7 +9,8 @@
 	all_vars = duplicate_vars(parent)
 	if(isitem(parent))
 		var/obj/item/I = parent
-		armor = I.armor.getList()
+		if(!istype(I, /obj/item/clothing/head/fishing)) //Occulus edit: if not fish hat, put in armor list
+			armor = I.armor.getList()
 
 /datum/component/oldficator/proc/make_young()
 	for(var/V in all_vars)
@@ -207,7 +208,7 @@
 	if(.)
 		if(prob(30))
 			slowdown += pick(0.5, 0.5, 1, 1.5)
-		if(prob(40))/*
+		if(prob(40) && (islist(armor)))/* //Occulus edit: if not armor, don't do this (only applies to fishing hats)
 			if(islist(armor)) //Possible to run before the initialize proc, thus having to modify the armor list
 				var/list/armorList = armor	// Typecasting to a list from datum
 				for(var/i in armorList)

--- a/zzzz_modular_occulus/code/modules/clothing/head/fishing.dm
+++ b/zzzz_modular_occulus/code/modules/clothing/head/fishing.dm
@@ -53,7 +53,7 @@
 	name = "black fishing hat"
 	colourtype = "black"
 
-/obj/item/clothing/head/fishing/Initialize() //Hey, uh, i'm like 75% sure this breaks ui initialize in clothing.dm
+/obj/item/clothing/head/fishing/Initialize()
 	//short phrases that women and fish may have about you
 	var/feelings = list("love me",
 						"fear me",

--- a/zzzz_modular_occulus/code/modules/clothing/head/fishing.dm
+++ b/zzzz_modular_occulus/code/modules/clothing/head/fishing.dm
@@ -54,6 +54,7 @@
 	colourtype = "black"
 
 /obj/item/clothing/head/fishing/Initialize()
+	. = ..()
 	//short phrases that women and fish may have about you
 	var/feelings = list("love me",
 						"fear me",

--- a/zzzz_modular_occulus/code/modules/clothing/head/fishing.dm
+++ b/zzzz_modular_occulus/code/modules/clothing/head/fishing.dm
@@ -53,7 +53,7 @@
 	name = "black fishing hat"
 	colourtype = "black"
 
-/obj/item/clothing/head/fishing/Initialize()
+/obj/item/clothing/head/fishing/Initialize() //Hey, uh, i'm like 75% sure this breaks ui initialize in clothing.dm
 	//short phrases that women and fish may have about you
 	var/feelings = list("love me",
 						"fear me",


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

![hat](https://user-images.githubusercontent.com/61395535/187060248-46bb1447-b93d-4753-82b3-ffcc12df528c.png)

^ this is a joke ^
makes fishing hats not cause a runtime when initializing the round.

~~I'm 75% sure that this happens because the fishing hat code uses Initialize() when no other clothing item directly uses it. My theory is that this breaks the UI code which uses Initialize(), which in turn breaks the effects of the oldificator code when applied to a fishing hat.~~

That seems to be the case and adding ". = ..()" fixed it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

its so annoying for to have that runtime happen whenever you test your code for a PR
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
fix: a single line in fishing hat code
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
