### PR TITLE
Updated Club

### DIFF
--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -11012,7 +11012,7 @@
 	input_tag = "incernator_in";
 	name = "Incernator Control";
 	output_tag = "incernator_out";
-	sensors = list("incernator_sensor" = "Tank")
+	sensors = list("incernator_sensor"="Tank")
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -13142,7 +13142,7 @@
 	input_tag = "tox_in";
 	name = "phoron Supply Control";
 	output_tag = "tox_out";
-	sensors = list("tox_sensor" = "Tank")
+	sensors = list("tox_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/engineering/atmos)
@@ -13639,7 +13639,7 @@
 	input_tag = "waste_in";
 	name = "Gas Mix Tank Control";
 	output_tag = "waste_out";
-	sensors = list("waste_sensor" = "Tank")
+	sensors = list("waste_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/engineering/atmos)
@@ -13691,7 +13691,7 @@
 	input_tag = "n2o_in";
 	name = "Nitrous Oxide Supply Control";
 	output_tag = "n2o_out";
-	sensors = list("n2o_sensor" = "Tank")
+	sensors = list("n2o_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/engineering/atmos)
@@ -13996,7 +13996,7 @@
 	name = "Mixed Air Supply Control";
 	output_tag = "air_out";
 	pressure_setting = 2000;
-	sensors = list("air_sensor" = "Tank")
+	sensors = list("air_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/engineering/atmos)
@@ -14006,7 +14006,7 @@
 	input_tag = "co2_in";
 	name = "Carbon Dioxide Supply Control";
 	output_tag = "co2_out";
-	sensors = list("co2_sensor" = "Tank")
+	sensors = list("co2_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/engineering/atmos)
@@ -15434,7 +15434,7 @@
 	input_tag = "n2_in";
 	name = "Nitrogen Supply Control";
 	output_tag = "n2_out";
-	sensors = list("n2_sensor" = "Tank")
+	sensors = list("n2_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/engineering/atmos)
@@ -15461,7 +15461,7 @@
 	input_tag = "o2_in";
 	name = "Oxygen Supply Control";
 	output_tag = "o2_out";
-	sensors = list("o2_sensor" = "Tank")
+	sensors = list("o2_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/dark/danger,
 /area/eris/engineering/atmos)
@@ -30671,7 +30671,7 @@
 	frequency = 1443;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Waste Loop")
+	sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Waste Loop")
 	},
 /obj/machinery/camera/network/engineering{
 	dir = 1
@@ -31859,7 +31859,7 @@
 	dir = 8;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
+	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
 	},
 /obj/machinery/power/apc{
 	name = "South APC";
@@ -47863,7 +47863,7 @@
 	dir = 8;
 	frequency = 1430;
 	name = "Mixing Chamber Monitor";
-	sensors = list("toxins_mixing_1" = "Mixing Chamber - 1")
+	sensors = list("toxins_mixing_1"="Mixing Chamber - 1")
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/eris/rnd/mixing)
@@ -47998,7 +47998,7 @@
 	dir = 8;
 	frequency = 1430;
 	name = "Mixing Chamber Monitor";
-	sensors = list("toxins_mixing_1" = "Mixing Chamber - 1", "toxins_mixing_2" = "Mixing Chamber - 2")
+	sensors = list("toxins_mixing_1"="Mixing Chamber - 1","toxins_mixing_2"="Mixing Chamber - 2")
 	},
 /turf/simulated/floor/tiled/white/gray_perforated,
 /area/eris/rnd/mixing)
@@ -48257,7 +48257,7 @@
 	dir = 8;
 	frequency = 1430;
 	name = "Mixing Chamber Monitor";
-	sensors = list("toxins_mixing_2" = "Mixing Chamber - 2")
+	sensors = list("toxins_mixing_2"="Mixing Chamber - 2")
 	},
 /turf/simulated/floor/tiled/white/techfloor_grid,
 /area/eris/rnd/mixing)
@@ -49181,6 +49181,12 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/lab)
+"cnb" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/white/bluecorner,
+/area/eris/crew_quarters/bar)
 "cnc" = (
 /obj/structure/railing{
 	dir = 8
@@ -52180,17 +52186,10 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/storage)
 "cuv" = (
-/obj/structure/table/woodentable,
-/obj/item/gun/projectile/shotgun/doublebarrel,
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 8
-	},
-/obj/item/reagent_containers/bonsai{
-	pixel_x = 8;
-	pixel_y = 16
-	},
-/turf/simulated/floor/carpet/sblucarpet,
-/area/eris/crew_quarters/barbackroom)
+/obj/structure/table/bar_special,
+/obj/item/oddity/instructional/common/bio/aid,
+/turf/simulated/floor/tiled/white/bluecorner,
+/area/eris/crew_quarters/bar)
 "cuw" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -52529,16 +52528,8 @@
 /turf/simulated/open,
 /area/eris/maintenance/section3deck4port)
 "cvs" = (
-/obj/structure/table/woodentable,
-/obj/item/book/manual/barman_recipes,
-/obj/item/flame/lighter/zippo,
-/obj/item/reagent_containers/food/drinks/flask/vacuumflask,
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/item/device/eftpos,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/eris/crew_quarters/barbackroom)
+/turf/simulated/floor/tiled/white/bluecorner,
+/area/eris/crew_quarters/bar)
 "cvt" = (
 /obj/machinery/door/window/eastleft,
 /turf/simulated/floor/tiled/steel/bar_flat,
@@ -53275,9 +53266,15 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/oldtele)
 "cxi" = (
-/obj/machinery/vending/boozeomat,
-/turf/simulated/floor/tiled/steel/bar_light,
-/area/eris/crew_quarters/bar)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/cafe,
+/area/eris/crew_quarters/kitchen)
 "cxj" = (
 /obj/machinery/door/firedoor,
 /obj/effect/window_lwall_spawn/smartspawnphoron,
@@ -53309,8 +53306,8 @@
 /turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/hallway/side/bridgehallway)
 "cxm" = (
-/obj/machinery/smartfridge/drinks,
-/turf/simulated/floor/tiled/steel/bar_flat,
+/obj/machinery/vending/boozeomat/public,
+/turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/crew_quarters/bar)
 "cxn" = (
 /obj/machinery/firealarm{
@@ -53408,8 +53405,9 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section1deck2central)
 "cxA" = (
-/turf/simulated/wall,
-/area/eris/crew_quarters/barbackroom)
+/obj/structure/bed/chair/sofa/black/left,
+/turf/simulated/floor/tiled/steel/bluecorner,
+/area/eris/crew_quarters/bar)
 "cxC" = (
 /obj/machinery/disposal,
 /obj/structure/disposalpipe/trunk,
@@ -53582,20 +53580,11 @@
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/engeva)
 "cxS" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/camera/network/third_section{
+	dir = 4
 	},
