### PR TITLE
Makes /me accept speech formatting too

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -51,6 +51,8 @@
 		return
 
 	message = sanitize(message)
+	message = formatSpeech(message, "|", "<i>", "</i>") // OCCULUS EDIT: Emote formating, symbols as suggested by driftingpaws
+	message = formatSpeech(message, "+", "<b>", "</b>") // OCCULUS EDIT: Emote formating, symbols as suggested by driftingpaws
 
 	set_typing_indicator(FALSE)
 	if(use_me)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. Tested and confirmed to be working.

## Why It's Good For The Game

Output from chatGPT:
Allowing users to format their custom emotes with bold and italic can be a useful feature in a few different ways:

    Emphasis: Bold and italic text can be used to add emphasis to certain words or phrases in an emote, making them stand out more and potentially adding to the humor or meaning of the emote.

    Clarity: Using bold or italic text can help make certain words or phrases in an emote easier to read and understand, especially if they are part of a longer message or sentence.

    Creativity: Allowing users to format their emotes with bold and italic text can encourage creativity and experimentation with different ways of expressing oneself through emotes.

    Customizability: Giving users more control over the appearance of their emotes can help them feel more invested in the game and its community, and can also make their emotes more distinctive and recognizable.

Overall, the ability to format custom emotes with bold and italic text can add a new dimension of expressiveness and creativity to the game, as well as make messages more clear and memorable.

## Changelog
```changelog
add: You can now use speechformatting tags in /me emotes. Bold with +me+ and italic with |me|. Huzzah!
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
