### PR TITLE
No law zero'd drones

### DIFF
--- a/code/game/antagonist/station/rogue_ai.dm
+++ b/code/game/antagonist/station/rogue_ai.dm
@@ -12,7 +12,7 @@
 	var/mob/living/silicon/ai/master = owner.current
 
 	for(var/mob/living/silicon/robot/R in GLOB.player_list)
-		if(R.connected_ai || R.isdrone())
+		if(R.connected_ai || isdrone(R))
 			continue
 		R.connect_to_ai(master)
 		R.lawupdate = TRUE

--- a/code/game/antagonist/station/rogue_ai.dm
+++ b/code/game/antagonist/station/rogue_ai.dm
@@ -12,7 +12,7 @@
 	var/mob/living/silicon/ai/master = owner.current
 
 	for(var/mob/living/silicon/robot/R in GLOB.player_list)
-		if(R.connected_ai)
+		if(R.connected_ai || R.isdrone())
 			continue
 		R.connect_to_ai(master)
 		R.lawupdate = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Maintenence drones shouldn't be forcefully law zero'd when an AI becomes malf.
The only time they should get those laws is when emagged.

## Changelog
```changelog
fix: Maintenence drones will no longer be force synced to a AI if it becomes an antag.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