-/obj/machinery/door/airlock{
-	name = "Club Office";
-	req_access = list(28)
-	},
-/turf/simulated/floor/bluegrid,
-/area/eris/crew_quarters/barbackroom)
+/turf/simulated/floor/tiled/steel/bluecorner,
+/area/eris/crew_quarters/bar)
 "cxT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -54017,17 +54006,23 @@
 /turf/simulated/open,
 /area/eris/maintenance/section4deck4port)
 "cyT" = (
-/obj/machinery/vending/dinnerware,
-/turf/simulated/floor/tiled/steel/bar_light,
-/area/eris/crew_quarters/bar)
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/barbackroom)
 "cyU" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/table/bar_special,
-/obj/item/oddity/instructional/common/vig/ross,
+/obj/machinery/smartfridge/drinks,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
 "cyV" = (
-/obj/item/stool/custom/bar_special,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/table/bar_special,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/eris/crew_quarters/bar)
 "cyW" = (
@@ -54305,7 +54300,8 @@
 /area/eris/neotheology/chapelritualroom)
 "czA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/steel/bar_dance,
+/obj/item/stool/custom/bar_special,
+/turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/crew_quarters/bar)
 "czB" = (
 /turf/simulated/floor/wood,
@@ -54379,7 +54375,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled/steel/bar_dance,
+/obj/item/stool/custom/bar_special,
+/turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/crew_quarters/bar)
 "czN" = (
 /obj/machinery/door/firedoor,
@@ -54679,7 +54676,6 @@
 /area/eris/quartermaster/storage)
 "cAu" = (
 /obj/structure/reagent_dispensers/beerkeg,
-/obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/eris/crew_quarters/bar)
 "cAv" = (
@@ -54699,9 +54695,8 @@
 /area/eris/maintenance/section1deck2central)
 "cAw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/table/bar_special,
-/obj/item/oddity/instructional/common/tgh/soldier,
-/turf/simulated/floor/tiled/steel/bar_light,
+/obj/structure/disposalpipe/segment,
+/turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/crew_quarters/bar)
 "cAx" = (
 /turf/simulated/floor/tiled/steel/monofloor{
@@ -55497,7 +55492,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock{
-	name = "Kitchen Freezer";
+	name = "Kitchen";
 	req_access = list(28)
 	},
 /turf/simulated/floor/tiled/white/cargo,
@@ -61137,7 +61132,7 @@
 "cQe" = (
 /obj/structure/cyberplant{
 	emagged = 1;
-	possible_plants = list("emagged2-orange", "emagged2-blue")
+	possible_plants = list("emagged2-orange","emagged2-blue")
 	},
 /obj/machinery/floor_light/prebuilt{
 	color = "#8F00FF";
@@ -79793,7 +79788,7 @@
 	dir = 1;
 	frequency = 1441;
 	name = "Tank Monitor";
-	sensors = list("n2_sensor" = "Nitrogen", "o2_sensor" = "Oxygen", "co2_sensor" = "Carbon Dioxide", "tox_sensor" = "Toxins", "n2o_sensor" = "Nitrous Oxide", "waste_sensor" = "Gas Mix Tank")
+	sensors = list("n2_sensor"="Nitrogen","o2_sensor"="Oxygen","co2_sensor"="Carbon Dioxide","tox_sensor"="Toxins","n2o_sensor"="Nitrous Oxide","waste_sensor"="Gas Mix Tank")
 	},
 /turf/simulated/floor/tiled/steel/brown_platform,
 /area/eris/command/exultant)
@@ -80677,7 +80672,7 @@
 	input_tag = "cooling_in";
 	name = "Engine Cooling Control";
 	output_tag = "cooling_out";
-	sensors = list("engine_sensor" = "Engine Core")
+	sensors = list("engine_sensor"="Engine Core")
 	},
 /turf/simulated/floor/tiled/steel/gray_perforated,
 /area/eris/engineering/engine_room)
