### PR TITLE
Artist Bench no longer require Plasteel

### DIFF
--- a/code/game/machinery/autolathe/artist_bench.dm
+++ b/code/game/machinery/autolathe/artist_bench.dm
@@ -9,7 +9,7 @@
 
 /obj/machinery/autolathe/artist_bench
 	name = "artist's bench"
-	desc = "Insert wood, steel, glass, plasteel, plastic and a bit of your soul to create a beautiful work of art. \
+	desc = "Insert wood, steel, glass, plastic and a bit of your soul to create a beautiful work of art. \
 			Requires a stock of at least 20 sheets of each of the aforementioned materials before you begin sacrificing your soul."	// OCCULUS EDIT - Makes its requirements clear
 	icon = 'icons/obj/machines/autolathe.dmi'
 	icon_state = "bench"
@@ -20,7 +20,7 @@
 	have_design_selector = FALSE
 	categories = list("Artwork")
 
-	suitable_materials = list(MATERIAL_WOOD, MATERIAL_STEEL, MATERIAL_GLASS, MATERIAL_PLASTEEL, MATERIAL_PLASTIC)
+	suitable_materials = list(MATERIAL_WOOD, MATERIAL_STEEL, MATERIAL_GLASS, MATERIAL_PLASTIC) // Occulus Edit: No Plasteel!
 	var/min_mat = 20
 	var/min_insight = 40
 	var/datum/component/inspiration/inspiration
@@ -373,6 +373,5 @@
 		MATERIAL_STEEL = 20,
 		MATERIAL_PLASTIC = 20,
 		MATERIAL_GLASS = 20,
-		MATERIAL_PLASTEEL = 20,
 		MATERIAL_WOOD = 20
 		)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Remove Plasteel requirement from Artist's bench

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Make it so that Artist no longer compete for the most in demand item. Buff Artist, random revolver go! 

Not like anyone steal anything else from the Artist Bench anywa-

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
tweak: Artist Bench no longer require Plasteel.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
