### PR TITLE
Vote windows will now close properly

### DIFF
--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -19,14 +19,9 @@ SUBSYSTEM_DEF(vote)
 		interface_client(C)
 
 /datum/controller/subsystem/vote/proc/interface_client(client/C)
-// OCCULUS EDIT START - Experimental revert to plain html to attempt to mitigate the whole unable to reliably close window thing
-	C << browse(interface(C),"window=vote;size=500x700;can_close=0;can_resize=0;can_minimize=0")
-/*
-	var/datum/browser/panel = new(C.mob, "Vote","Vote", 500, 650)
+	var/datum/browser/panel = new(C.mob, "Vote", "Vote", 500, 750) //Occulus Edit - Increasing size so it doesn't scroll back up on refresh
 	panel.set_content(interface(C))
 	panel.open()
-*/
-// OCCULUS EDIT END - Experimental revert to plain html to attempt to mitigate the whole unable to reliably close window thing
 
 /datum/controller/subsystem/vote/fire()
 	if(active_vote)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Vote windows now close when you tell them to.
Also rolls back our 'temporary' change to make it use plain HTML.

## Changelog
```changelog
tweak: The vote panel is now styled, instead of plain HTML.
fix: Vote panel will now close when you tell it to.
```