### PR TITLE
Autopsy Scanner Tweaks & Rebalance

### DIFF
--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -27,15 +27,15 @@
 
 /datum/autopsy_data
 	var/weapon
-	var/pretend_weapon
+	// var/pretend_weapon // Occulus Edit: Remove pretend weapon mechanic
 	var/damage = 0
 	var/hits = 0
 	var/time_inflicted = 0
 
-	proc/copy()
+/datum/autopsy_data/proc/copy() // Occulus Edit: No relative path
 		var/datum/autopsy_data/W = new()
 		W.weapon = weapon
-		W.pretend_weapon = pretend_weapon
+		// W.pretend_weapon = pretend_weapon // Occulus Edit: Remove pretend weapon mechanic
 		W.damage = damage
 		W.hits = hits
 		W.time_inflicted = time_inflicted
@@ -47,17 +47,18 @@
 	for(var/V in O.autopsy_data)
 		var/datum/autopsy_data/W = O.autopsy_data[V]
 
-		if(!W.pretend_weapon)
-			/*
-			// the more hits, the more likely it is that we get the right weapon type
-			if(prob(50 + W.hits * 10 + W.damage))
-			*/
+		// Occulus Edit: Remove pretend weapon mechanic
+		// if(!W.pretend_weapon)
+		// 	/*
+		// 	// the more hits, the more likely it is that we get the right weapon type
+		// 	if(prob(50 + W.hits * 10 + W.damage))
+		// 	*/
 
-			// Buffing this stuff up for now!
-			if(prob(min(20 + (user.stats.getMult(STAT_BIO, STAT_LEVEL_EXPERT) * 100 ), 100)))
-				W.pretend_weapon = W.weapon
-			else
-				W.pretend_weapon = pick("mechanical toolbox", "wirecutters", "revolver", "crowbar", "fire extinguisher", "tomato soup", "oxygen tank", "emergency oxygen tank", "laser", "bullet")
+		// 	// Buffing this stuff up for now!
+		// 	if(prob(min(20 + (user.stats.getMult(STAT_BIO, STAT_LEVEL_EXPERT) * 100 ), 100)))
+		// 		W.pretend_weapon = W.weapon
+		// 	else
+		// 		W.pretend_weapon = pick("mechanical toolbox", "wirecutters", "revolver", "crowbar", "fire extinguisher", "tomato soup", "oxygen tank", "emergency oxygen tank", "laser", "bullet")
 
 
 		var/datum/autopsy_data_scanner/D = wdata[V]
@@ -100,17 +101,20 @@
 		var/datum/autopsy_data_scanner/D = wdata[wdata_idx]
 		var/total_hits = 0
 		var/total_score = 0
-		var/list/weapon_chances = list() // maps weapon names to a score
+		// var/list/weapon_chances = list() // maps weapon names to a score
 		var/age = 0
 
 		for(var/wound_idx in D.organs_scanned)
 			var/datum/autopsy_data/W = D.organs_scanned[wound_idx]
 			total_hits += W.hits
 
-			var/wname = W.pretend_weapon
+			// Occulus Edit: Remove pretend weapon mechanic
+			// var/wname = W.weapon
 
-			if(wname in weapon_chances) weapon_chances[wname] += W.damage
-			else weapon_chances[wname] = max(W.damage, 1)
+			// if(wname in weapon_chances) weapon_chances[wname] += W.damage
+			// else weapon_chances[wname] = max(W.damage, 1)
+			// Occulus Edit: End
+
 			total_score+=W.damage
 
 
@@ -142,9 +146,12 @@
 			scan_data += "Hits by weapon: [total_hits]<br>"
 		scan_data += "Approximate time of wound infliction: [worldtime2stationtime(age)]<br>"
 		scan_data += "Affected limbs: [D.organ_names]<br>"
-		scan_data += "Possible weapons:<br>"
-		for(var/weapon_name in weapon_chances)
-			scan_data += "\t[100*weapon_chances[weapon_name]/total_score]% [weapon_name]<br>"
+
+		// Occulus Edit: Adjust code for removal of pretend weapon
+		scan_data += "Weapon: [D.weapon]<br>"
+		// for(var/weapon_name in weapon_chances)
+		// 	scan_data += "\t[100*weapon_chances[weapon_name]/total_score]% [weapon_name]<br>"
+		// Occulus Edit: End
 
 		scan_data += "<br>"
 

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -79,7 +79,7 @@
 		if(O.trace_chemicals[V] > 0 && !chemtraces.Find(V))
 			chemtraces += V
 	if(did_it_wrong)
-		to_chat(user, SPAN_WARNING("You got a feeling you are not doing this right, maybe you should clear the data and try again"))
+		to_chat(user, SPAN_WARNING("You got a feeling you are not doing this right, maybe you should clear the data and try again."))
 	
 /obj/item/autopsy_scanner/verb/print_data()
 	set category = "Object"

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -185,7 +185,7 @@
 	set name = "Clear Data"
 	
 	if(usr.stat)
-		to_chat(usr, "You must be conscious to do that!")
+		to_chat(usr, SPAN_NOTICE("You must be conscious to do that!"))
 		return
 	
 	if (!usr.IsAdvancedToolUser())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adjust the Autopsy Scanner Mechanics:

- If your biology is at or above 25, you will succeed automatically without fake weapons. Success chance is equal to biology * 4.
- If your biology is at or above 10, and you scan for a fake weapon, you will get a warning message that you probably did it wrong and you should clear data.
- If your biology is below you are too dumb to realize you fucked up
- Added clear data proc.
- Tweaked autopsy scanner so that it would override the "pretend weapon" on the autopsy data (Which are stored on the organs instead of the scanner) so that bad or good scan doesn't persist.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Make autopsy reliable if you are good at it
- Provide feedback if you are competent enough
- Remove the jank where if someone with bad autopsy skill scanned a corpse then you will never get accurate data, and if someone good at bio scan a corpse you'll never get bad data.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
tweak: Autopsy scanner are now 100% reliable at 25 biology. At 10 Biology or above, it will give a warning message if you get false data in your scan(s). Autopsy Scanner can now clear data without scanning another body.
fix: Autopsy scanner's fake weapons no longer persist between two person's scan.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
