### PR TITLE
Fix Tar, Chlorine missing ID, fix Phoron bad typepath

### DIFF
--- a/code/modules/integrated_electronics/passive/power.dm
+++ b/code/modules/integrated_electronics/passive/power.dm
@@ -97,7 +97,7 @@
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	reagent_flags = OPENCONTAINER
 	var/volume = 60
-	var/list/fuel = list(/datum/reagent/toxin/plasma = 50000, /datum/reagent/toxin/fuel = 15000, /datum/reagent/carbon = 10000, /datum/reagent/ethanol = 10000, /datum/reagent/organic/nutriment = 8000)
+	var/list/fuel = list(/datum/reagent/toxin/phoron = 50000, /datum/reagent/toxin/fuel = 15000, /datum/reagent/carbon = 10000, /datum/reagent/ethanol = 10000, /datum/reagent/organic/nutriment = 8000)
 	var/lfwb =TRUE
 
 /obj/item/integrated_circuit/passive/power/chemical_cell/New()

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -99,6 +99,7 @@
 
 ///datum/reagent/toxin/blattedin is defined in blattedin.dm
 
+// Occulus Edit - Plasma is renamed Phoron
 /datum/reagent/toxin/phoron
 	name = "Phoron"
 	id = "phoron"
@@ -109,22 +110,23 @@
 	strength = 0.3
 	touch_met = 5
 
-/datum/reagent/toxin/plasma/touch_mob(mob/living/L, var/amount)
+/datum/reagent/toxin/phoron/touch_mob(mob/living/L, var/amount)
 	if(istype(L))
 		L.adjust_fire_stacks(amount / 5)
 
-/datum/reagent/toxin/plasma/affect_touch(mob/living/carbon/M, alien, effect_multiplier)
+/datum/reagent/toxin/phoron/affect_touch(mob/living/carbon/M, alien, effect_multiplier)
 	M.take_organ_damage(0, effect_multiplier * 0.1) //being splashed directly with plasma causes minor chemical burns
 	if(prob(50))
 		M.pl_effects()
 
-/datum/reagent/toxin/plasma/touch_turf(turf/simulated/T)
+/datum/reagent/toxin/phoron/touch_turf(turf/simulated/T)
 	if(!istype(T))
 		return
 	T.assume_gas("phoron", volume, T20C)
 	remove_self(volume)
 	return TRUE
 
+// End Occulus Edit
 /datum/reagent/toxin/cyanide //Fast and Lethal
 	name = "Cyanide"
 	id = "cyanide"
@@ -740,17 +742,19 @@
 		remove_self(volume)
 		return TRUE
 
-/datum/reagent/toxin/biomatter
-	name = "Biomatter"
-	id = "biomatter"
-	description = "A goo of unknown to you origin. Its better to stay that way."
-	taste_description = "vomit"
-	reagent_state = LIQUID
-	color = "#527f4f"
-	strength = 0.3
+// Occulus Edit redundant def
+// /datum/reagent/toxin/biomatter
+// 	name = "Biomatter"
+// 	id = "biomatter"
+// 	description = "A goo of unknown to you origin. Its better to stay that way."
+// 	taste_description = "vomit"
+// 	reagent_state = LIQUID
+// 	color = "#527f4f"
+// 	strength = 0.3
 
 /datum/reagent/toxin/chlorine
 	name = "Chlorine"
+	id = "chlorine" // Occulus Edit: add missing id
 	description = "A highly poisonous liquid. Smells strongly of bleach."
 	reagent_state = LIQUID
 	taste_description = "bleach"
@@ -759,6 +763,7 @@
 
 /datum/reagent/toxin/tar
 	name = "Tar"
+	id = "tar" // Occulus Edit: add missing id
 	description = "A dark, viscous liquid."
 	taste_description = "petroleum"
 	color = "#140b30"

--- a/code/modules/reagents/reagents/toxins.dm
+++ b/code/modules/reagents/reagents/toxins.dm
@@ -741,20 +741,9 @@
 			spill_biomass(T)
 		remove_self(volume)
 		return TRUE
-
-// Occulus Edit redundant def
-// /datum/reagent/toxin/biomatter
-// 	name = "Biomatter"
-// 	id = "biomatter"
-// 	description = "A goo of unknown to you origin. Its better to stay that way."
-// 	taste_description = "vomit"
-// 	reagent_state = LIQUID
-// 	color = "#527f4f"
-// 	strength = 0.3
-
 /datum/reagent/toxin/chlorine
 	name = "Chlorine"
-	id = "chlorine" // Occulus Edit: add missing id
+	id = "chlorine"
 	description = "A highly poisonous liquid. Smells strongly of bleach."
 	reagent_state = LIQUID
 	taste_description = "bleach"
@@ -763,7 +752,7 @@
 
 /datum/reagent/toxin/tar
 	name = "Tar"
-	id = "tar" // Occulus Edit: add missing id
+	id = "tar"
 	description = "A dark, viscous liquid."
 	taste_description = "petroleum"
 	color = "#140b30"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tar, which was supposed to be an exoplanet exclusive, instead appeared in everyone's body for every situation imaginable.

This was because chlorine and tar were missing ID and as a result inherited the "Toxin" id of the baseline toxin. Chlorine is 300x as strong as baseline toxin and tar 40x. 

Rename of Plasma to Phoron were incomplete and it also inherited the toxin ID, leading to Phoron not adjusting fire stacks, causing chemical burn or any of the dangerous effect it is supposed to have when splashed on ground.

This PR add back in the missing ID to Chlorine and Tar and fix Phoron typepath, which means no more mystery deadly tar when it was supposed to be just generic poisoning.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
stop mass murdering the crew with rotten food, rejected organ being 40x deadlier than it is.

phoron spills should be more dangerous (not deadly, but still dangerous). 

fix bugs

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
fix: Toxin reference in code no longer mistakenly adds tar, a toxin 40x as deadly as baseline toxin. This mean that maint food, microwave burnt mess, some random plants, rejected organs, incompatible blood, maint loot etc. no longer give tar but give baseline toxin.
fix: Phoron splash on people cause chemical burns again, phoron spilled on ground cause phoron gas to appear potentially causing fire and atmos alarm, phoron splashed on people increase the fire stack.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