@@ -80886,7 +80881,7 @@
 	input_tag = "left_propulsion_in";
 	name = "Left Propulsion Control";
 	output_tag = "left_propulsion_out";
-	sensors = list("left_propulsion_sensor" = "Tank")
+	sensors = list("left_propulsion_sensor"="Tank")
 	},
 /obj/machinery/button/ignition{
 	id = "left_prop_chamber";
@@ -81139,7 +81134,7 @@
 	input_tag = "tox_in";
 	name = "Toxin Supply Control";
 	output_tag = "tox_out";
-	sensors = list("tox_sensor" = "Tank")
+	sensors = list("tox_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/propulsion/left)
@@ -81358,7 +81353,7 @@
 	input_tag = "tox_in";
 	name = "Toxin Supply Control";
 	output_tag = "tox_out";
-	sensors = list("tox_sensor" = "Tank")
+	sensors = list("tox_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/propulsion/right)
@@ -81515,7 +81510,7 @@
 	input_tag = "right_propulsion_in";
 	name = "Right Propulsion Control";
 	output_tag = "right_propulsion_out";
-	sensors = list("right_propulsion_sensor" = "Tank")
+	sensors = list("right_propulsion_sensor"="Tank")
 	},
 /obj/machinery/button/ignition{
 	id = "right_prop_chamber";
@@ -81640,7 +81635,7 @@
 	input_tag = "o2_in";
 	name = "Oxygen Supply Control";
 	output_tag = "o2_out";
-	sensors = list("o2_sensor" = "Tank")
+	sensors = list("o2_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/propulsion/left)
@@ -81670,7 +81665,7 @@
 	input_tag = "o2_in";
 	name = "Oxygen Supply Control";
 	output_tag = "o2_out";
-	sensors = list("o2_sensor" = "Tank")
+	sensors = list("o2_sensor"="Tank")
 	},
 /turf/simulated/floor/tiled/steel/gray_platform,
 /area/eris/engineering/propulsion/right)
@@ -83492,15 +83487,17 @@
 /turf/simulated/floor/tiled/techmaint,
 /area/eris/maintenance/section4deck2port)
 "dRS" = (
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "West APC";
-	pixel_x = -28
+/obj/structure/table/woodentable,
+/obj/item/gun/projectile/shotgun/doublebarrel,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
 	},
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
+/obj/item/reagent_containers/bonsai{
+	pixel_x = 8;
+	pixel_y = 16
 	},
+/obj/structure/table/woodentable,
+/obj/item/paper_bin,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/barbackroom)
 "dRT" = (
@@ -85781,7 +85778,6 @@
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/research)
 "dXM" = (
-/obj/structure/table/bar_special,
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
@@ -85791,6 +85787,7 @@
 	name = "West APC";
 	pixel_x = -28
 	},
+/obj/machinery/vending/boozeomat,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
 "dXN" = (
@@ -85821,18 +85818,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/eris/crew_quarters/bar)
 "dXP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4;
-	icon_state = "pipe-c"
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
@@ -85841,7 +85829,6 @@
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/eris/crew_quarters/bar)
 "dXQ" = (
-/obj/structure/table/bar_special,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -85850,35 +85837,36 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/item/oddity/instructional/common/bio/aid,
-/turf/simulated/floor/tiled/steel/bar_light,
+/turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/crew_quarters/bar)
 "dXR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/steel/bar_dance,
+/obj/item/stool/custom/bar_special,
+/obj/structure/disposalpipe/segment{
+	dir = 4;
+	icon_state = "pipe-c"
+	},
+/turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/crew_quarters/bar)
 "dXS" = (
-/obj/structure/table/bar_special,
-/obj/structure/table/bar_special,
-/turf/simulated/floor/tiled/steel/bar_light,
-/area/eris/crew_quarters/bar)
-"dXT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/closet/chefcloset,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/crew_quarters/barbackroom)
+"dXT" = (
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/table/bar_special,
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/eris/crew_quarters/bar)
 "dXU" = (
@@ -89354,17 +89342,10 @@
 /turf/simulated/floor/wood,
 /area/eris/maintenance/section2deck2port)
 "egl" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/table/bar_special,
-/obj/structure/table/bar_special,
-/obj/item/storage/fancy/cigarettes,
-/turf/simulated/floor/tiled/steel/bar_light,
-/area/eris/crew_quarters/bar)
+/obj/machinery/door/firedoor,
+/obj/effect/window_lwall_spawn/smartspawn,
+/turf/simulated/floor/plating,
+/area/eris/crew_quarters/kitchen)
 "egm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_research{
