### PR TITLE
Fix fryer reagents NRE spam

### DIFF
--- a/zzzz_modular_occulus/code/game/machinery/kitchen/fryer.dm
+++ b/zzzz_modular_occulus/code/game/machinery/kitchen/fryer.dm
@@ -60,6 +60,10 @@
 /obj/machinery/appliance/cooker/fryer/update_cooking_power()
 	..()//In addition to parent temperature calculation
 	//Fryer efficiency also drops when oil levels arent optimal
+	if(!oil)
+		cooking_power *= 0
+		return
+	
 	var/oil_level = oil
 	var/datum/reagent/organic/nutriment/cornoil/OL = oil.get_master_reagent()
 	if (OL && istype(OL))


### PR DESCRIPTION
## About The Pull Request

Fixes a null-reference expcetion thrown from the `/obj/machinery/appliance/cooker/fryer/update_cooking_power()`, that was added in #1008 

Which has the adverse effects of:
- Blocking the CI from working correctly, spamming false negatives in almost every PR
- Within the first minutes of the server starting up, there already are about 100 of those runtimes in the log
- Makes it frustrating to debug the codebase in Visual Studio Code

## Why It's Good For The Game

Makes it easier to debug the codebase. The CI becomes more useful for everyone involved. Less space is dedicated to the endless stream of runtime.

## Changelog
```changelog
balance: The fryer cooker's powerful ability to destabilize the whole server in secret has been mitigated.
```
