### PR TITLE
Fix pen attack override

### DIFF
--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -60,15 +60,15 @@
 	colour = "white"
 
 
-/obj/item/pen/attack(mob/M, mob/user)
-	if(!ismob(M))
-		return
+/obj/item/pen/attack(mob/M, mob/user, target_zone)
+	if(..())
+		return TRUE
+
 	to_chat(user, SPAN_WARNING("You stab [M] with the pen."))
 //	M << "\red You feel a tiny prick!" //That's a whole lot of meta!
 	M.attack_log += text("\[[time_stamp()]\] <font color='orange'>Has been stabbed with [name]  by [user.name] ([user.ckey])</font>")
 	user.attack_log += text("\[[time_stamp()]\] <font color='red'>Used the [name] to stab [M.name] ([M.ckey])</font>")
 	msg_admin_attack("[user.name] ([user.ckey]) Used the [name] to stab [M.name] ([M.ckey]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[user.x];Y=[user.y];Z=[user.z]'>JMP</a>)")
-	return
 
 /*
  * Reagent pens

--- a/zzzz_modular_occulus/code/game/objects/items/weapons/traitor_weapons.dm
+++ b/zzzz_modular_occulus/code/game/objects/items/weapons/traitor_weapons.dm
@@ -186,7 +186,7 @@
 	origin_tech = list(TECH_COMBAT = 3, TECH_ILLEGAL = 1)
 	attack_verb = list("slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut") //these wont show up if the pen is off
 	sharp = TRUE
-	var/on = TRUE
+	var/on = FALSE
 	var/brightness_on = 2
 	light_color = "#B40000"
 


### PR DESCRIPTION
## About The Pull Request

- Fixes an untracked issue: energy daggers do not do damage regardless of state

## Why It's Good For The Game

I don't know. Makes energy daggers actually lethal for once?

## Changelog
```changelog
fix: Fixed pens' attack override making concealable energy dagger pens harmless
```
