### PR TITLE
Fix improper mecha prebuild

### DIFF
--- a/code/modules/mechs/components/body.dm
+++ b/code/modules/mechs/components/body.dm
@@ -100,7 +100,7 @@
 
 /obj/item/mech_component/chassis/prebuild()
 	computer = new /obj/item/robot_parts/robot_component/exosuit_control(src)
-	armor = new /obj/item/robot_parts/robot_component/armour/exosuit(src)
+	armor_plate = new /obj/item/robot_parts/robot_component/armour/exosuit(src)
 	cell = new /obj/item/cell/large/high(src)
 
 /obj/item/mech_component/chassis/attackby(obj/item/I, mob/living/user)


### PR DESCRIPTION
## About The Pull Request

- Fixes #847 
- Fixes #844 

## Why It's Good For The Game

Makes scrap mechas more useful, hopefully.

## Changelog
```changelog
fix: Fixed improper mech armour assignment still leaving it highly exposed
```
