### PR TITLE
More Coin items + Shotgun Ammo Box Disk

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -2830,6 +2830,7 @@
 #include "zzzz_modular_occulus\code\controllers\subsystems\staverbs.dm"
 #include "zzzz_modular_occulus\code\controllers\subsystems\vote.dm"
 #include "zzzz_modular_occulus\code\datums\datacore.dm"
+#include "zzzz_modular_occulus\code\datums\autolathe\ammo.dm"
 #include "zzzz_modular_occulus\code\datums\autolathe\biomatter.dm"
 #include "zzzz_modular_occulus\code\datums\autolathe\circuits.dm"
 #include "zzzz_modular_occulus\code\datums\autolathe\coins.dm"

--- a/zzzz_modular_occulus/code/datums/autolathe/ammo.dm
+++ b/zzzz_modular_occulus/code/datums/autolathe/ammo.dm
@@ -1,0 +1,23 @@
+/datum/design/autolathe/ammo/shotgunbox
+	name = "shotgun shells (slug)"
+	build_path = /obj/item/ammo_magazine/ammobox/shotgun
+
+/datum/design/autolathe/ammo/shotgunbox_buckshot
+	name = "shotgun shells (buckshot)"
+	build_path = /obj/item/ammo_magazine/ammobox/shotgun/buckshot
+
+/datum/design/autolathe/ammo/shotgunbox_beanbag
+	name = "shotgun shells (beanbag)"
+	build_path = /obj/item/ammo_magazine/ammobox/shotgun/beanbags
+
+/datum/design/autolathe/ammo/shotgunbox_rubbershot
+	name = "shotgun shells (rubbershot)"
+	build_path = /obj/item/ammo_magazine/ammobox/shotgun/rubbershot
+
+/datum/design/autolathe/ammo/shotgunbox_flash
+	name = "shotgun shells (flash)"
+	build_path = /obj/item/ammo_magazine/ammobox/shotgun/flashshells
+
+/datum/design/autolathe/ammo/shotgunbox_blanks
+	name = "shotgun shells (blank)"
+	build_path = /obj/item/ammo_magazine/ammobox/shotgun/blanks

--- a/zzzz_modular_occulus/code/game/machinery/vending.dm
+++ b/zzzz_modular_occulus/code/game/machinery/vending.dm
@@ -48,11 +48,12 @@
 
 	contraband = list(/obj/item/reagent_containers/food/snacks/wok = 8, /obj/item/storage/ration_pack = 1)
 
-	premium = list(/obj/item/reagent_containers/food/snacks/syndicake = 2)
+	premium = list(/obj/item/reagent_containers/food/snacks/syndicake = 2, /obj/item/storage/box/donut = 1)
 
 	prices = list(/obj/item/reagent_containers/food/snacks/shokoloud = 60,/obj/item/reagent_containers/food/drinks/dry_ramen = 80,/obj/item/reagent_containers/food/snacks/chips = 70,
 					/obj/item/reagent_containers/food/snacks/sosjerky = 75,/obj/item/reagent_containers/food/snacks/no_raisin = 80,/obj/item/reagent_containers/food/snacks/spacetwinkie = 60,
 					/obj/item/reagent_containers/food/snacks/cheesiehonkers = 90, /obj/item/reagent_containers/food/snacks/tastybread = 100,
+					/obj/item/reagent_containers/food/snacks/syndicake = 30, /obj/item/storage/box/donut = 100,
 					/obj/item/reagent_containers/food/snacks/wok = 80, /obj/item/storage/ration_pack = 500)
 
 /obj/machinery/vending/cola
@@ -305,6 +306,13 @@
 
 /obj/machinery/vending/engineering
 	vendor_department = DEPARTMENT_ENGINEERING
+	premium = list(
+		/obj/item/storage/hcases/parts = 3,
+		/obj/item/storage/hcases/engi = 3,
+		/obj/item/storage/hcases/ammo = 3,
+		/obj/item/storage/hcases/med = 3,
+		/obj/item/weldpack/canister = 3
+	)
 
 /obj/machinery/vending/tool
 	vendor_department = DEPARTMENT_ENGINEERING
@@ -354,6 +362,35 @@
 					/obj/item/cell/medium/hyper = 1000,
 					/obj/item/cell/small/hyper = 500
 					)
