### PR TITLE
Measuring Tape no longer display excavation level as 2x in cm

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -253,7 +253,7 @@
 		var/obj/item/device/measuring_tape/P = I
 		user.visible_message(SPAN_NOTICE("\The [user] extends [P] towards [src]."),SPAN_NOTICE("You extend [P] towards [src]."))
 		if(do_after(user,25, src))
-			to_chat(user, SPAN_NOTICE("\icon[P] [src] has been excavated to a depth of [2*excavation_level]cm."))
+			to_chat(user, SPAN_NOTICE("\icon[P] [src] has been excavated to a depth of [excavation_level]cm."))  // Occulus Edit. Used to be 2* excavation level
 		return
 
 	else

--- a/code/modules/research/xenoarchaeology/artifact/artifact.dm
+++ b/code/modules/research/xenoarchaeology/artifact/artifact.dm
@@ -109,7 +109,7 @@
 		var/obj/item/device/measuring_tape/P = I
 		user.visible_message("<span class='notice'>[user] extends [P] towards [src].","\blue You extend [P] towards [src].</span>")
 		if(do_after(user,40,src))
-			to_chat(user, SPAN_NOTICE("[src] has been excavated to a depth of [2*src.excavation_level]cm."))
+			to_chat(user, SPAN_NOTICE("[src] has been excavated to a depth of [src.excavation_level]cm.")) // Occulus Edit. Used to be 2* excavation level
 		return
 
 /obj/structure/boulder/Bumped(AM)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Measuring Tape displays 2x the excavation level as the excavated depth in CM, leading to players mistakenly thinking that their tools have dug twice as deep. But no, this is just some stupid obscure decision made 7 years ago.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Because this is dumb

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
tweak: Xenoarch - Measuring Tape no longer displays excav depth as 2x of what it actually is. If you entered a depth of 10cm, then the excavation level is 10, you will see 10cm displayed as the depth instead of 20cm. 
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
