### PR TITLE
Adds short magazine (.50 rubbershot and beanbag) to bullethaven vendors

### DIFF
--- a/zzzz_modular_occulus/code/game/machinery/vending.dm
+++ b/zzzz_modular_occulus/code/game/machinery/vending.dm
@@ -182,6 +182,8 @@
 					/obj/item/ammo_magazine/ammobox/shotgun/beanbags = 5,
 					/obj/item/ammo_magazine/ammobox/shotgun/rubbershot = 5,
 					/obj/item/cell/small/high = 10,
+					/obj/item/ammo_magazine/s5mag/rubbershot = 5,
+					/obj/item/ammo_magazine/s5mag/beanbag = 5,
 					/obj/item/computer_hardware/hard_drive/portable/design/guns/fs_cheap_guns/generic = 2
 					)
 	premium = list(
@@ -206,6 +208,8 @@
 					/obj/item/ammo_magazine/ammobox/shotgun/beanbags = 575,
 					/obj/item/ammo_magazine/ammobox/shotgun/rubbershot = 575,
 					/obj/item/cell/small/high = 500,
+					/obj/item/ammo_magazine/s5mag/beanbag = 125,
+					/obj/item/ammo_magazine/s5mag/rubbershot = 125,
 					/obj/item/computer_hardware/hard_drive/portable/design/guns/fs_cheap_guns/generic = 2500,
 					/obj/item/storage/pouch/ammo = 750,
 					/obj/item/ammo_magazine/ammobox/clrifle/rubber = 1500,

--- a/zzzz_modular_occulus/code/game/machinery/vending.dm
+++ b/zzzz_modular_occulus/code/game/machinery/vending.dm
@@ -182,8 +182,8 @@
 					/obj/item/ammo_magazine/ammobox/shotgun/beanbags = 5,
 					/obj/item/ammo_magazine/ammobox/shotgun/rubbershot = 5,
 					/obj/item/cell/small/high = 10,
-					/obj/item/ammo_magazine/s5mag/rubbershot = 5,
-					/obj/item/ammo_magazine/s5mag/beanbag = 5,
+					/obj/item/ammo_magazine/s5mag/rubbershot = 10,
+					/obj/item/ammo_magazine/s5mag/beanbag = 10,
 					/obj/item/computer_hardware/hard_drive/portable/design/guns/fs_cheap_guns/generic = 2
 					)
 	premium = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

125 credits per mag bby

## Why It's Good For The Game

Vending good

## Changelog
```changelog
add: s5mags are now in vendors
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