+
+/obj/machinery/vending/printomat
+	premium = list(/obj/item/computer_hardware/hard_drive/portable/design/ammo_boxes_rifle = 3,
+					/obj/item/computer_hardware/hard_drive/portable/design/ammo_boxes_shotgun = 3,
+					/obj/item/computer_hardware/hard_drive/portable/design/ammo_boxes_smallarms = 3,
+					/obj/item/computer_hardware/hard_drive/portable/advanced = 10,)
+	prices = list(/obj/item/computer_hardware/hard_drive/portable = 50,
+					/obj/item/storage/box/data_disk/basic = 100,
+					/obj/item/computer_hardware/hard_drive/portable/design/misc = 300,
+					/obj/item/computer_hardware/hard_drive/portable/design/devices = 400,
+					/obj/item/computer_hardware/hard_drive/portable/design/tools = 400,
+					/obj/item/computer_hardware/hard_drive/portable/design/components = 500,
+					/obj/item/computer_hardware/hard_drive/portable/design/adv_tools = 1800,
+					/obj/item/computer_hardware/hard_drive/portable/design/circuits = 600,
+					/obj/item/computer_hardware/hard_drive/portable/design/conveyors = 400,
+					/obj/item/computer_hardware/hard_drive/portable/design/medical = 400,
+					/obj/item/computer_hardware/hard_drive/portable/design/computer = 500,
+					/obj/item/computer_hardware/hard_drive/portable/design/security = 600,
+					/obj/item/computer_hardware/hard_drive/portable/design/armor/asters = 900,
+					/obj/item/computer_hardware/hard_drive/portable/design/guns/fs_cheap_guns = 3000,
+					/obj/item/computer_hardware/hard_drive/portable/design/nonlethal_ammo = 700,
+					/obj/item/electronics/circuitboard/autolathe = 700,
+					/obj/item/electronics/circuitboard/autolathe_disk_cloner = 1000,
+					/obj/item/electronics/circuitboard/vending = 500,
+					/obj/item/computer_hardware/hard_drive/portable/design/lethal_ammo = 1200,
+					/obj/item/computer_hardware/hard_drive/portable/design/ammo_boxes_rifle = 900,
+					/obj/item/computer_hardware/hard_drive/portable/design/ammo_boxes_shotgun = 900,
+					/obj/item/computer_hardware/hard_drive/portable/design/ammo_boxes_smallarms = 900,
+					/obj/item/computer_hardware/hard_drive/portable/advanced = 75,)
 
 //Mekhane Theomat
 

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/design_disks/frozen_star.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/design_disks/frozen_star.dm
@@ -23,5 +23,19 @@
 		/datum/design/autolathe/ammo/shotgun_blanks,
 	)
 
+/obj/item/computer_hardware/hard_drive/portable/design/ammo_boxes_shotgun
+	disk_name = "Frozen Star Shotgun Ammunition"
+	icon_state = "frozenstar"
+	spawn_tags = SPAWN_TAG_DESIGN_ADVANCED_COMMON
+	license = 20
+	designs = list(
+		/datum/design/autolathe/ammo/shotgunbox,
+		/datum/design/autolathe/ammo/shotgunbox_buckshot,
+		/datum/design/autolathe/ammo/shotgunbox_beanbag,
+		/datum/design/autolathe/ammo/shotgunbox_rubbershot,
+		/datum/design/autolathe/ammo/shotgunbox_flash,
+		/datum/design/autolathe/ammo/shotgunbox_blanks = 0,
+	)
+
 /obj/item/computer_hardware/hard_drive/portable/design/guns/nt_regulator
 	disk_name = "Frozen Star - .50 Regulator Shotgun"

--- a/zzzz_modular_occulus/code/modules/projectiles/ammunition/magazines.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/ammunition/magazines.dm
@@ -15,6 +15,9 @@
 	name = "shotgun shells (rubbershot)"
 	build_path = /obj/item/ammo_casing/shotgun/pellet/rubber/prespawned
 
+/obj/item/ammo_magazine/ammobox/shotgun
+	matter = list(MATERIAL_CARDBOARD = 1)
+
 /obj/item/ammo_magazine/ammobox/shotgun/rubbershot
 	name = "ammunition box (rubbershot shell)"
 	icon_state = "shot_r"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds the following items to the following vendors:
Getmore Snacks: Donut box for 100 + Coin (Syndicakes were 30 when testing pre-price adding and i have no explanation so i just tacked it on)
Print-O-Mat: Shotgun, Rifle, And Pistol ammo box disks for 900 + coin. Advanced Data Disk for 75+ coin.
Robco Tool Maker: Tool, Med, Ammo and Parts Hardcase for 1 coin. Welding Canister for 1 coin. (Note: The hardcases are already printable, craftable, and are practically everywhere)

Also adds the Shotgun Ammo Box disk, Allowing the printing of Slug, Buckshot, Rubbershot, Beanbag, Flash and Blank shell boxes for 30 steel and 1 cardboard (Except flash shells, which also require 15 silver). Other integrations outside of printomat pending, though it hasn't been loot blacklisted.

Small consequence: Shotgun Ammo boxes have been nerfed to have a material balance of just 1 cardboard instead of 24 steel. This is bring it more inline with other ammo box printing design and costs.

## Why It's Good For The Game

More integration of certain items + shotgun ammo box disk. Printing 5 at a time is nice but sometimes you just need a box of shells.

## Changelog
```changelog
add: More vendors have coinslots now.
add: Frozen Star started releasing shotgun ammo box designs in disk form.
tweak: Shotgun ammo box has been material-swapped to just 1 cardboard
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
