### PR TITLE
Adjustment to critical APCs

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1225,7 +1225,10 @@ obj/machinery/power/apc/proc/autoset(var/val, var/on)
 /obj/machinery/power/apc/emp_act(severity)
 	// Fail for 8-12 minutes (divided by severity)
 	// Division by 2 is required, because machinery ticks are every two seconds. Without it we would fail for 16-24 minutes.
-	energy_fail(round(rand(240, 360) / severity))
+	if(is_critical)//Occulus Edit
+		energy_fail(round(rand(12, 24) / severity))//Occulus Edit
+	else//Occulus edit
+		energy_fail(round(rand(240, 360) / severity))//Occulus edit
 	if(cell)
 		cell.emp_act(severity+1)
 	update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Significantly reduces cooldowns for emped APCs if they are in critical areas.

## Why It's Good For The Game

Killing the AI should take more than one EMP grenade.
Also makes engineering proper a bit more robust

## Changelog
```changelog
tweak: Critical APCs now have significantly lower short timers.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
