### PR TITLE
Fix: Autodocs can remove shrapnel now.

### DIFF
--- a/code/modules/surgery/autodoc.dm
+++ b/code/modules/surgery/autodoc.dm
@@ -93,7 +93,7 @@
 				patchnote.surgery_operations |= AUTODOC_FRACTURE
 		if(AUTODOC_EMBED_OBJECT in possible_operations)
 			if(external.implants)
-				if(/obj/item/material/shard/shrapnel in external.implants)
+				if(locate(/obj/item/material/shard/shrapnel) in external.implants) //occy edit
 					patchnote.surgery_operations |= AUTODOC_EMBED_OBJECT
 
 		if(external.wounds.len)

--- a/code/modules/surgery/autodoc.dm
+++ b/code/modules/surgery/autodoc.dm
@@ -93,7 +93,7 @@
 				patchnote.surgery_operations |= AUTODOC_FRACTURE
 		if(AUTODOC_EMBED_OBJECT in possible_operations)
 			if(external.implants)
-				if(locate(/obj/item/material/shard/shrapnel) in external.implants) //occy edit
+				if(locate(/obj/item/material/shard/shrapnel) in external.implants)
 					patchnote.surgery_operations |= AUTODOC_EMBED_OBJECT
 
 		if(external.wounds.len)


### PR DESCRIPTION
watch this break everything.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So, the autodoc couldn't remove shrapnel because it wasn't using "locate" to find shrapnel in the limbs, like how surgery code does it, so it never found any.

"if(/obj/item/material/shard/shrapnel in external.implants)" VS "if(locate(/obj/item/material/shard/shrapnel) in external.implants)"

Implemented that and it worked as expected.

## Why It's Good For The Game

Unbuggening the autodoc seems useful for when there's no surgeons arounds.

## Changelog
```changelog
fix:autodoc can now remove shrapnel
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
