### PR TITLE
Makes gun deconstruction yield more materials

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -40,7 +40,7 @@
 	var/rigged = FALSE
 	var/fire_sound_text = "gunshot"
 	var/recoil_buildup = 2 //How quickly recoil builds up
-	var/list/gun_parts = list(/obj/item/part/gun = 1 ,/obj/item/stack/material/steel = 4)
+	var/list/gun_parts = list(/obj/item/part/gun = 3 ,/obj/item/stack/material/steel = 6)
 
 	var/muzzle_flash = 3
 	var/dual_wielding


### PR DESCRIPTION
## About The Pull Request

As the title says, this makes it so that deconstructing firearms with a wrench gives you more to work with

## Why It's Good For The Game

Currently, deconstructing weapons yields very little parts - it's not worthwhile whatsoever, and you're better off keeping whatever dirty, worn down peashooter you found instead of trying to get something better.

## Changelog
```changelog
-Deconstructing a gun can now yield up to 3 gun parts, from 1
-Deconstructing a gun can now yield up to 6 steel, from 4
```
The result from deconstructing 3 guns, character with 15 mechanical skill
![image](https://user-images.githubusercontent.com/51841793/217270554-347b3dc0-504f-468a-a156-4e37191873c4.png)
![image](https://user-images.githubusercontent.com/51841793/217270573-0bc31446-f145-4a20-ba5d-18acad5fae95.png)
![image](https://user-images.githubusercontent.com/51841793/217270607-f8c06d40-6019-4057-9b7e-5fc617177e78.png)
