### PR TITLE
Roach Dead Sprite Fix

### DIFF
--- a/zzzz_modular_occulus/code/modules/mob/living/carbon/superior_animal/roach/roachlingmarked.dm
+++ b/zzzz_modular_occulus/code/modules/mob/living/carbon/superior_animal/roach/roachlingmarked.dm
@@ -2,3 +2,4 @@
 	name = "Painted Roachling"
 	desc = "A tiny cockroach. It never stays still for long. Despite being freshly hatched, it still seems to have a bright pink paint covering its abdomen."
 	icon_state = "roachlingmarked" // Literally just a standard roachling, just with the painted butt from the mark recapture anomaly. 1 in 50 chance to spawn from a hatched egg.
+	icon_dead = "roachling_dead"

--- a/zzzz_modular_occulus/code/modules/mob/living/carbon/superior_animal/roach/roachmarked.dm
+++ b/zzzz_modular_occulus/code/modules/mob/living/carbon/superior_animal/roach/roachmarked.dm
@@ -2,4 +2,5 @@
     name = "Painted Kampfer Roach"
     desc = "A monstrous, dog-sized cockroach. This one seems to have some kind of marking on its abdomen."
     icon_state = "roachmarked"
+    icon_dead = "roach_dead"
     rarity_value = 50 // Rather rare, appeared as an unintended side effect to an experiment. Bog-standard kampfer roach, just with a pink butt


### PR DESCRIPTION
## About The Pull Request

Fixes missing code on the two marked roach sprites which meant they didn't actually have a dead sprite.

## Why It's Good For The Game

Generally, roaches shouldn't turn invisible when they're killed.

## Changelog
```changelog
fix: painted roaches now stay visible when they die
```

