### PR TITLE
Fixed drone death code

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/_drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/_drone.dm
@@ -279,11 +279,11 @@ var/list/mob_hat_cache = list()
 //Standard robots use config for crit, which is somewhat excessive for these guys.
 //Drones killed by damage will gib.
 /mob/living/silicon/robot/drone/handle_regular_status_updates()
-	var/turf/T = get_turf(src)
-	if((!T || health <= -maxHealth) && src.stat != DEAD)
-		timeofdeath = world.time
-		death() //Possibly redundant, having trouble making death() cooperate.
-		gib()
+	//var/turf/T = get_turf(src)
+	if(health <= 0 && src.stat != 2) // Occulus Time! drones should explode properly now
+		timeofdeath = world.time //Occulus fix
+		death() //Oh boy fixes
+		gib() //Still Occulus
 		return
 	..()
 

--- a/code/modules/mob/living/silicon/robot/drone/_drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/_drone.dm
@@ -280,7 +280,7 @@ var/list/mob_hat_cache = list()
 //Drones killed by damage will gib.
 /mob/living/silicon/robot/drone/handle_regular_status_updates()
 	//var/turf/T = get_turf(src)
-	if(health <= 0 && src.stat != 2) // Occulus Time! drones should explode properly now
+	if(health <= 0 && src.stat != DEAD) // Occulus Time! drones should explode properly now
 		timeofdeath = world.time //Occulus fix
 		death() //Oh boy fixes
 		gib() //Still Occulus


### PR DESCRIPTION
Fixes drone death code. It was failing to properly load.
Drones once again gib when they reach 0 health.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Turns out a legitimate feature to have drones gib when they reach 0HP wasn't being called, and drones were instead using borg death/incapacitation rules.
This has been fixed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bugfix, unfortunately
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
fix: drones once again gib at 0 health.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
