### PR TITLE
Give Engineering Equipment (Reactor) access to ensign

### DIFF
--- a/zzzz_modular_occulus/code/game/jobs/job/captain.dm
+++ b/zzzz_modular_occulus/code/game/jobs/job/captain.dm
@@ -61,7 +61,7 @@ Should the worst occur, defend your ship, post, and commanders with your life."
 
 	access = list(
 		access_maint_tunnels, access_heads, access_RC_announce, access_sec_doors, access_tcomsat,
-		access_moebius, access_tech_storage, access_teleporter, access_bar, access_kitchen, access_engine
+		access_moebius, access_tech_storage, access_teleporter, access_bar, access_kitchen, access_engine, access_engine_equip
 	)
 
 	stat_modifiers = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Ensign had engine accesses, which gave them access to the thrusters. Turn out the reactor (supermatter) is gated behind engineering equipment access. Oops. 

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix an oversight that led Ensign to be unable to set up an engine, a prerequisite for running the round
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
fix: Ensign have access to the reactor (Engineering Equipment) room again. They had "Engine" access, which was to the thrusters room. Woops.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
