### PR TITLE
Balance Tweak for DSS

### DIFF
--- a/zzzz_modular_occulus/code/modules/projectiles/guns/energy/dssguns.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/guns/energy/dssguns.dm
@@ -19,7 +19,7 @@
 	fire_sound = 'sound/weapons/Laser.ogg'
 	rarity_value = 8
 	init_firemodes = list(
-		list(mode_name="stun", burst=1, projectile_type=/obj/item/projectile/beam/stun, fire_sound='sound/weapons/Taser.ogg', fire_delay=5, charge_cost=40, icon="stun", projectile_color = "#00FFFF")
+		list(mode_name="stun", burst=1, projectile_type=/obj/item/projectile/beam/stun, fire_sound='sound/weapons/Taser.ogg', fire_delay=5, charge_cost=40, icon="stun", projectile_color = "#00FFFF"),
 		list(mode_name="stun burst", burst=3, projectile_type=/obj/item/projectile/beam/stun, fire_sound='sound/weapons/Taser.ogg', fire_delay=8, charge_cost=40, icon="burst", projectile_color = "#00FFFF"),
 		list(mode_name="kill", burst=3, projectile_type=/obj/item/projectile/beam, fire_sound='sound/weapons/Laser.ogg', fire_delay=8, charge_cost=60, icon="kill", projectile_color = "#8bbdd9"),
 		)

--- a/zzzz_modular_occulus/code/modules/projectiles/guns/energy/dssguns.dm
+++ b/zzzz_modular_occulus/code/modules/projectiles/guns/energy/dssguns.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/energy/resolute
 	name = "DSS ECAR \"Resolute\""
-	desc = "\"DeepFlare Security System\" energy carbine. The byzantine internal capacitor design requires this gun to fire in bursts of three. It has notably become a go-to firearm for station security forces due to it's stun capabilities."
+	desc = "\"DeepFlare Security System\" energy carbine. The byzantine internal capacitor design limits this guns lasers to fire in bursts of three. It has notably become a go-to firearm for station security forces due to it's stun capabilities."
 	icon = 'zzzz_modular_occulus/icons/obj/guns/energy/resolute.dmi'
 	item_state = "vulprifle"
 	icon_state = "vulprifle"
@@ -19,7 +19,8 @@
 	fire_sound = 'sound/weapons/Laser.ogg'
 	rarity_value = 8
 	init_firemodes = list(
-		list(mode_name="stun", burst=3, projectile_type=/obj/item/projectile/beam/stun, fire_sound='sound/weapons/Taser.ogg', fire_delay=8, charge_cost=40, icon="stun", projectile_color = "#00FFFF"),
+		list(mode_name="stun", burst=1, projectile_type=/obj/item/projectile/beam/stun, fire_sound='sound/weapons/Taser.ogg', fire_delay=5, charge_cost=40, icon="stun", projectile_color = "#00FFFF")
+		list(mode_name="stun burst", burst=3, projectile_type=/obj/item/projectile/beam/stun, fire_sound='sound/weapons/Taser.ogg', fire_delay=8, charge_cost=40, icon="burst", projectile_color = "#00FFFF"),
 		list(mode_name="kill", burst=3, projectile_type=/obj/item/projectile/beam, fire_sound='sound/weapons/Laser.ogg', fire_delay=8, charge_cost=60, icon="kill", projectile_color = "#8bbdd9"),
 		)
 
@@ -42,5 +43,5 @@
 	fire_sound = 'sound/weapons/guns/fire/energy_shotgun.ogg'
 	rarity_value = 8
 	init_firemodes = list(
-		list(mode_name="kill", projectile_type=/obj/item/projectile/bullet/pellet/energy, fire_sound='sound/weapons/guns/fire/energy_shotgun.ogg', fire_delay=6, charge_cost=180, icon="kill" ),
+		list(mode_name="kill", projectile_type=/obj/item/projectile/bullet/pellet/energy, fire_sound='sound/weapons/guns/fire/energy_shotgun.ogg', fire_delay=6, charge_cost=80, icon="kill" ),
 		)


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This rebalances 2 of the DSS weapons, the Resolute Energy Carbine, and the scatter gun
Adds a single shot mode to the carbine, leaving it's lethal as only burst fire.
reduces firing cost of the energy shotgun to make it more pallateable.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes 2 expensive guns actually worth using/buying. >_>

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
```changelog
tweak: weapon balance.
```

<!-- Leave the codeblock and the "changelog" alone for your PR to have working automatic change-log generation. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