@@ -92037,6 +92018,10 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
+/obj/machinery/light_switch{
+	pixel_x = -23;
+	pixel_y = 13
+	},
 /turf/simulated/floor/tiled/white,
 /area/eris/rnd/xenobiology/xenoflora)
 "emY" = (
@@ -93090,27 +93075,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/structure/closet/crate,
-/obj/item/storage/box/donkpockets,
-/obj/item/storage/box/donkpockets,
-/obj/item/storage/box/donkpockets,
-/obj/item/storage/box/donkpockets,
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/storage/box/donkpockets{
-	pixel_x = 3;
-	pixel_y = 3
-	},
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/cafe,
 /area/eris/crew_quarters/kitchen)
 "epI" = (
@@ -94530,8 +94495,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/vending/boozeomat/public,
-/turf/simulated/floor/tiled/steel/bar_dance,
+/obj/structure/bed/chair/sofa/black/left,
+/turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/bar)
 "esO" = (
 /obj/structure/disposalpipe/segment{
@@ -94579,13 +94544,8 @@
 /area/eris/engineering/gravity_generator)
 "esS" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/defibcabinet{
-	pixel_y = 32
-	},
-/turf/simulated/floor/tiled/steel/bar_dance,
+/obj/item/stool/custom/bar_special,
+/turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/crew_quarters/bar)
 "esT" = (
 /obj/structure/disposalpipe/segment{
@@ -94618,7 +94578,7 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/turf/simulated/floor/tiled/steel/bar_dance,
+/turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/crew_quarters/bar)
 "esX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -94647,11 +94607,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/steel/bar_dance,
 /area/eris/crew_quarters/bar)
 "etc" = (
@@ -94661,8 +94616,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/item/stool/custom/bar_special,
-/turf/simulated/floor/tiled/steel/bar_dance,
+/turf/simulated/floor/tiled/white/bluecorner,
 /area/eris/crew_quarters/bar)
 "etd" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -94713,10 +94667,10 @@
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/hydroponics)
 "eti" = (
-/obj/structure/table/bar_special,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/vending/dinnerware,
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
 "etj" = (
@@ -94752,8 +94706,11 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/item/stool/custom/bar_special,
-/turf/simulated/floor/tiled/steel/bar_dance,
+/obj/machinery/disposal,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/crew_quarters/bar)
 "etn" = (
 /obj/structure/bed/chair/office/light{
@@ -94783,9 +94740,10 @@
 /turf/simulated/floor/tiled/cafe,
 /area/eris/crew_quarters/kitchen)
 "etr" = (
-/obj/machinery/light/small,
-/obj/structure/table/bar_special,
-/turf/simulated/floor/tiled/steel/bar_dance,
+/obj/structure/bed/chair/sofa/black/right{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/bar)
 "ets" = (
 /obj/structure/multiz/stairs/enter{
@@ -94827,11 +94785,54 @@
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/structure/closet/crate,
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/donkpockets{
+	pixel_x = 3;
+	pixel_y = 3
+	},
 /turf/simulated/floor/tiled/white/brown_platform,
 /area/eris/crew_quarters/kitchen)
 "etw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/cafe,
 /area/eris/crew_quarters/kitchen)
 "etx" = (
@@ -95851,18 +95852,11 @@
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/barbackroom)
 "evT" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/machinery/firealarm{
-	pixel_y = 28
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/item/modular_computer/console/preset/civilian,
-/turf/simulated/floor/carpet/sblucarpet,
-/area/eris/crew_quarters/barbackroom)
+/obj/structure/table/bar_special,
+/obj/item/oddity/instructional/common/vig/ross,
+/obj/item/oddity/instructional/common/tgh/soldier,
+/turf/simulated/floor/tiled/white/bluecorner,
+/area/eris/crew_quarters/bar)
 "evU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -95984,10 +95978,13 @@
 /turf/simulated/floor/tiled/steel,
 /area/eris/quartermaster/office)
 "ewf" = (
-/obj/machinery/camera/network/third_section{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/window/eastleft{
+	dir = 1;
+	req_access = list(28)
 	},
-/turf/simulated/floor/tiled/steel/bar_light,
+/turf/simulated/floor/tiled/steel/bar_flat,
 /area/eris/crew_quarters/bar)
 "ewg" = (
 /obj/structure/bed/chair{
@@ -96097,7 +96094,7 @@
 	},
 /obj/structure/table/bar_special,
 /obj/machinery/cash_register{
-	dir = 1
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel/bar_light,
 /area/eris/crew_quarters/bar)
@@ -96148,10 +96145,6 @@
 /turf/simulated/floor/tiled/steel/cargo,
 /area/eris/quartermaster/hangarsupply)
 "ewv" = (
-/obj/machinery/disposal,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
 /obj/machinery/camera/network/third_section{
 	dir = 1
 	},
@@ -98502,7 +98495,7 @@
 /obj/machinery/camera/network/third_section{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/steel/bar_light,
+/turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/crew_quarters/bar)
 "eBy" = (
 /obj/effect/decal/cleanable/dirt,
@@ -100281,7 +100274,7 @@
 	frequency = 1443;
 	level = 3;
 	name = "Distribution and Waste Monitor";
-	sensors = list("mair_in_meter" = "Mixed Air In", "air_sensor" = "Mixed Air Supply Tank", "mair_out_meter" = "Mixed Air Out", "dloop_atm_meter" = "Distribution Loop", "wloop_atm_meter" = "Engine Waste")
+	sensors = list("mair_in_meter"="Mixed Air In","air_sensor"="Mixed Air Supply Tank","mair_out_meter"="Mixed Air Out","dloop_atm_meter"="Distribution Loop","wloop_atm_meter"="Engine Waste")
 	},
 /obj/machinery/light{
 	dir = 8
@@ -100440,6 +100433,23 @@
 /obj/item/tool/minihoe,
 /turf/simulated/floor/tiled/dark,
 /area/eris/security/prison)
+"eGW" = (
+/obj/structure/table/woodentable,
+/obj/item/book/manual/barman_recipes,
+/obj/item/flame/lighter/zippo,
+/obj/item/reagent_containers/food/drinks/flask/vacuumflask,
+/obj/item/device/eftpos,
+/obj/structure/cable/green{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/apc{
+	dir = 8;
+	name = "West APC";
+	pixel_x = -28
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/crew_quarters/barbackroom)
 "eHb" = (
 /obj/machinery/firealarm{
 	pixel_y = 28
@@ -101016,7 +101026,7 @@
 	})
 "eZk" = (
 /obj/machinery/slotmachine,
-/turf/simulated/floor/tiled/steel/bar_light,
+/turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/crew_quarters/bar)
 "eZG" = (
 /obj/structure/railing,
@@ -101116,6 +101126,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/eris/command/meeting_room)
+"ffO" = (
+/obj/structure/bed/chair/sofa/black/right,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/crew_quarters/bar)
 "fgo" = (
 /obj/structure/multiz/ladder,
 /turf/simulated/floor/wood,
@@ -102011,6 +102025,29 @@
 /obj/item/clothing/gloves/latex,
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/eris/rnd/anomal)
+"gAG" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock{
+	name = "Club Office";
+	req_access = list(28)
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/bluegrid,
+/area/eris/crew_quarters/barbackroom)
 "gBc" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -102480,11 +102517,16 @@
 /obj/structure/cyberplant,
 /turf/simulated/floor/wood,
 /area/eris/maintenance/section4deck4central)
-"hnS" = (
-/obj/machinery/light/small,
-/obj/structure/closet/secure_closet/personal,
+"hnz" = (
+/obj/structure/table/woodentable,
+/obj/item/storage/fancy/cigarettes,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/kitchen)
+"hnS" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/eris/crew_quarters/bar)
 "hoL" = (
 /obj/machinery/camera/network/fist_section{
 	dir = 8
@@ -102969,6 +103011,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck2port)
+"hTs" = (
+/obj/structure/cyberplant,
+/turf/simulated/floor/tiled/white/bluecorner,
+/area/eris/crew_quarters/bar)
 "hTU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
@@ -103046,6 +103092,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /turf/simulated/floor/tiled/cafe,
 /area/eris/crew_quarters/kitchen)
@@ -104273,6 +104324,9 @@
 	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/occulus/medical/storage)
+"jPO" = (
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/crew_quarters/bar)
 "jQb" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4
@@ -104572,6 +104626,13 @@
 	},
 /turf/simulated/floor/wood,
 /area/eris/crew_quarters/fitness)
+"kqG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/crew_quarters/kitchen)
 "kst" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/gloves,
@@ -104698,6 +104759,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/kitchen)
 "kDs" = (
@@ -104726,12 +104790,17 @@
 /area/eris/engineering/construction)
 "kDP" = (
 /obj/machinery/door/airlock{
-	name = "Kitchen Freezer";
+	name = "Club Backrooms";
 	req_access = list(28)
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/cafe,
 /area/eris/crew_quarters/kitchen)
 "kDW" = (
@@ -104750,6 +104819,12 @@
 /obj/structure/catwalk,
 /turf/simulated/open,
 /area/eris/engineering/atmos)
+"kFa" = (
+/obj/structure/bed/chair/sofa/black/left{
+	dir = 1
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/crew_quarters/bar)
 "kFB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -104835,7 +104910,7 @@
 /area/eris/maintenance/section2deck2port)
 "kJA" = (
 /obj/item/stool/custom/bar_special,
-/turf/simulated/floor/tiled/steel/bar_light,
+/turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/crew_quarters/bar)
 "kLq" = (
 /obj/structure/table/standard,
@@ -104956,6 +105031,15 @@
 "kWP" = (
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/space)
+"kXg" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/crew_quarters/kitchen)
 "kXS" = (
 /obj/structure/railing{
 	dir = 1
@@ -105157,6 +105241,20 @@
 /obj/structure/reagent_dispensers/coolanttank,
 /turf/simulated/floor/tiled/dark,
 /area/eris/rnd/anomal)
+"lnp" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/crew_quarters/barbackroom)
 "lnT" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/floor_decal/rust,
@@ -105233,6 +105331,14 @@
 /obj/structure/catwalk,
 /turf/space,
 /area/space)
