### PR TITLE
Warrior now give 120 points to roleset event (antags) when voted in

### DIFF
--- a/code/controllers/subsystems/voting/poll_types.dm
+++ b/code/controllers/subsystems/voting/poll_types.dm
@@ -105,8 +105,8 @@
 
 	SSticker.story_vote_ended = TRUE
 
-
-	set_storyteller(config.pick_storyteller(master_storyteller), announce = !(pregame)) //This does the actual work //Even if master storyteller is null, this will pick the default
+	// Occulus Edit - added voted variable
+	set_storyteller(config.pick_storyteller(master_storyteller), announce = !(pregame), voted = !(pregame)) //This does the actual work //Even if master storyteller is null, this will pick the default
 	if (pregame)
 		round_progressing = TRUE
 		to_chat(world, "<b>The game will start in [SSticker.pregame_timeleft] seconds.</b>")

--- a/code/game/gamemodes/storyteller.dm
+++ b/code/game/gamemodes/storyteller.dm
@@ -39,6 +39,16 @@ GLOBAL_DATUM(storyteller, /datum/storyteller)
 	EVENT_LEVEL_ROLESET = 0 //Roleset
 	)
 
+	// Occulus Edit Start: Vote Points provide additional point to a storyteller when it is voted in after game start
+	//Set values here for starting points
+	var/list/voted_points = list(
+	EVENT_LEVEL_MUNDANE = 0, //Mundane
+	EVENT_LEVEL_MODERATE = 0, //Moderate
+	EVENT_LEVEL_MAJOR = 0, //Major
+	EVENT_LEVEL_ROLESET = 0 //Roleset
+	)
+	// Occulus Edit End
+
 	//Lists of events. These are built dynamically at runtime
 	var/list/event_pool_mundane = list()
 	var/list/event_pool_moderate = list()
@@ -250,9 +260,13 @@ GLOBAL_DATUM(storyteller, /datum/storyteller)
 	if(points[EVENT_LEVEL_ROLESET] >= POOL_THRESHOLD_ROLESET)
 		handle_event(EVENT_LEVEL_ROLESET)
 
-
-
-
+// Occulus Edit: Helper Proc for adding in additional points after it is voted in
+/datum/storyteller/proc/add_voted_points()
+	points[EVENT_LEVEL_MUNDANE] += voted_points[EVENT_LEVEL_MUNDANE]
+	points[EVENT_LEVEL_MODERATE] += voted_points[EVENT_LEVEL_MODERATE]
+	points[EVENT_LEVEL_MAJOR] += voted_points[EVENT_LEVEL_MAJOR]
+	points[EVENT_LEVEL_ROLESET] += voted_points[EVENT_LEVEL_ROLESET]
+// Occulus Edit End
 
 /*******************
 *  Event Handling

--- a/code/game/gamemodes/storyteller_helpers.dm
+++ b/code/game/gamemodes/storyteller_helpers.dm
@@ -28,7 +28,7 @@
 		GLOB.storyteller.points = oldST.points.Copy()//Transfer over points
 		//TODO: Cleanup and handover
 	
-	// Occulus Edit: If it was voted in, then add in the votedpoints
+	// Occulus Edit: If it was voted in, then add in the voted_points
 
 	if(voted)
 		GLOB.storyteller.add_voted_points() 

--- a/code/game/gamemodes/storyteller_helpers.dm
+++ b/code/game/gamemodes/storyteller_helpers.dm
@@ -1,6 +1,6 @@
 
 //Sets the storyteller to a new one, and does any heavy lifting for a handover
-/proc/set_storyteller(var/datum/storyteller/newST, var/announce = TRUE)
+/proc/set_storyteller(var/datum/storyteller/newST, var/announce = TRUE, var/voted = FALSE) // Occulus Edit: Add in voted variable
 	if (!newST)
 		//You can call this without passing anything, we'll go fetch it ourselves
 		newST = config.pick_storyteller(STORYTELLER_BASE) //This function is in code/controllers/configuration.dm
@@ -27,6 +27,11 @@
 	if (oldST != null)
 		GLOB.storyteller.points = oldST.points.Copy()//Transfer over points
 		//TODO: Cleanup and handover
+	
+	// Occulus Edit: If it was voted in, then add in the votedpoints
+
+	if(voted)
+		GLOB.storyteller.add_voted_points() 
 
 	//Configure the new storyteller
 	GLOB.storyteller.set_up()

--- a/code/game/gamemodes/storytellers/warrior.dm
+++ b/code/game/gamemodes/storytellers/warrior.dm
@@ -17,3 +17,11 @@
 	EVENT_LEVEL_MAJOR = 75, //Major
 	EVENT_LEVEL_ROLESET = 140 //Roleset
 	)
+
+	// Occulus Edit - When the crew vote in Warrior they want blood we'll give them blood
+	voted_points = list(
+	EVENT_LEVEL_MUNDANE = 0, //Mundane
+	EVENT_LEVEL_MODERATE = 0, //Moderate
+	EVENT_LEVEL_MAJOR = 0, //Major
+	EVENT_LEVEL_ROLESET = 120 //Roleset - GIVE THEM ANTAG
+	)

--- a/zzzz_modular_occulus/code/game/gamemodes/storytellers/storytellers.dm
+++ b/zzzz_modular_occulus/code/game/gamemodes/storytellers/storytellers.dm
@@ -94,6 +94,14 @@ It generates half again as many events as default, as well as more antagonists.
 	EVENT_LEVEL_ROLESET = 220 //Roleset. Spawn one antag immediately, and another quickly.
 	)
 
+	// When the crew vote in Warrior they want blood we'll give them blood
+	voted_points = list(
+	EVENT_LEVEL_MUNDANE = 0, //Mundane
+	EVENT_LEVEL_MODERATE = 0, //Moderate
+	EVENT_LEVEL_MAJOR = 0, //Major
+	EVENT_LEVEL_ROLESET = 120 //Roleset - GIVE THEM ANTAG
+	)
+
 
 /* The Tyrant is designed for rounds with moderate to high population.
 It generates a large number of events, but doesn't generate antagonists.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Add in voted_points variable to storyteller, which add points to a storyteller when they are voted in. This currently only apply to Warrior.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
when the playerbase want blood they'll have blood 
(because when you vote in warrior but all the points are spent it is kinda lame you need to wait so long for another antag)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
tweak: When Warrior is voted in mid round, it gives 120 roleset point and will almost immediately spawn an antag.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
