### PR TITLE
Port Upstream Nanites -> Bloodstream

### DIFF
--- a/code/modules/reagents/reagents/nanites.dm
+++ b/code/modules/reagents/reagents/nanites.dm
@@ -31,8 +31,9 @@
 /datum/reagent/nanites/consumed_amount(mob/living/carbon/M, alien, var/location)
 	if(will_occur(M, alien, location))
 		return ..()
-	else
-		return 0
+	else if(location == CHEM_INGEST)
+		holder.trans_to_mob(M, volume, CHEM_BLOOD) // Nanites dig through the stomach lining to get into the blood.
+	return 0
 
 /datum/reagent/nanites/affect_blood(mob/living/carbon/M, alien, effect_multiplier)
 	eat_blood(M)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Make nanites transfer to bloodstream when ingested.

Technically an upstream PR but in draft. Don't got the patience to wait with the two synth players onboard suffering.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Nanites work on FBP
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
add: Nanites now transfer into your bloodstream when ingested, meaning they now work for creature with synthetic stomach (Synth / FBP)
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