+"lwd" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock{
+	name = "Kitchen";
+	req_access = list(28)
+	},
+/turf/simulated/floor/tiled/white/cargo,
+/area/eris/crew_quarters/kitchen)
 "lwl" = (
 /obj/machinery/vending/snack,
 /turf/simulated/floor/tiled/dark/techfloor,
@@ -106295,6 +106401,10 @@
 /obj/machinery/atmospherics/unary/heat_exchanger,
 /turf/simulated/floor/tiled/steel/danger,
 /area/eris/engineering/engine_room)
+"mNe" = (
+/obj/structure/table/bar_special,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/crew_quarters/bar)
 "mNs" = (
 /obj/structure/multiz/ladder/up,
 /obj/structure/catwalk,
@@ -106500,6 +106610,17 @@
 "mZq" = (
 /turf/simulated/open,
 /area/eris/hallway/main/section3)
+"mZr" = (
+/obj/machinery/firealarm{
+	pixel_y = 28
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/item/modular_computer/console/preset/civilian,
+/obj/machinery/atmospherics/unary/vent_scrubber/on,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/crew_quarters/barbackroom)
 "mZL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/catwalk,
@@ -106661,7 +106782,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Acolyte Equipment";
-	req_access = list(35, 26)
+	req_access = list(35,26)
 	},
 /turf/simulated/floor/tiled/dark/gray_platform,
 /area/eris/neotheology/chapel)
