### PR TITLE
Notrip!

### DIFF
--- a/zzzz_modular_occulus/code/game/turfs/flooring/flooring.dm
+++ b/zzzz_modular_occulus/code/game/turfs/flooring/flooring.dm
@@ -9,6 +9,8 @@
 	//BSTs need this or they generate tons of soundspam while flying through the ship
 	if(!ishuman(M)|| M.incorporeal_move || !has_gravity(get_turf(M)) || M.stats.getPerk(PERK_NOTRIP)) //This should check if the person has the perk that makes you not trip on underplating
 		return
+	if(M.check_shoegrip()) // If they have NOSLIP shoes or magboots, they don't trip.
+		return
 	if(MOVING_QUICKLY(M))//Don't knock them over if they're an engineer?
 		if(prob(5))
 			M.adjustBruteLoss(5)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changes the trip check for underplating to check for shoes with NOSLIP (ie custodial galoshes, noslip'd shoes, etc) or magboots.
If found, STOP! THE! SLIP!

## Why It's Good For The Game

no more clonkclonkclonkclonk

## Changelog
```changelog
tweak: If you are wearing shoes with NOSLIP (or magboots), you will no longer trip on underplating.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
