### PR TITLE
Ticks railgun file

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2841,6 +2841,7 @@
 #include "zzzz_modular_occulus\code\datums\craft\recipes\furniture.dm"
 #include "zzzz_modular_occulus\code\datums\craft\recipes\guns.dm"
 #include "zzzz_modular_occulus\code\datums\craft\recipes\machinery.dm"
+#include "zzzz_modular_occulus\code\datums\craft\recipes\misc.dm"
 #include "zzzz_modular_occulus\code\datums\craft\recipes\tools.dm"
 #include "zzzz_modular_occulus\code\datums\craft\recipes\weapon.dm"
 #include "zzzz_modular_occulus\code\datums\language\merc.dm"


### PR DESCRIPTION
## About The Pull Request

ticks file for crafting ammo used in railguns

## Why It's Good For The Game

makes you able to make ammo

## Changelog
```changelog
fix: Refined scrap can now be crafted.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