@@ -107717,6 +107838,20 @@
 	},
 /turf/simulated/floor/tiled/dark/golden,
 /area/eris/crew_quarters/janitor)
+"oDn" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/crew_quarters/barbackroom)
 "oDx" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -108027,10 +108162,6 @@
 /obj/machinery/light_switch{
 	pixel_y = 28
 	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/table/rack,
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/kitchen)
 "oXG" = (
@@ -108144,6 +108275,17 @@
 "pbX" = (
 /turf/simulated/floor/tiled/steel/brown_perforated,
 /area/eris/quartermaster/storage)
+"pbZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel/bar_dance,
+/area/eris/crew_quarters/bar)
 "pcp" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -108192,9 +108334,7 @@
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/medical/reception)
 "pdH" = (
-/obj/structure/table/bar_special,
-/obj/item/paper_bin,
-/turf/simulated/floor/tiled/steel/bar_light,
+/turf/simulated/floor/tiled/steel/bluecorner,
 /area/eris/crew_quarters/bar)
 "pfl" = (
 /obj/structure/disposalpipe/segment,
@@ -108339,6 +108479,9 @@
 /obj/structure/bed/padded,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/item/bedsheet/blue,
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/kitchen)
 "ptx" = (
@@ -109535,6 +109678,10 @@
 	},
 /turf/simulated/floor/tiled/steel/techfloor,
 /area/eris/engineering/engine_room)
+"rhV" = (
+/obj/structure/cyberplant,
+/turf/simulated/floor/tiled/steel/bluecorner,
+/area/eris/crew_quarters/bar)
 "rir" = (
 /obj/structure/lattice,
 /obj/structure/railing{
@@ -109646,6 +109793,10 @@
 	},
 /turf/simulated/open,
 /area/eris/maintenance/section2deck1starboard)
+"rqD" = (
+/obj/structure/bed/chair/sofa/black/left,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/crew_quarters/bar)
 "rqI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -110550,6 +110701,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/simulated/floor/tiled/white,
 /area/occulus/medical/trauma)
+"sKJ" = (
+/obj/structure/bed/chair/sofa/black/right{
+	name = "Taur Couch"
+	},
+/turf/simulated/floor/tiled/steel/bluecorner,
+/area/eris/crew_quarters/bar)
 "sKZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
@@ -111059,6 +111216,12 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/cargo,
 /area/eris/medical/medbreak)
+"tpg" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/crew_quarters/kitchen)
 "tpC" = (
 /obj/structure/cable/green{
 	d2 = 4;
@@ -111240,10 +111403,17 @@
 /turf/space,
 /area/space)
 "tyk" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/closet/chefcloset,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/kitchen)
 "tyF" = (
@@ -111567,13 +111737,16 @@
 /turf/simulated/floor/plating/under,
 /area/eris/maintenance/section2deck3port)
 "tZH" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/kitchen)
@@ -111730,6 +111903,12 @@
 /area/eris/crew_quarters/library{
 	name = "\improper Cafe"
 	})
+"ukw" = (
+/obj/structure/defibcabinet{
+	pixel_y = 32
+	},
+/turf/simulated/floor/tiled/steel/bluecorner,
+/area/eris/crew_quarters/bar)
 "ukG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
 /turf/simulated/floor/plating/under,
@@ -111882,7 +112061,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass,
 /turf/simulated/floor/bluegrid,
