### PR TITLE
Implements Shucan into the game and adds Shoudin as a language

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -228,7 +228,7 @@
 #define SPECIES_MONKEY_UNATHI	"Stok"
 
 //species defines
-#define SPECIES_AKULA			"Akula"
+#define SPECIES_AKULA			"Shucan"
 #define SPECIES_ALRAUNE			"Alraune"
 #define SPECIES_NEVREAN			"Nevrean"
 #define SPECIES_PROTEAN			"Protean"

--- a/code/__DEFINES/species_languages.dm
+++ b/code/__DEFINES/species_languages.dm
@@ -55,6 +55,7 @@
 #define LANGUAGE_VOX "Vox-Pidgin"
 #define LANGUAGE_AKHANI "Akhani"
 #define LANGUAGE_SAGARU "Sagaru"
+#define LANGUAGE_SHOUDIN "Shoudin"
 
 // Species flags.
 #define SPECIES_FLAG_NO_MINOR_CUT               0x0001  // Can step on broken glass with no ill-effects. Either thick skin (diona/vox), cut resistant (slimes) or incorporeal (shadows)

--- a/code/modules/mob/language/station.dm
+++ b/code/modules/mob/language/station.dm
@@ -278,3 +278,14 @@
 	colour = "birdsongc"
 	key = "G"
 	syllables = list ("cheep", "peep", "tweet")
+
+/datum/language/shoudin
+	name = LANGUAGE_SHOUDIN
+	desc = "A language spoken by Shucan. It is very tongue-heavy and dependent on intonations of the same syllables."
+	speech_verb = "sings"
+	exclaim_verb = "chimes"
+	colour = "skrell" // can't figure how this colour thing works, so it'll use the same as the skrell's for now
+	key = "s"
+	syllables = list ("shisa", "catrin", "sia", "disa", "shae", "shiena", "sae", "soa", "shoca", "cassin", "cassova", "konta", "shii", "aesha", \
+	 "eesha", "iisha", "oousha", "sa", "shissinoro", "shisaente", "kokae","saro", "cantan", "shiso", "kala'e", "shi'ra", "shi'va", "soa'to", "vera", \
+	 "aeshaouda", "oushidino", "shuuca", "shisino", "shaeshae", "shiddin")

--- a/code/modules/mob/living/carbon/human/species/station/station_vr.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station_vr.dm
@@ -57,7 +57,7 @@
 */
 /datum/species/akula
 	name = SPECIES_AKULA
-	name_plural = "Akula"
+	name_plural = "Shucan"
 	icobase = 'icons/mob/human_races/r_akula.dmi'
 	deform = 'icons/mob/human_races/r_def_akula.dmi'
 	tail = "tail"
@@ -78,7 +78,10 @@
 	min_age = 18
 	max_age = 80
 
-	blurb = "Not an offical species, however it is here so it's sprite can be used for custom species." //Occulus edit
+	blurb = "Originating from Shoudona, the Shucan are selachimorphs hailing from the Shoussin Union, at the outermost edge of the Cygnus Region. \
+	They are tall, hard-built humanoids, with a soft underbelly. Their language 'Shoudin' is compromised majorily of consonants pronounced in varying vibrations,\
+	giving them a distinct accent aswell as often showing their teeth when speaking. Most Shucan working in UTS territories are pilgrims from their homeland, \
+	come to expand their horizons and worldview, either by choice or by their beliefs." //Occulus edit
 
 	primitive_form = "Sobaka"
 


### PR DESCRIPTION

## About The Pull Request

Per the shark species overhaul, the akula are now replaced by in-house-lore species 'Shucan'. This PR replaces the SPECIES_AKULA's displayed name with Shucan, adds their description and implements their language: Shoudin.

![Screenshot (3237)](https://user-images.githubusercontent.com/30506455/227657541-676adbcc-5009-4462-93ab-6e37f1466f22.png)
![Screenshot (3236)](https://user-images.githubusercontent.com/30506455/227657571-60f968f7-08b8-47c5-abfe-120fc979685a.png)

## Changelog
```changelog
add: Shoudin language
tweak: Akula are now Shucan
```