### PR TITLE
Hypo storage change

### DIFF
--- a/zzzz_modular_occulus/code/game/objects/items/weapons/storage/belt.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/storage/belt.dm
@@ -1,4 +1,4 @@
-//Makes the medical belt able to fit the advanced rollerbed in it! and hypospray.
+//Makes the medical belt able to fit the advanced rollerbed and the hypospray in it!
 
 /obj/item/storage/belt/medical
 	can_hold = list(

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/storage/belt.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/storage/belt.dm
@@ -1,4 +1,4 @@
-//Makes the medical belt able to fit the advanced rollerbed in it!
+//Makes the medical belt able to fit the advanced rollerbed in it! and hypospray.
 
 /obj/item/storage/belt/medical
 	can_hold = list(
@@ -23,7 +23,8 @@
 		/obj/item/tool/crowbar,
 		/obj/item/device/lighting/toggleable/flashlight,
 		/obj/item/extinguisher/mini,
-		/obj/item/roller/adv
+		/obj/item/roller/adv,
+		/obj/item/hypospray/mkii
 	)
 
 /obj/item/storage/belt/tactical//adds stun baton to belt! Whoop!

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/storage/pouches.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/storage/pouches.dm
@@ -87,6 +87,18 @@
 
 /obj/item/storage/pouch/tubular
 	price_tag = 600
+	can_hold = list(
+		/obj/item/device/lighting/glowstick,
+		/obj/item/reagent_containers/syringe,
+		/obj/item/reagent_containers/glass/beaker/vial,
+		/obj/item/reagent_containers/hypospray,
+		/obj/item/pen,
+		/obj/item/storage/pill_bottle,
+		/obj/item/hatton_magazine,
+		/obj/item/ammo_casing/rocket,
+		/obj/item/ammo_casing/grenade,
+		/obj/item/reagent_containers/glass/beaker/hypocartridge
+		)
 
 /obj/item/storage/pouch/pistol_holster
 	price_tag = 200


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes Hyopsprays storable in medical belts, and hypo cartridge storable in tubular/vial pouches. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes the various Hyposprays less of a hassle to use. Being able to holster the hypos is nice, but for actual use it is pretty meh when most will use holsters to store an actual gun. Also makes hypo cartridge storable in vial pouches, which is just a nice QoL thing and makes the tubular/vial pouch more viable.

Feel free to reject this PR if it conflicts with any balancing decisions, i just wanted to get this off my list of things i wanted to do.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
change: makes hypos storable in medical belts
change: makes hypo cartridge storable in vial pouches
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