-/area/eris/hallway/main/section3)
+/area/eris/crew_quarters/bar)
 "uxK" = (
 /obj/structure/bed/padded,
 /obj/item/bedsheet/blue,
@@ -111931,7 +112110,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock{
 	name = "Acolyte Equipment";
-	req_access = list(35, 26)
+	req_access = list(35,26)
 	},
 /turf/simulated/floor/tiled/dark/cargo,
 /area/eris/neotheology/chapel)
@@ -112148,6 +112327,12 @@
 /obj/spawner/scrap/dense,
 /turf/simulated/floor/carpet/bcarpet,
 /area/eris/maintenance/section4deck4central)
+"uWH" = (
+/obj/structure/bed/chair/office/dark{
+	dir = 4
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/crew_quarters/kitchen)
 "uWR" = (
 /obj/structure/catwalk,
 /obj/structure/lattice,
@@ -112248,17 +112433,8 @@
 /turf/simulated/floor/tiled/steel/techfloor_grid,
 /area/eris/maintenance/section2deck1port)
 "veS" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/item/stool/custom/bar_special,
-/turf/simulated/floor/tiled/steel/bar_dance,
-/area/eris/crew_quarters/bar)
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/crew_quarters/kitchen)
 "vfg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -112816,6 +112992,10 @@
 /area/eris/crew_quarters/library{
 	name = "\improper Cafe"
 	})
+"wcl" = (
+/obj/structure/table/woodentable,
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/crew_quarters/kitchen)
 "wcr" = (
 /obj/structure/bed/chair/office/light,
 /obj/landmark/join/start/chemist,
@@ -113761,10 +113941,13 @@
 /turf/simulated/open,
 /area/eris/quartermaster/misc)
 "xzb" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/carpet/sblucarpet,
 /area/eris/crew_quarters/kitchen)
 "xzP" = (
@@ -114131,6 +114314,13 @@
 /obj/effect/window_lwall_spawn/smartspawn,
 /turf/simulated/floor/plating,
 /area/eris/maintenance/section2deck1starboard)
