### PR TITLE
Siren Weight Adjust & Required Crew Fix

### DIFF
--- a/code/game/gamemodes/storyevent.dm
+++ b/code/game/gamemodes/storyevent.dm
@@ -32,7 +32,8 @@
 
 	var/req_stage = -1
 
-	var/max_crew_diff_lower = 10	//Maximum difference between above values and real crew distribution. If difference is greater, weight will be 0
+	// var/max_crew_diff_lower = 10		// Occulus Edit: Removed since this is no longer used as the original
+	// And it was causing required crew to be unexpectedly low (reduced by 10) on all events, leading to coder confusion and unintentional event firing
 	var/max_crew_diff_higher = 10
 
 	var/max_stage_diff_lower = 0

--- a/code/game/gamemodes/storyteller_helpers.dm
+++ b/code/game/gamemodes/storyteller_helpers.dm
@@ -71,7 +71,7 @@
 /datum/storyteller/proc/calculate_event_weight(var/datum/storyevent/R)
 	var/new_weight = R.weight
 	//Occulus Edit - Disables events with crew below a certain threshold
-	if(crew < (R.req_crew - R.max_crew_diff_lower))
+	if(crew < R.req_crew)
 		return 0
 	// End occulus edit
 

--- a/zzzz_modular_occulus/code/game/gamemodes/events/siren_scan.dm
+++ b/zzzz_modular_occulus/code/game/gamemodes/events/siren_scan.dm
@@ -9,9 +9,8 @@
 
 	event_type = /datum/event/siren_scan
 	event_pools = list(EVENT_LEVEL_MODERATE = POOL_THRESHOLD_MODERATE)
-	req_crew = 8
-	weight = 0.5
-	max_crew_diff_lower = 3
+	req_crew = 12
+	weight = 0.25
 	tags = list(TAG_SCARY, TAG_COMMUNAL, TAG_COMBAT)
 
 

--- a/zzzz_modular_occulus/code/game/gamemodes/storytellers/storyevent.dm
+++ b/zzzz_modular_occulus/code/game/gamemodes/storytellers/storyevent.dm
@@ -2,13 +2,11 @@
 
 /datum/storyevent/hivemind
 	tags = list(TAG_COMMUNAL, TAG_DESTRUCTIVE, TAG_NEGATIVE, TAG_SCARY, TAG_ROUNDENDING)
-	req_crew = 9	//Makes it so that at least 6 players must be playing in order to spawn
-	max_crew_diff_lower = 3
+	req_crew = 6
 
 /datum/storyevent/blob
 	tags = list(TAG_COMBAT, TAG_DESTRUCTIVE, TAG_NEGATIVE, TAG_ROUNDENDING)
-	req_crew = 9
-	max_crew_diff_lower = 3
+	req_crew = 6
 
 /datum/storyevent/roleset/blitz
 	name = "rogue drone"
@@ -21,7 +19,6 @@
 /*
 /datum/storyevent/roleset/faction/excelsior
 	req_crew = 12	//Makes it so that at least 9 players must be playing in order to spawn
-	max_crew_diff_lower = 3
 	base_quantity = 2 //They're a group antag, we want a few of em
 	scaling_threshold = 15
 */


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Adjust siren weight to 0.25 and required crewmember to 12 (Instead of the intended 8 which ended up as a de facto 8). 
- Remove the max_crew_diff_lower variable which defaulted to 10, leading to all event without it set explicitly having 10 lower required crew than expected.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Make Siren no longer fire on low pop, lower its chance of firing. Also align coder expectations of req_crew blocking events firing on low pop round with what is happening. 

CHANGES: 
Because of these changes, numerous event's actual required crew has been adjusted upward. I am open to feedback to changing it back.
- Malf AI now fire on min. 15 pop instead of 10 pop (might need adjustment?)
- Marshal fire on min. 10 pop instead of 0 pop
- Mercenary fire on min. 5 pop instead of -5 pop
- Siren fire on min. 12 pop instead of 5 pop

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
tweak: Siren have half the initial weight and can only fire when there's 12 crew or more 
tweak: Malf AI now fire on minimal 15 pop instead of 5 pop. 
tweak: Marshal now fire on minimum 10 pop and mercenary 5 instead of 0 / -5 which was not working as intended. (These events can fire but fail to find a target)
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
