### PR TITLE
allows pockets/suit storage to quick-equip

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -3073,6 +3073,7 @@
 #include "zzzz_modular_occulus\code\modules\mining\ore.dm"
 #include "zzzz_modular_occulus\code\modules\mining\ore_datum.dm"
 #include "zzzz_modular_occulus\code\modules\mob\gender.dm"
+#include "zzzz_modular_occulus\code\modules\mob\inventory\equip.dm"
 #include "zzzz_modular_occulus\code\modules\mob\living\bot\cleanbot_occulus.dm"
 #include "zzzz_modular_occulus\code\modules\mob\living\bot\farmbot_occulus.dm"
 #include "zzzz_modular_occulus\code\modules\mob\living\carbon\carbon.dm"

--- a/code/modules/mob/inventory/equip.dm
+++ b/code/modules/mob/inventory/equip.dm
@@ -137,7 +137,14 @@ var/list/slot_equipment_priority = list(
 			return TRUE
 	if(quick_equip_belt(Item))
 		return TRUE
+	if(quick_equip_s_store(Item)) //occy edit start
+		return TRUE
+	if(quick_equip_l_store(Item))
+		return TRUE
+	if(quick_equip_r_store(Item))
+		return TRUE //occy edit end
 	return FALSE
+
 /mob/living/carbon/human/proc/quick_equip_belt(obj/item/Item)
 	if(istype(src.belt,/obj/item/storage/))
 		var/obj/item/storage/B= src.belt

--- a/zzzz_modular_occulus/code/modules/mob/inventory/equip.dm
+++ b/zzzz_modular_occulus/code/modules/mob/inventory/equip.dm
@@ -1,0 +1,20 @@
+/mob/living/carbon/human/proc/quick_equip_s_store(obj/item/Item)
+	if(istype(src.s_store,/obj/item/storage/))
+		var/obj/item/storage/B= src.s_store
+		if(B.attackby(Item,src))
+			return TRUE
+	return FALSE
+
+/mob/living/carbon/human/proc/quick_equip_l_store(obj/item/Item)
+	if(istype(src.l_store,/obj/item/storage/))
+		var/obj/item/storage/B= src.l_store
+		if(B.attackby(Item,src))
+			return TRUE
+	return FALSE
+
+/mob/living/carbon/human/proc/quick_equip_r_store(obj/item/Item)
+	if(istype(src.r_store,/obj/item/storage/))
+		var/obj/item/storage/B= src.r_store
+		if(B.attackby(Item,src))
+			return TRUE
+	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

When you press E in hotkey mode, the game will now attempt to put things into containers in your pockets or suit slot instead of just your belt and back containers. I had to edit some non-modular stuff but I put the bulk of it in modular.

## Why It's Good For The Game

less fiddling with storage items.

## Changelog
```changelog
tweak: allows pockets/suit storage to be quick-equipped to.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
