### PR TITLE
Hub Visibility Toggle & Restricted Observation

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -386,6 +386,16 @@ proc/establish_db_connection()
 	else
 		return 1
 
+//Toggles whether the server is visible to the hub or not.
+/world/proc/update_hub_visibility(new_visibility)
+	if(new_visibility == GLOB.hub_visibility)
+		return
+	GLOB.hub_visibility = new_visibility
+	if(GLOB.hub_visibility)
+		hub_password = "kMZy3U5jJHSiBQjr"
+	else
+		hub_password = "SORRYNOPASSWORD"
+
 /world/proc/incrementMaxZ()
 	maxz++
 	SSmobs.MaxZChanged()

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1221,3 +1221,19 @@ ADMIN_VERB_ADD(/datum/admins/proc/paralyze_mob, R_ADMIN, FALSE)
 			return 0
 		return 1
 	return 0
+
+
+//Whether the server is visible to the hub or not. No other good place for this to go, unfortunately.
+GLOBAL_VAR_INIT(hub_visibility, FALSE)
+
+//Toggle the hub visibility of the server.
+ADMIN_VERB_ADD(/datum/admins/proc/toggle_hub, R_SERVER, FALSE)
+/datum/admins/proc/toggle_hub()
+	set category = "Server"
+	set name = "Toggle Hub"
+
+	world.update_hub_visibility(!GLOB.hub_visibility)
+
+	log_and_message_admins("[key_name_admin(usr)] has toggled the server's hub status for the round, it is now [(GLOB.hub_visibility?"on":"off")] the hub.")
+	if (GLOB.hub_visibility && !world.reachable)
+		message_admins("WARNING: The server will not show up on the hub because byond is detecting that a filewall is blocking incoming connections.")

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -143,6 +143,9 @@
 		new_player_panel_proc()
 
 	if(href_list["observe"])
+		if(!is_player_whitelisted(src))
+			discord_redirect(usr)//AEIOU addition
+			return 0
 
 		if(alert(src,"Are you sure you wish to observe? You will have to wait [config.respawn_delay] before being able join the crew! But you can play as a mouse or drone immediately.","Player Setup","Yes","No") == "Yes")
 			if(!client)	return 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Admins with the SERVER permission flag can toggle hub visibility via the "Toggle Hub" verb in the Server tab.
Doing so messages admins and logs the action.

Additionally, non-whitelisted players can no longer observe, and will receive the "go to our discord!" message. (Same that you receive when trying to join/talk in OOC unwhitelisted.)

## Changelog
```changelog
admin: Unwhitelisted players can no longer observe.
server: Hub visibility can be toggled with the "Toggle Hub" verb in the Server tab.
```