### PR TITLE
Cleans up Circuit disk addition + Re-allows crafting station printing

### DIFF
--- a/zzzz_modular_occulus/code/game/objects/items/weapons/design_disks/ees.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/design_disks/ees.dm
@@ -30,28 +30,13 @@
 
 /obj/item/computer_hardware/hard_drive/portable/design/circuits
 	disk_name = "EES-ESPO-830 Circuits"
-	designs = list(
-		/datum/design/autolathe/circuit/airlockmodule = 0,
-		/datum/design/autolathe/circuit/airlockmodule/secure,
-		/datum/design/autolathe/circuit/airalarm = 0,
-		/datum/design/autolathe/circuit/firealarm = 0,
-		/datum/design/autolathe/circuit/powermodule = 0,
-		/datum/design/autolathe/circuit/recharger,
-		/datum/design/research/circuit/autolathe,
-		/datum/design/autolathe/circuit/autolathe_disk_cloner = 3,
-		/datum/design/autolathe/circuit/vending,
-		/datum/design/research/circuit/arcade_battle,
-		/datum/design/research/circuit/arcade_orion_trail,
-		/datum/design/research/circuit/teleconsole,
-		/datum/design/research/circuit/operating,
-		/datum/design/autolathe/circuit/helm,
-		/datum/design/autolathe/circuit/nav,
-		/datum/design/autolathe/circuit/centrifuge,
-		/datum/design/autolathe/circuit/electrolyzer,
-		/datum/design/autolathe/circuit/reagentgrinder,
-		/datum/design/autolathe/circuit/industrialgrinder = 2,		
-		/datum/design/autolathe/circuit/chemheater = 2,
+
+/obj/item/computer_hardware/hard_drive/portable/design/circuits/Initialize()
+	designs += list(		
+	/datum/design/autolathe/circuit/chemheater = 2,
 	)
+	. = ..()
+	
 
 /obj/item/computer_hardware/hard_drive/portable/design/conveyors
 	disk_name = "EES-LAT-018 Logistics"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces a hard over-write with an initialization addition to the list

## Why It's Good For The Game

hard overwrites bad, re-enables obtainment for crafting station

## Changelog
```changelog
fix: Replaces the circuit disk overwrites with a better addition
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
