### PR TITLE
Fixes Pump-action runtimes from Shotslot's existance

### DIFF
--- a/zzzz_modular_occulus/code/modules/projectiles/guns/projectile/shotgun/pump.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/guns/projectile/shotgun/pump.dm
@@ -11,10 +11,9 @@
 		loaded -= AC //Remove casing from loaded list.
 		chambered = AC
 
-	if(ammo_magazine)	
-		if(ammo_magazine.stored_ammo.len)
-			var/obj/item/ammo_casing/AC = ammo_magazine.stored_ammo[1] 
-			ammo_magazine.stored_ammo -= AC 
-			chambered = AC
+	if(ammo_magazine?.stored_ammo.len)
+		var/obj/item/ammo_casing/AC = ammo_magazine.stored_ammo[1] 
+		ammo_magazine.stored_ammo -= AC 
+		chambered = AC
 
 	update_icon()

--- a/zzzz_modular_occulus/code/modules/projectiles/guns/projectile/shotgun/pump.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/guns/projectile/shotgun/pump.dm
@@ -11,9 +11,10 @@
 		loaded -= AC //Remove casing from loaded list.
 		chambered = AC
 
-	if(ammo_magazine.stored_ammo.len)
-		var/obj/item/ammo_casing/AC = ammo_magazine.stored_ammo[1] 
-		ammo_magazine.stored_ammo -= AC 
-		chambered = AC
+	if(ammo_magazine)	
+		if(ammo_magazine.stored_ammo.len)
+			var/obj/item/ammo_casing/AC = ammo_magazine.stored_ammo[1] 
+			ammo_magazine.stored_ammo -= AC 
+			chambered = AC
 
 	update_icon()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Turns out, i needed just a small addition to make it not fekked

## Why It's Good For The Game

Dusty distracting roaches is too good for the game.

## Changelog
```changelog
fix: Pump actions no longer runtime due to reading a magazine's content that wasn't there.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
