### PR TITLE
Fix breakdown debuff expiring early

### DIFF
--- a/code/modules/sanity/breakdown.dm
+++ b/code/modules/sanity/breakdown.dm
@@ -100,7 +100,7 @@
 		if(!finished)
 			holder.unmanaged_breakdown = TRUE
 			to_chat(holder.owner, SPAN_WARNING("A lingering unease settles in your bones. Though the intensity of your craving has subsided, a void unfilled hints at a difficult hour yet to come."))
-			addtimer(CALLBACK(holder, .datum/sanity/proc/reset_unmanaged_breakdown, 1 HOUR))
+			addtimer(CALLBACK(holder, .datum/sanity/proc/reset_unmanaged_breakdown), 1 HOUR)
 		// Occulus Edit End: Progressive Breakdown
 		if(finished)
 			// Occulus Edit: Success message on fulfilling your obsession


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fix breakdown debuff expiring early

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fix breakdown debuff expiring early


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
fix: Breakdown debuff now expires after an hour instead of immediately, so you WILL get negative breakdowns if you don't fulfill your objective
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
