### PR TITLE
fix for species bleeding the wrong color when no blood color is set

### DIFF
--- a/zzzz_modular_occulus/code/modules/client/preferences.dm
+++ b/zzzz_modular_occulus/code/modules/client/preferences.dm
@@ -95,7 +95,7 @@
 	character.appearance_flags	-= fuzzy*PIXEL_SCALE
 
 	character.body_markings = body_markings
-	character.blood_color = blood_color
+	character.blood_color = blood_color ? blood_color : character.species.blood_color
 
 	QDEL_NULL_LIST(character.worn_underwear)
 	character.worn_underwear = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Bug fix PR for species bleeding the wrong color when their blood color isn't set.

## Changelog
```changelog
fix: player mobs bleeding the wrong color when having picked null blood color
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