+"yaz" = (
+/obj/structure/table/rack,
+/obj/machinery/alarm{
+	pixel_y = 26
+	},
+/turf/simulated/floor/carpet/sblucarpet,
+/area/eris/crew_quarters/barbackroom)
 "yaG" = (
 /obj/structure/bed/chair/sofa/red/right,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -209964,10 +210154,10 @@ ewC
 cBU
 cCk
 cAS
-aaa
-abF
-abF
-abF
+ctD
+ctD
+ctD
+ctD
 abF
 abF
 abF
@@ -210166,10 +210356,10 @@ ewB
 cBV
 etv
 cAS
-aaa
-abF
-abF
-abF
+dRS
+eGW
+evS
+cyT
 abF
 abF
 abF
@@ -210368,10 +210558,10 @@ ewD
 cBW
 cCm
 cAS
-aaa
-abF
-abF
-abF
+mZr
+esM
+oDn
+cyT
 abF
 abF
 abF
@@ -210571,9 +210761,9 @@ cDH
 egG
 cAS
 cAS
-abF
-abF
-abF
+dXS
+lnp
+cyT
 abF
 abF
 abF
@@ -210773,12 +210963,12 @@ cCf
 dNS
 cCx
 wja
-abF
-abF
-abF
-abF
-abF
-abF
+yaz
+lnp
+ctD
+cAS
+cAS
+cAS
 abF
 abF
 abF
@@ -210975,11 +211165,11 @@ cCg
 dYS
 esC
 cAS
-cAS
-cAS
-cAS
-cAS
-cAS
+ctD
+gAG
+ctD
+rJf
+wHO
 cAS
 abF
 abF
@@ -211180,8 +211370,8 @@ cAS
 oXf
 tyk
 cAS
-rJf
-wHO
+kXg
+nvd
 cAS
 abF
 abF
@@ -211376,14 +211566,14 @@ vgH
 cAS
 etq
 iar
-etw
+cxi
 etw
 kDP
 tZH
 xzb
 cBO
 hNp
-kCH
+kqG
 cAS
 abF
 abF
@@ -211564,10 +211754,10 @@ tjU
 ctk
 sAL
 tjU
-ctD
-ctD
-ctD
-ctD
+anJ
+anJ
+anJ
+anJ
 anJ
 anJ
 anJ
@@ -211587,7 +211777,7 @@ cAS
 cAS
 cAS
 cAS
-abF
+cAS
 abF
 abF
 cKp
@@ -211766,18 +211956,18 @@ dGn
 dGU
 dJp
 dOc
-cxA
-evS
-dRS
-cxA
-cxi
-cyT
+aqa
+cuJ
+cvt
+aqa
+ewh
+cjQ
 czt
 bZh
 dXM
 eti
-cjQ
-egG
+cyU
+egl
 ewE
 cCy
 cBr
@@ -211785,11 +211975,11 @@ pVU
 cAS
 ptg
 xlA
+veS
+veS
+veS
 cos
-cAS
-abF
-abF
-abF
+egl
 abF
 abF
 cKp
@@ -211968,13 +212158,13 @@ dGn
 dGU
 dJp
 dOc
-cxA
+aqV
 evT
-esM
+cvs
 cxS
-dTJ
-dTJ
-dTJ
+ewf
+hnS
+hnS
 etb
 dXO
 dTJ
@@ -211987,11 +212177,11 @@ epZ
 cAS
 uOJ
 nvd
-hnS
-cAS
-abF
-abF
-abF
+uWH
+uWH
+veS
+cos
+egl
 abF
 abF
 cwU
@@ -212170,18 +212360,18 @@ dGn
 dGU
 dJp
 dOc
-cxA
+aqV
 cuv
 cvs
-cxA
-ewh
+sKJ
+cDj
 cil
 cil
 czL
 dXP
 cAu
 ewv
-egG
+egl
 eiJ
 cCi
 dZm
@@ -212189,11 +212379,11 @@ epH
 cAS
 orX
 kCH
+hnz
+wcl
+tpg
 cos
-cAS
-abF
-abF
-abF
+egl
 abF
 abF
 cwU
@@ -212372,18 +212562,18 @@ dGn
 dGU
 dJp
 dOc
-cxA
-cxA
-cxA
-cxA
+aqV
 cxm
-pdH
-cil
-czL
+cvs
+cxA
+cDj
+cjQ
+cCO
+cyV
 dXT
 ewq
 uMe
-egG
+egl
 cBC
 cBr
 elW
@@ -212393,9 +212583,9 @@ cAS
 cAS
 cAS
 cAS
-abF
-abF
-abF
+cAS
+cAS
+cAS
 abF
 abF
 abF
@@ -212575,20 +212765,20 @@ ctl
 cwi
 anJ
 aqa
-cuJ
-cvt
-aqa
+cnb
+cvs
+rhV
 esS
-cyU
+czA
 czA
 czM
 dXR
 cAw
 etm
-egG
-egG
-cDI
-egG
+egl
+egl
+lwd
+egl
 cAS
 cAS
 abF
@@ -212778,19 +212968,19 @@ dJu
 anJ
 eZk
 kJA
-ctE
-ewf
-cil
-cjQ
-dXS
-egl
+cvs
+cvs
+cvs
+cvs
+cvs
+etc
 dXQ
-cjQ
-cyV
-ctE
-ctE
-ctE
-ctE
+cvs
+cvs
+cvs
+cvs
+pdH
+pdH
 anJ
 aaa
 aCM
@@ -212978,20 +213168,20 @@ bsS
 eeB
 tyF
 anJ
-ctE
-ctE
-ctE
-ctE
-cil
-cyV
-cyV
+ukw
+pdH
+cvs
+cvs
+cvs
+cvs
+cvs
 etc
-veS
-cyV
-cil
-ctE
-ctE
-ctE
+dXQ
+cvs
+cvs
+cvs
+cvs
+pdH
 eBx
 anJ
 aaa
@@ -213182,17 +213372,17 @@ dJy
 anJ
 ctF
 aqV
-cil
-cil
-cil
-cil
-cil
-czL
-dXT
-cil
-cil
-cil
-cil
+jPO
+jPO
+jPO
+cvs
+cvs
+etc
+dXQ
+cvs
+jPO
+jPO
+jPO
 aqV
 ctF
 anJ
@@ -213384,17 +213574,17 @@ evC
 anJ
 ctG
 aqV
-cil
-cCq
-cCq
-cil
-cil
+ffO
+mNe
+kFa
+cvs
+cvs
 esW
-dXT
-cil
-cCq
-cCq
-cCq
+dXQ
+cvs
+ffO
+mNe
+kFa
 aqV
 ctG
 anJ
@@ -213587,15 +213777,15 @@ anJ
 anJ
 anJ
 esN
-cCO
-cCO
-cld
-cil
-czL
-dXT
-cld
-cCO
-cCO
+mNe
+etr
+hTs
+cvs
+etc
+dXQ
+hTs
+rqD
+mNe
 etr
 anJ
 anJ
@@ -213792,9 +213982,9 @@ dRW
 dRW
 dRW
 exn
-ctE
-czR
-dXW
+cil
+czL
+pbZ
 dYh
 dRW
 dRW


### PR DESCRIPTION
Remodel of the club, backroom and storefront



## About The Pull Request

Made changes to the Club's upper floor to make more of a dining area, leaving lower floor as a nightclub, also expanded the backrooms with the office being in the back
![image](https://user-images.githubusercontent.com/7069464/201497061-89d1a7bc-ce52-4783-93bd-f1598ab715aa.png)
![image](https://user-images.githubusercontent.com/7069464/201497076-9404e357-14df-4661-aefe-01f61bbbc69e.png)




## Why It's Good For The Game

A large portion of the active club players were requesting a remodel to alleviate eyestrain of the overly BLUE front rooms, as well as having more than a broom closet backroom. 

These changes should make the club feel more like a place where people can relax, while leaving the lower floor for more active relaxation 

## Changelog
```changelog
tweak: Remaped the bar, and bar backrooms
```
