### PR TITLE
Breakdown Rework Part 1: Simple Progressive Breakdown

### DIFF
--- a/cev_eris.dme
+++ b/cev_eris.dme
@@ -3213,6 +3213,7 @@
 #include "zzzz_modular_occulus\code\modules\research\nodes\engineering.dm"
 #include "zzzz_modular_occulus\code\modules\research\nodes\illegal.dm"
 #include "zzzz_modular_occulus\code\modules\research\xenoarchaeology\tools\anomaly_suit.dm"
+#include "zzzz_modular_occulus\code\modules\sanity\breakdowns.dm"
 #include "zzzz_modular_occulus\code\modules\sanity\sanity_mob.dm"
 #include "zzzz_modular_occulus\code\modules\scrap\oldificator.dm"
 #include "zzzz_modular_occulus\code\modules\shield_generators\shield_generator.dm"

--- a/code/modules/sanity/breakdown.dm
+++ b/code/modules/sanity/breakdown.dm
@@ -96,7 +96,16 @@
 		log_and_message_admins("[holder.owner] is no longer affected by [name]")
 		to_chat(holder.owner,SPAN_NOTICE(pick(end_messages)))
 	if(insight_reward)
+		// Occulus Edit: Progressive Breakdown
+		if(!finished)
+			holder.unmanaged_breakdown = TRUE
+			to_chat(holder.owner, SPAN_WARNING("A lingering unease settles in your bones. Though the intensity of your craving has subsided, a void unfilled hints at a difficult hour yet to come."))
+			addtimer(CALLBACK(holder, .datum/sanity/proc/reset_unmanaged_breakdown, 1 HOUR))
+		// Occulus Edit End: Progressive Breakdown
 		if(finished)
+			// Occulus Edit: Success message on fulfilling your obsession
+			to_chat(holder.owner, SPAN_NOTICE("Your yearnings satiated, a vibrant surge of readiness infuses you. The world feels conquerable again, at least for the present moment."))
+			// Occulus Edit End
 			holder.give_insight(insight_reward)
 			if(restore_sanity_post)
 				holder.restoreLevel(restore_sanity_post)

--- a/code/modules/sanity/sanity_mob.dm
+++ b/code/modules/sanity/sanity_mob.dm
@@ -84,6 +84,9 @@
 
 	var/eat_time_message = 0
 
+	var/unmanaged_breakdown = FALSE // Occulus Edit: Whether there's a common breakdown with unfulfilled objective
+	// Occulus Edit: Gates negative breakdown behind not fulfilling a breakdown with insight reward
+
 	var/life_tick_modifier = 2	//How often is the onLife() triggered and by how much are the effects multiplied
 
 /datum/sanity/New(mob/living/carbon/human/H)
@@ -394,12 +397,16 @@
 			S.reg_break(owner)
 
 	var/list/possible_results
+
+	// Occulus Edit: Rewritten to gate negative breakdown behind not managing a normal breakdown w/ objective instead of percentage
 	if((prob(positive_prob) && positive_prob_multiplier > 0) || positive_breakdown)
 		possible_results = subtypesof(/datum/breakdown/positive)
-	else if(prob(negative_prob))
+	else if(unmanaged_breakdown)
 		possible_results = subtypesof(/datum/breakdown/negative)
+		unmanaged_breakdown = FALSE // Reset
 	else
 		possible_results = subtypesof(/datum/breakdown/common)
+	// Occulus Edit End
 
 	for(var/datum/breakdown/B in breakdowns)
 		possible_results -= B.type

--- a/zzzz_modular_occulus/code/modules/sanity/breakdowns.dm
+++ b/zzzz_modular_occulus/code/modules/sanity/breakdowns.dm
@@ -1,0 +1,19 @@
+// Stat Loss breakdown, negative mirror of lesson learnt
+/datum/breakdown/negative/forgotten
+    name = "A Lesson Forgotten"
+    duration = 0
+    restore_sanity_post = 50
+
+    start_messages = list(
+        "Your experience weighs you down, each one making you worse",
+        "Nothing in your mind clicks anymore, you feel more incompetent",
+        "Your past mistakes haunt you, and they keep repeating",
+        "You've forgotten what you've learned in the past",
+        "Nothing makes sense anymore!"
+    )
+
+// This is like a negative mirror of A Lesson Learnt, stat loss is less harsh but still significant
+/datum/breakdown/negative/forgotten/conclude()
+    for(var/stat in ALL_STATS)
+        holder.owner.stats.changeStat(stat, -rand(2,5))
+    ..()

--- a/zzzz_modular_occulus/code/modules/sanity/sanity_mob.dm
+++ b/zzzz_modular_occulus/code/modules/sanity/sanity_mob.dm
@@ -11,3 +11,6 @@
 	if(resting)
 		add_rest(INSIGHT_DESIRE_EXERCISE, rate)
 
+/datum/sanity/proc/reset_unmanaged_breakdown()
+    to_chat(owner, SPAN_NOTICE("An hour has passed and the storm within has finally stilled. Unfulfilled desires recede into oblivion, and a newfound calm reigns, readying you for whatever comes next."))
+    unmanaged_breakdown = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR is meant to be an intermediate solution to complaints about the breakdown system. Numbers subject to feedbakc.

Proof of Concept for Progressive Breakdown, part 1. There were a lot of suggestions discussed in the thread and this is what I can reasonably get out in a day. Eventually this should be developed into a more elaborate system.

Part two is implementing the Jaded Perk.

- Negative breakdown probability no longer matter. Kept for upstream compatibility 
- Your first breakdown will always be a positive or common (minor) breakdown 
- If you roll a breakdown without objective, you're lucky and nothing follows 
- If you roll a common breakdown with an objective, and fail to fulfill it, your next breakdown in an hour is guaranteed to be a negative breakdown 
- If you fulfill the objective your next breakdown will once again be a normal / positive breakdown

Also add Forgotten breakdown, a mirrored counterpart to A Lesson Learnt, as step 1 to add in more breakdowns and move away from breakdown that totally take away player agency. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Restore player agency by giving player forewarning before they get a breakdown that robs them of agency. 
- Increases the predictability of the system by making the harsh punishment a direct, and unavoidable consequences of neglecting sanity for a long period. 
- Encourage interaction with the system - meaning players have to engage with objective breakdown instead of ignoring it and get lucky until they don't

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
add: A new forgotten lesson breakdown that hits your stat across the board between 2 to 5, a (weaker) mirror to "A Lesson Learnt" positive breakdown.
tweak: Tweaked the breakdown system. Now you cannot roll a negative breakdown on first try. Instead, negative breakdown occurs as a result of getting a normal breakdown with objective but failing to fulfill the objective. If you don't get any breakdown with objective, there's nothing you need to do.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
