### PR TITLE
Fix appearance changer UI deleting the user

### DIFF
--- a/code/modules/nano/modules/human_appearance.dm
+++ b/code/modules/nano/modules/human_appearance.dm
@@ -14,7 +14,7 @@
 
 
 /datum/nano_module/appearance_changer/New(var/location, var/mob/living/carbon/human/H, var/check_species_whitelist = 1, var/list/species_whitelist = list("human"), var/list/species_blacklist = list())
-	..()
+	..(location, null)
 	owner = H
 	src.check_whitelist = check_species_whitelist
 	src.whitelist = species_whitelist


### PR DESCRIPTION
## About The Pull Request

- Fixes #697 

## Why It's Good For The Game

Whatever happens in the mirror universe... stays in the mirror universe. You would not want their fate to be reflected on yours, yeah?

## Changelog
```changelog
fix: Fixed both handheld and stationary mirrors deleting their users when themselves were deleted.
```