### PR TITLE
Xenobio adjustments

### DIFF
--- a/code/modules/mob/living/carbon/slime/subtypes.dm
+++ b/code/modules/mob/living/carbon/slime/subtypes.dm
@@ -14,10 +14,10 @@
 			slime_mutation[3] = "green"
 			slime_mutation[4] = "green"
 		if("metal")
-			slime_mutation[1] = MATERIAL_SILVER
+			slime_mutation[1] = "silver"
 			slime_mutation[2] = "yellow"
-			slime_mutation[3] = MATERIAL_GOLD
-			slime_mutation[4] = MATERIAL_GOLD
+			slime_mutation[3] = "gold"
+			slime_mutation[4] = "gold"
 		if("orange")
 			slime_mutation[1] = "dark purple"
 			slime_mutation[2] = "yellow"
@@ -25,7 +25,7 @@
 			slime_mutation[4] = "red"
 		if("blue")
 			slime_mutation[1] = "dark blue"
-			slime_mutation[2] = MATERIAL_SILVER
+			slime_mutation[2] = "silver"
 			slime_mutation[3] = "pink"
 			slime_mutation[4] = "pink"
 		//Tier 3
@@ -44,7 +44,7 @@
 			slime_mutation[2] = "metal"
 			slime_mutation[3] = "orange"
 			slime_mutation[4] = "orange"
-		if(MATERIAL_SILVER)
+		if("silver")
 			slime_mutation[1] = "metal"
 			slime_mutation[2] = "metal"
 			slime_mutation[3] = "blue"
@@ -60,9 +60,9 @@
 			slime_mutation[2] = "red"
 			slime_mutation[3] = "oil"
 			slime_mutation[4] = "oil"
-		if(MATERIAL_GOLD)
-			slime_mutation[1] = MATERIAL_GOLD
-			slime_mutation[2] = MATERIAL_GOLD
+		if("gold")
+			slime_mutation[1] = "gold"
+			slime_mutation[2] = "gold"
 			slime_mutation[3] = "adamantine"
 			slime_mutation[4] = "adamantine"
 		if("green")

--- a/code/modules/reagents/recipes.dm
+++ b/code/modules/reagents/recipes.dm
@@ -1121,6 +1121,8 @@
 /datum/chemical_reaction/slime/cell/on_reaction(var/datum/reagents/holder, var/created_volume)
 	var/obj/item/cell/large/slime/P = new /obj/item/cell/large/slime
 	P.loc = get_turf(holder.my_atom)
+	var/obj/item/slime_extract/T = holder.my_atom //Occulus Edit: Deletes old yellow core
+	del(T) //Occulus Edit: Deletes old yellow core
 
 /datum/chemical_reaction/slime/glow
 	result = null
@@ -1133,6 +1135,8 @@
 	..()
 	var/obj/item/device/slimelight/F = new /obj/item/device/slimelight
 	F.loc = get_turf(holder.my_atom)
+	var/obj/item/slime_extract/T = holder.my_atom //Occulus Edit: Deletes old yellow core
+	del(T) //Occulus Edit: Deletes old yellow core
 
 //Purple
 /datum/chemical_reaction/slime/psteroid

--- a/code/modules/research/experiment.dm
+++ b/code/modules/research/experiment.dm
@@ -50,10 +50,22 @@ GLOBAL_LIST_EMPTY(explosion_watcher_list)
 	// Points for special slime cores
 	var/static/list/core_points = list( //Occulus Edit Start
 		/obj/item/slime_extract/grey = 200,
+		/obj/item/slime_extract/darkblue = 3000,
+		/obj/item/slime_extract/darkpurple = 3000,
+		/obj/item/slime_extract/yellow = 3000,
+		/obj/item/slime_extract/silver = 3000,
+		/obj/item/slime_extract/pink = 4000,
+		/obj/item/slime_extract/red = 4000,
 		/obj/item/slime_extract/gold = 4000,
-		/obj/item/slime_extract/adamantine = 6000,
+		/obj/item/slime_extract/green = 4000,
+		/obj/item/slime_extract/adamantine = 10000,
 		/obj/item/slime_extract/bluespace = 10000,
-		/obj/item/slime_extract/rainbow = 20000
+		/obj/item/slime_extract/sepia = 10000,
+		/obj/item/slime_extract/rainbow = 10000,
+		/obj/item/slime_extract/pyrite = 10000,
+		/obj/item/slime_extract/oil = 10000,
+		/obj/item/slime_extract/black = 10000,
+		/obj/item/slime_extract/lightpink = 10000
 	) //Occulus Edit End
 
 /*

--- a/maps/CEVEris/_CEV_Eris.dmm
+++ b/maps/CEVEris/_CEV_Eris.dmm
@@ -34401,6 +34401,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/steel,
 /area/eris/rnd/xenobiology)
 "bED" = (
@@ -63069,14 +63072,12 @@
 /area/eris/command/exultant)
 "cWn" = (
 /obj/structure/table/standard,
-/obj/item/storage/box/beakers,
-/obj/item/storage/box/syringes{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
+/obj/item/ammo_magazine/ammobox/pistol,
+/obj/item/gun/projectile/selfload/moebius,
+/obj/item/ammo_magazine/pistol/empty,
 /turf/simulated/floor/tiled/white/violetcorener,
 /area/eris/rnd/xenobiology)
 "cWo" = (
@@ -69034,8 +69035,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/item/gun/projectile/handmade_pistol,
-/obj/item/ammo_magazine/ammobox/pistol/rubber,
+/obj/item/storage/box/beakers,
+/obj/item/storage/box/syringes{
+	pixel_x = 3;
+	pixel_y = 3
+	},
 /turf/simulated/floor/tiled/white/brown_perforated,
 /area/eris/rnd/xenobiology)
 "dkf" = (
@@ -70096,6 +70100,9 @@
 "dmM" = (
 /obj/machinery/camera/network/research{
 	dir = 8
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/white/danger,
 /area/eris/rnd/xenobiology)
@@ -97930,14 +97937,6 @@
 /area/eris/quartermaster/misc)
 "eBL" = (
 /obj/structure/table/reinforced,
-/obj/item/extinguisher{
-	pixel_x = 4;
-	pixel_y = 3
-	},
-/obj/item/extinguisher{
-	pixel_x = 4;
-	pixel_y = 3
-	},
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/monkeycubes,
 /obj/structure/disposalpipe/segment{


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes yellow slime cores. The original core is now deleted when making slimelights and slimecells
Buffed slime research points 
removed zipgun from xenobiology, added an anne, one mag, and one box of lethal ammo
fixed some improperly used defines in slimetype file
moved the syringes and beakers in xenobio

## Why It's Good For The Game

Just some light adjustments to xenobiology

## Changelog
```changelog
fix: Yellow cores now are deleted when creating slimelights and slimecells
fix: Removed MATERIAL_GOLD and MATERIAL_SILVER from slime mutation file. Why.
tweak: increased point gain from slime cores
tweak: slime cores now give points based on tier. Sadly spaghet coded
tweak: adjusted loadout in xenobiology lab
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
