### PR TITLE
FEATURE: Clonexadone now unhusks 

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -143,9 +143,9 @@
 /mob/living/carbon/human/proc/UnHusk()
 	if(!(HUSK in mutations))	return FALSE
 
-	if(f_style)
+	if(f_style && client?.prefs?.f_style) // Occulus Edit null check for client prefs
 		f_style = client.prefs.f_style	//we only change the icon_state of the hair datum, so it doesn't mess up their UI/UE
-	if(h_style)
+	if(h_style && client?.prefs?.h_style) // Occulus Edit null check for client prefs
 		h_style = client.prefs.h_style
 	update_hair(0)
 

--- a/code/modules/reagents/reagents/medicine.dm
+++ b/code/modules/reagents/reagents/medicine.dm
@@ -181,6 +181,10 @@
 		M.add_chemical_effect(CE_PULSE, -2)
 		if(M.stat == DEAD)//Occulus Edit
 			M.timeofdeath += 20//Occulus Edit
+		if(ishuman(M))
+			var/mob/living/carbon/human/H = M
+			if(prob(10)) // Occulus Edit - gives Medbay a way to unhusk people
+				H.UnHusk()
 
 /* Painkillers */
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Clonexadone now have a 10% probability of unhusking a body per tick.
Also fixes unhusk proc not working on people without client, since there were no null checks on client preferences.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Husking is caused by taking burn damage above 200 / 250. It is common and can be done even with a laser rifle. 
Mekhane is the only one capable of fixing this with their wine basin. This gives Medical a way to fix husking instead of having to clone or rely solely on Mekhane.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
add: Clonexadone now has a 10% probability of unhusking per tick (Works on the dead)
fix: Unhusking (Done by Wine Basin and Clonexadone) now works on mob without a client
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
