### PR TITLE
Update effects.dm

### DIFF
--- a/code/modules/projectiles/effects.dm
+++ b/code/modules/projectiles/effects.dm
@@ -131,6 +131,7 @@
 
 /obj/effect/projectile/stun/impact
 	icon_state = "impact_stun"
+	lifetime = 7.5 //Occulus Edit
 
 //----------------------------
 // Bullet


### PR DESCRIPTION
Should fix Brigador stun projectiles from failing to delete.

TORRRRRRIIIIII

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Extends the lifetime for brigador stun projectiles so they can be deleted properly after their animation plays

## Why It's Good For The Game

Currently our stun projectiles have a lifetime of 3, but play as long as the plasma projectiles (which have a lifetime of 7.5)
This is not an inherited path due to how they are constructed. lifetime needs to be set for every impact effect that is longer than 0.3 ticks

## Changelog
```changelog
fix: Graphical glitch caused by brigador projectile animations on impact.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
