### PR TITLE
Revert "Fixes Zoom Function"

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -213,7 +213,7 @@
 			else
 				client.perspective = EYE_PERSPECTIVE
 				client.eye = loc
-		usr.client.view = world.view  // Reset view range if it has been altered
+		client.view = world.view  // Reset view range if it has been altered
 
 	if(hud_used)
 		hud_used.updatePlaneMasters(src)


### PR DESCRIPTION
Reverts Occulus-Server/Occulus-Eris#936

reset_view() isn't called by a `usr` -- a client is passed to the proc and everything interesting happens to the client.
This was causing MANY runtimes. (25 minutes into a round, ~4500 runtimes.)

Stacktrace for convenience: 
```
[23:14:54] Runtime in mob.dm,216: Cannot read null.client
   proc name: reset view (/mob/proc/reset_view)
   src: (/mob/living/carbon/human)
   src.loc: the floor (80,65,5) (/turf/simulated/floor/tiled/steel/techfloor_grid)
   call stack:
   (/mob/living/carbon/human): reset view(null, 0)
   (/mob/living/carbon/human): reset view(null, 0)
   (/mob/living/carbon/human): handle vision()
   (/mob/living/carbon/human): handle regular hud updates()
   (/mob/living/carbon/human): handle regular hud updates()
   (/mob/living/carbon/human): Life Check()
   (/mob/living/carbon/human): Life(20, 0, Mobs (/datum/controller/subsystem/processing/mobs))
   (/mob/living/carbon/human): Life(20, 0, Mobs (/datum/controller/subsystem/processing/mobs))
   (/mob/living/carbon/human): Life(20, 0, Mobs (/datum/controller/subsystem/processing/mobs))
   Mobs (/datum/controller/subsystem/processing/mobs): fire(1)
   Mobs (/datum/controller/subsystem/processing/mobs): ignite(1)
   Master (/datum/controller/master): RunQueue()
   Master (/datum/controller/master): Loop()
   Master (/datum/controller/master): StartProcessing(0)
   ```