### PR TITLE
subtle emote!

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -3077,6 +3077,7 @@
 #include "zzzz_modular_occulus\code\modules\mining\mineral_effect.dm"
 #include "zzzz_modular_occulus\code\modules\mining\ore.dm"
 #include "zzzz_modular_occulus\code\modules\mining\ore_datum.dm"
+#include "zzzz_modular_occulus\code\modules\mob\emote.dm"
 #include "zzzz_modular_occulus\code\modules\mob\gender.dm"
 #include "zzzz_modular_occulus\code\modules\mob\inventory\equip.dm"
 #include "zzzz_modular_occulus\code\modules\mob\living\bot\cleanbot_occulus.dm"

--- a/code/modules/economy/cash_register.dm
+++ b/code/modules/economy/cash_register.dm
@@ -26,7 +26,7 @@
 
 
 // Claim machine ID
-/obj/machinery/cash_register/New()
+/obj/machinery/cash_register/LateInitialize()
 	. = ..()
 	machine_id = "[station_name()] RETAIL #[num_financial_terminals++]"
 	cash_stored = rand(10, 70)*10
@@ -520,7 +520,7 @@
 		cash_locked = 0
 		open_cash_box()
 
-/*
+
 //--Premades--//
 
 /obj/machinery/cash_register/command
@@ -550,4 +550,3 @@
 /obj/machinery/cash_register/civilian
 	account_to_connect = "Civilian"
 	..()
-*/

--- a/code/modules/economy/cash_register.dm
+++ b/code/modules/economy/cash_register.dm
@@ -26,7 +26,7 @@
 
 
 // Claim machine ID
-/obj/machinery/cash_register/LateInitialize()
+/obj/machinery/cash_register/New()
 	. = ..()
 	machine_id = "[station_name()] RETAIL #[num_financial_terminals++]"
 	cash_stored = rand(10, 70)*10
@@ -520,7 +520,7 @@
 		cash_locked = 0
 		open_cash_box()
 
-
+/*
 //--Premades--//
 
 /obj/machinery/cash_register/command
@@ -550,3 +550,4 @@
 /obj/machinery/cash_register/civilian
 	account_to_connect = "Civilian"
 	..()
+*/

--- a/zzzz_modular_occulus/code/modules/mob/emote.dm
+++ b/zzzz_modular_occulus/code/modules/mob/emote.dm
@@ -1,0 +1,62 @@
+/mob/verb/me_verb_subtle(message as message) //This would normally go in say.dm
+	set name = "Subtle"
+	set hidden = TRUE
+
+	message = sanitize(message)
+	message = formatSpeech(message, "|", "<i>", "</i>")
+	message = formatSpeech(message, "+", "<b>", "</b>")
+
+	if(say_disabled)
+		to_chat(usr, "Speech is currently admin-disabled.")
+		return
+
+	if(!message)
+		return
+	if(use_me)
+		usr.emote_subtle("subtle", usr.emote_type, message)
+
+/mob/proc/emote_subtle(var/act, var/type, var/message) //This would normally go in say.dm
+	if(act == "subtle")
+		return subtle_emote(type, message)
+
+/mob/verb/subtle_wrapper()
+	set name = "Subtle  verb"
+	set category = "IC"
+	set desc = "Emote to nearby people only."
+
+	set_typing_indicator(FALSE)
+	var/message = input("", "subtle (text)") as message|null
+	hud_typing = FALSE
+	set_typing_indicator(FALSE)
+	if(message)
+		me_verb_subtle(message)
+
+
+//This is a central proc that all subtle emotes are run through. This handles sending the messages to living mobs
+/mob/proc/subtle_emote(var/type, var/message)
+	var/list/messageturfs = list()//List of turfs we broadcast to.
+	var/list/messagemobs = list()//List of living mobs nearby who can hear it, and distant ghosts who've chosen to hear it
+	var/list/messagemobs_neardead = list()//List of nearby ghosts who can hear it. Those that qualify ONLY go in this list
+	for (var/turf in circlerangeturfs(center=usr, radius=1))
+		messageturfs += turf
+
+	for(var/mob/M in GLOB.player_list)
+		if (!M.client || istype(M, /mob/new_player))
+			continue
+		if(get_turf(M) in messageturfs)
+			if (istype(M, /mob/observer))
+				messagemobs_neardead += M
+				continue
+			else if (istype(M, /mob/living) && !(type == 2 && (sdisabilities & DEAF || ear_deaf)))
+				messagemobs += M
+		else if(src.client)
+			if  (M.stat == DEAD && (M.get_preference_value(/datum/client_preference/ghost_ears) == GLOB.PREF_ALL_SPEECH))
+				messagemobs += M
+				continue
+
+	message = "<i><b>[src]</b> [message]</i>"
+
+	for (var/mob/N in messagemobs)
+		N.show_message(message, type)
+	for (var/mob/O in messagemobs_neardead)
+		O.show_message(message, type)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds in a proper subtle emote in the IC tab!
Can now emote to anyone next to you subtly. Has a one tile range, and does not flash anyone further with scrambled words.

![image](https://github.com/Occulus-Server/Occulus-Eris/assets/12434413/027bcbdc-b942-4c8b-8b01-293ccff4c6c0)

![image](https://github.com/Occulus-Server/Occulus-Eris/assets/12434413/0e12b6c9-ed5c-4ef7-bd87-8cb47fb04538)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Allows a far less jank version of subtly emoting to people. Allow us to not suffer people two tiles away from being /blinded/ by whatever scrambled text they get when whisper emoting.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
add: subtle emote
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
